### PR TITLE
[outlune] Fix wrong scopes format in OIDC scopes secret

### DIFF
--- a/charts/outline/Chart.yaml
+++ b/charts/outline/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -59,7 +59,7 @@ annotations:
       url: https://docs.getoutline.com/s/hosting/
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - Fix minio bucket length problem
+    - Fix wrong scopes format in OIDC scopes secret
   artifacthub.io/images: |
     - name: outline
       image: outlinewiki/outline:0.82.0

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for the fastest knowledge base for growing teams. Beautiful, realtime collaborative, feature packed, and markdown compatible.
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.82.0](https://img.shields.io/badge/AppVersion-0.82.0-informational?style=flat-square)
+![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.82.0](https://img.shields.io/badge/AppVersion-0.82.0-informational?style=flat-square)
 
 ## Get Helm Repository Info
 

--- a/charts/outline/templates/secret.yaml
+++ b/charts/outline/templates/secret.yaml
@@ -128,7 +128,7 @@ data:
   OIDC_USERINFO_URI: {{ printf "https://%s/login/oauth/userinfo" (.Values.auth.gitea.baseUrl | trimPrefix "https://" | trimPrefix "http://" | trimSuffix "/") | b64enc | quote }}
   OIDC_USERNAME_CLAIM: {{ .Values.auth.gitea.usernameClaim | b64enc | quote }}
   OIDC_DISPLAY_NAME: {{ .Values.auth.gitea.displayName | b64enc | quote }}
-  OIDC_SCOPES: {{ .Values.auth.gitea.scopes | join "," | b64enc | quote }}
+  OIDC_SCOPES: {{ .Values.auth.gitea.scopes | join " " | b64enc | quote }}
 {{- else if .Values.auth.gitlab.enabled }}
   OIDC_CLIENT_ID: {{ .Values.auth.gitlab.clientId | b64enc | quote }}
   OIDC_CLIENT_SECRET: {{ .Values.auth.gitlab.clientSecret | b64enc | quote }}
@@ -137,7 +137,7 @@ data:
   OIDC_USERINFO_URI: {{ printf "https://%s/oauth/userinfo" (.Values.auth.gitlab.baseUrl | trimPrefix "https://" | trimPrefix "http://" | trimSuffix "/") | b64enc | quote }}
   OIDC_USERNAME_CLAIM: {{ .Values.auth.gitlab.usernameClaim | b64enc | quote }}
   OIDC_DISPLAY_NAME: {{ .Values.auth.gitlab.displayName | b64enc | quote }}
-  OIDC_SCOPES: {{ .Values.auth.gitlab.scopes | join "," | b64enc | quote }}
+  OIDC_SCOPES: {{ .Values.auth.gitlab.scopes | join " " | b64enc | quote }}
 {{- else if .Values.auth.auth0.enabled }}
   OIDC_CLIENT_ID: {{ .Values.auth.auth0.clientId | b64enc | quote }}
   OIDC_CLIENT_SECRET: {{ .Values.auth.auth0.clientSecret | b64enc | quote }}
@@ -146,7 +146,7 @@ data:
   OIDC_USERINFO_URI: {{ printf "https://%s/userinfo" (.Values.auth.auth0.baseUrl | trimPrefix "https://" | trimPrefix "http://" | trimSuffix "/") | b64enc | quote }}
   OIDC_USERNAME_CLAIM: {{ .Values.auth.auth0.usernameClaim | b64enc | quote }}
   OIDC_DISPLAY_NAME: {{ .Values.auth.auth0.displayName | b64enc | quote }}
-  OIDC_SCOPES: {{ .Values.auth.auth0.scopes | join "," | b64enc | quote }}
+  OIDC_SCOPES: {{ .Values.auth.auth0.scopes | join " " | b64enc | quote }}
 {{- else if .Values.auth.keycloak.enabled }}
   OIDC_CLIENT_ID: {{ .Values.auth.keycloak.clientId | b64enc | quote }}
   OIDC_CLIENT_SECRET: {{ .Values.auth.keycloak.clientSecret | b64enc | quote }}
@@ -156,7 +156,7 @@ data:
   OIDC_LOGOUT_URI: {{ printf "https://%s/realms/%s/protocol/openid-connect/logout" (.Values.auth.keycloak.baseUrl | trimPrefix "https://" | trimPrefix "http://" | trimSuffix "/") .Values.auth.keycloak.realmName | b64enc | quote }}
   OIDC_USERNAME_CLAIM: {{ .Values.auth.keycloak.usernameClaim | b64enc | quote }}
   OIDC_DISPLAY_NAME: {{ .Values.auth.keycloak.displayName | b64enc | quote }}
-  OIDC_SCOPES: {{ .Values.auth.keycloak.scopes | join "," | b64enc | quote }}
+  OIDC_SCOPES: {{ .Values.auth.keycloak.scopes | join " " | b64enc | quote }}
 {{- else if .Values.auth.oidc.enabled }}
   OIDC_CLIENT_ID: {{ .Values.auth.oidc.clientId | b64enc | quote }}
   OIDC_CLIENT_SECRET: {{ .Values.auth.oidc.clientSecret | b64enc | quote }}
@@ -166,7 +166,7 @@ data:
   OIDC_LOGOUT_URI: {{ .Values.auth.oidc.logoutUri | b64enc | quote }}
   OIDC_USERNAME_CLAIM: {{ .Values.auth.oidc.usernameClaim | b64enc | quote }}
   OIDC_DISPLAY_NAME: {{ .Values.auth.oidc.displayName | b64enc | quote }}
-  OIDC_SCOPES: {{ .Values.auth.oidc.scopes | join "," | b64enc | quote }}
+  OIDC_SCOPES: {{ .Values.auth.oidc.scopes | join " " | b64enc | quote }}
 {{- end }}
 {{- if .Values.auth.saml.enabled }}
   SAML_SSO_ENDPOINT: {{ .Values.auth.saml.ssoEndpoint | b64enc | quote }}

--- a/charts/outline/unittests/secret_test.yaml
+++ b/charts/outline/unittests/secret_test.yaml
@@ -327,7 +327,7 @@ tests:
           decodeBase64: true
       - equal:
           path: data.OIDC_SCOPES
-          value: "fake-scope-1,fake-scope-2"
+          value: "fake-scope-1 fake-scope-2"
           decodeBase64: true
 
   - it: should set gitlab client id and secret when auth.gitlab.enabled is true
@@ -380,7 +380,7 @@ tests:
           decodeBase64: true
       - equal:
           path: data.OIDC_SCOPES
-          value: "fake-scope-1,fake-scope-2"
+          value: "fake-scope-1 fake-scope-2"
           decodeBase64: true
 
   - it: should set auth0 client id and secret when auth.auth0.enabled is true
@@ -433,7 +433,7 @@ tests:
           decodeBase64: true
       - equal:
           path: data.OIDC_SCOPES
-          value: "fake-scope-1,fake-scope-2"
+          value: "fake-scope-1 fake-scope-2"
           decodeBase64: true
 
   - it: should set keycloak client id and secret when auth.keycloak.enabled is true
@@ -491,7 +491,7 @@ tests:
           decodeBase64: true
       - equal:
           path: data.OIDC_SCOPES
-          value: "fake-scope-1,fake-scope-2"
+          value: "fake-scope-1 fake-scope-2"
           decodeBase64: true
 
   - it: should set oidc client id and secret when auth.oidc.enabled is true
@@ -551,7 +551,7 @@ tests:
           decodeBase64: true
       - equal:
           path: data.OIDC_SCOPES
-          value: "fake-scope-1,fake-scope-2"
+          value: "fake-scope-1 fake-scope-2"
           decodeBase64: true
 
   - it: should set saml sso endpoint and cert when auth.saml.enabled is true


### PR DESCRIPTION
<!--
Thank you for contributing to community-charts/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in community-charts/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

Changes OIDC scopes parameter format from comma separated scopes to space separated scopes.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #77 

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Chart `artifacthub.io/changes` field updated (if exists)
- [X] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [X] Unit tests written
- [X] `values.yaml` file fields documented
- [X] `README.md` file updated
