### PR TITLE
[outline] Update outline chart to 0.83.0

### DIFF
--- a/charts/outline/Chart.lock
+++ b/charts/outline/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 20.8.0
+  version: 20.11.5
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.4.13
+  version: 16.6.3
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:f7155d8c8b2bed4a91ea163a02ee7528486bc50b01c290c817a1c4b9e0823666
-generated: "2025-02-21T07:40:17.883061043Z"
+digest: sha256:4968ef6afab92f68831ccbb6247b314be2c4ff47b3d1cd458e3750af6156a7bf
+generated: "2025-04-11T02:48:09.981012091Z"

--- a/charts/outline/Chart.yaml
+++ b/charts/outline/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.3
+version: 0.3.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.82.0"
+appVersion: "0.83.0"
 
 kubeVersion: ">=1.23.0-0"
 
@@ -59,10 +59,10 @@ annotations:
       url: https://docs.getoutline.com/s/hosting/
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - Fix wrong scopes format in OIDC scopes secret
+    - Update outlinewiki/outline image version to 0.83.0
   artifacthub.io/images: |
     - name: outline
-      image: outlinewiki/outline:0.82.0
+      image: outlinewiki/outline:0.83.0
       platforms:
         - linux/amd64
         - linux/arm64
@@ -82,12 +82,12 @@ annotations:
 
 dependencies:
   - name: redis
-    version: 20.8.0
+    version: 20.11.5
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
 
   - name: postgresql
-    version: 16.4.13
+    version: 16.6.3
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
 

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for the fastest knowledge base for growing teams. Beautiful, realtime collaborative, feature packed, and markdown compatible.
 
-![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.82.0](https://img.shields.io/badge/AppVersion-0.82.0-informational?style=flat-square)
+![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.83.0](https://img.shields.io/badge/AppVersion-0.83.0-informational?style=flat-square)
 
 ## Get Helm Repository Info
 
@@ -434,8 +434,8 @@ Kubernetes: `>=1.23.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 16.4.13 |
-| https://charts.bitnami.com/bitnami | redis | 20.8.0 |
+| https://charts.bitnami.com/bitnami | postgresql | 16.6.3 |
+| https://charts.bitnami.com/bitnami | redis | 20.11.5 |
 | https://charts.min.io/ | minio | 5.4.0 |
 
 ## Uninstall Helm Chart


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the outline chart to use the latest image version 0.83.0 from outlinewiki/outline. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated