### PR TITLE
[actualbudget] Update actualbudget chart to 25.4.0

### DIFF
--- a/charts/actualbudget/Chart.yaml
+++ b/charts/actualbudget/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.2
+version: 1.4.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "25.3.1"
+appVersion: "25.4.0"
 
 kubeVersion: ">=1.16.0-0"
 
@@ -52,10 +52,10 @@ annotations:
       url: https://github.com/actualbudget/actual
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - Update actualbudget/actual-server image version to 25.3.1
+    - Update actualbudget/actual-server image version to 25.4.0
   artifacthub.io/images: |
     - name: actualbudget
-      image: actualbudget/actual-server:25.3.1
+      image: actualbudget/actual-server:25.4.0
       platforms:
         - linux/amd64
         - linux/arm64

--- a/charts/actualbudget/README.md
+++ b/charts/actualbudget/README.md
@@ -4,7 +4,7 @@
 
 A local-first personal finance app
 
-![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 25.3.1](https://img.shields.io/badge/AppVersion-25.3.1-informational?style=flat-square)
+![Version: 1.4.3](https://img.shields.io/badge/Version-1.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 25.4.0](https://img.shields.io/badge/AppVersion-25.4.0-informational?style=flat-square)
 
 ## Get Helm Repository Info
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the actualbudget chart to use the latest image version 25.4.0 from actualbudget/actual-server. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated