### PR TITLE
[mlflow] Added namespace to templates for mlflow chart

### DIFF
--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.14
+version: 0.7.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mlflow/templates/configmap.yaml
+++ b/charts/mlflow/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "mlflow.fullname" . }}-env-configmap
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "mlflow.name" . }}
     chart: {{ template "mlflow.chart" . }}

--- a/charts/mlflow/templates/deployment.yaml
+++ b/charts/mlflow/templates/deployment.yaml
@@ -24,6 +24,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "mlflow.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "mlflow.labels" . | nindent 4 }}
 spec:

--- a/charts/mlflow/templates/ingress.yaml
+++ b/charts/mlflow/templates/ingress.yaml
@@ -16,6 +16,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "mlflow.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/mlflow/templates/secret.yaml
+++ b/charts/mlflow/templates/secret.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "mlflow.fullname" . }}-env-secret
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "mlflow.name" . }}
     chart: {{ template "mlflow.chart" . }}

--- a/charts/mlflow/templates/service.yaml
+++ b/charts/mlflow/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mlflow.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "mlflow.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}

--- a/charts/mlflow/templates/serviceaccount.yaml
+++ b/charts/mlflow/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "mlflow.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "mlflow.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}


### PR DESCRIPTION
Signed-off-by: PiePra <pierre.prange@gmail.com>

#### What this PR does / why we need it:
introduced metadata namespace to relevant template files to enable workflows which require templating manifests first before applying. If the field is missing the manifests are deployed to default ns. 


#### Which issue this PR fixes
When using helm template to generate manifests before applying (e.g. kustomize/gitops workflows) the namespace does not get templated.

#### Special notes for your reviewer:
@burakince 

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [ ] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [ ] Unit tests written
- [ ] `values.yaml` file fields documented
- [ ] `README.md` file updated
