### PR TITLE
Fix typo in sqlite in-memory URI (issue 48)

### DIFF
--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.19
+version: 0.7.20
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mlflow/templates/deployment.yaml
+++ b/charts/mlflow/templates/deployment.yaml
@@ -104,7 +104,7 @@ spec:
           {{- else if .Values.backendStore.mysql.enabled }}
             - --backend-store-uri=mysql{{ $dbConnectionDriver }}://$(MYSQL_USERNAME):$(MYSQL_PWD)@$(MYSQL_HOST):$(MYSQL_TCP_PORT)/$(MYSQL_DATABASE)
           {{- else }}
-            - --backend-store-uri=sqlite:///:memory
+            - "--backend-store-uri=sqlite:///:memory:"
           {{- end }}
             - {{ $artifactCommand }}
           {{- if .Values.artifactRoot.proxiedArtifactStorage }}

--- a/charts/mlflow/unittests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/mlflow/unittests/__snapshot__/deployment_test.yaml.snap
@@ -31,7 +31,7 @@ should match snapshot of default values:
             - server
             - --host=0.0.0.0
             - --port=5000
-            - --backend-store-uri=sqlite:///:memory
+            - "--backend-store-uri=sqlite:///:memory:"
             - --default-artifact-root=./mlruns
             command:
             - mlflow

--- a/charts/mlflow/unittests/deployment_test.yaml
+++ b/charts/mlflow/unittests/deployment_test.yaml
@@ -17,7 +17,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].args[3]
-          value: --backend-store-uri=sqlite:///:memory
+          value: "--backend-store-uri=sqlite:///:memory:"
 
   - it: should be Postgres backend when Postgres is enabled
     set:


### PR DESCRIPTION

@burakince 
#### What this PR does / why we need it:

This is a fix for https://github.com/community-charts/helm-charts/issues/48 

#### Which issue this PR fixes

  - fixes #48 

#### Special notes for your reviewer:

I don't have much time for this, this is my first contribution. 
It's a tiny fix, and I tried it can be installed and that it works. And it does it. It doesn't create a ":memory" file anymore.

Thanks for your time for any missing items. 

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [ ] Chart `artifacthub.io/changes` field updated (if exists)
- [X] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [ ] Unit tests written
- [ ] `values.yaml` file fields documented
- [ ] `README.md` file updated
