### PR TITLE
[mlflow] Update mlflow chart to 2.21.1

### DIFF
--- a/charts/mlflow/Chart.lock
+++ b/charts/mlflow/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.5.2
+  version: 16.5.6
 - name: mysql
   repository: https://charts.bitnami.com/bitnami
   version: 12.3.2
-digest: sha256:b2adfaa7c3e5ae2e9f1ab821f41efe0e4150739e5ad618943210c65a42bfb109
-generated: "2025-03-23T17:16:11.003853+01:00"
+digest: sha256:d4ac4c73384ea9511093eb442a95feec1d42bd7fc1ddae3c81e932b94fd89441
+generated: "2025-03-26T00:40:34.466253932Z"

--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.16.1
+version: 0.16.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.21.0"
+appVersion: "2.21.1"
 
 kubeVersion: ">=1.16.0-0"
 
@@ -58,10 +58,10 @@ annotations:
       url: https://github.com/burakince/mlflow
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - Fix wrong sqlite memory syntax.
+    - Update burakince/mlflow image version to 2.21.1
   artifacthub.io/images: |
     - name: mlflow
-      image: burakince/mlflow:2.21.0
+      image: burakince/mlflow:2.21.1
   artifacthub.io/license: MIT
   artifacthub.io/maintainers: |
     - name: burakince
@@ -95,7 +95,7 @@ annotations:
 
 dependencies:
   - name: postgresql
-    version: 16.5.2
+    version: 16.5.6
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
 

--- a/charts/mlflow/README.md
+++ b/charts/mlflow/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for Mlflow open source platform for the machine learning lifecycle
 
-![Version: 0.16.1](https://img.shields.io/badge/Version-0.16.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.21.0](https://img.shields.io/badge/AppVersion-2.21.0-informational?style=flat-square)
+![Version: 0.16.2](https://img.shields.io/badge/Version-0.16.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.21.1](https://img.shields.io/badge/AppVersion-2.21.1-informational?style=flat-square)
 
 ## Get Helm Repository Info
 
@@ -473,7 +473,7 @@ Kubernetes: `>=1.16.0-0`
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.bitnami.com/bitnami | mysql | 12.3.2 |
-| https://charts.bitnami.com/bitnami | postgresql | 16.5.2 |
+| https://charts.bitnami.com/bitnami | postgresql | 16.5.6 |
 
 ## Uninstall Helm Chart
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the mlflow chart to use the latest image version 2.21.1 from burakince/mlflow. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated