### PR TITLE
[n8n] Update n8n chart to 1.86.0

### DIFF
--- a/charts/n8n/Chart.lock
+++ b/charts/n8n/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 20.11.4
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.6.0
+  version: 16.6.2
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:bdf93a2e8d37a9c5bf0a14b135b0cab98009469ff45d79e52e07892ff488a615
-generated: "2025-04-01T02:49:18.643234269Z"
+digest: sha256:248cbefa5686f6555cf0aabd257779f987fa678be98eaa42e73b01be8f6f10dd
+generated: "2025-04-09T02:48:34.783100446Z"

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.4
+version: 1.5.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.85.4"
+appVersion: "1.86.0"
 
 kubeVersion: ">=1.23.0-0"
 
@@ -57,10 +57,10 @@ annotations:
       url: https://docs.n8n.io/
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - Update n8nio/n8n image version to 1.85.4
+    - Update n8nio/n8n image version to 1.86.0
   artifacthub.io/images: |
     - name: n8n
-      image: n8nio/n8n:1.85.4
+      image: n8nio/n8n:1.86.0
       platforms:
         - linux/amd64
         - linux/arm64
@@ -118,7 +118,7 @@ dependencies:
     condition: redis.enabled
 
   - name: postgresql
-    version: 16.6.0
+    version: 16.6.2
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
 

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.5.4](https://img.shields.io/badge/Version-1.5.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.85.4](https://img.shields.io/badge/AppVersion-1.85.4-informational?style=flat-square)
+![Version: 1.5.5](https://img.shields.io/badge/Version-1.5.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.86.0](https://img.shields.io/badge/AppVersion-1.86.0-informational?style=flat-square)
 
 ## Get Helm Repository Info
 
@@ -502,7 +502,7 @@ Kubernetes: `>=1.23.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 16.6.0 |
+| https://charts.bitnami.com/bitnami | postgresql | 16.6.2 |
 | https://charts.bitnami.com/bitnami | redis | 20.11.4 |
 | https://charts.min.io/ | minio | 5.4.0 |
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the n8n chart to use the latest image version 1.86.0 from n8nio/n8n. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated