### PR TITLE
[n8n] Update n8n chart to 1.88.0

### DIFF
--- a/charts/n8n/Chart.lock
+++ b/charts/n8n/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 20.11.5
+  version: 20.12.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 16.6.3
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:4968ef6afab92f68831ccbb6247b314be2c4ff47b3d1cd458e3750af6156a7bf
-generated: "2025-04-10T02:47:56.968427025Z"
+digest: sha256:02eed22e234c0e3e08d00b68c32388beb99fb45a8303182e809628a78e7c1c62
+generated: "2025-04-16T02:46:37.550741532Z"

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.6
+version: 1.5.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.86.1"
+appVersion: "1.88.0"
 
 kubeVersion: ">=1.23.0-0"
 
@@ -57,10 +57,10 @@ annotations:
       url: https://docs.n8n.io/
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - Update n8nio/n8n image version to 1.86.1
+    - Update n8nio/n8n image version to 1.88.0
   artifacthub.io/images: |
     - name: n8n
-      image: n8nio/n8n:1.86.1
+      image: n8nio/n8n:1.88.0
       platforms:
         - linux/amd64
         - linux/arm64
@@ -113,7 +113,7 @@ annotations:
 
 dependencies:
   - name: redis
-    version: 20.11.5
+    version: 20.12.0
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
 

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.5.6](https://img.shields.io/badge/Version-1.5.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.86.1](https://img.shields.io/badge/AppVersion-1.86.1-informational?style=flat-square)
+![Version: 1.5.7](https://img.shields.io/badge/Version-1.5.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.88.0](https://img.shields.io/badge/AppVersion-1.88.0-informational?style=flat-square)
 
 ## Get Helm Repository Info
 
@@ -503,7 +503,7 @@ Kubernetes: `>=1.23.0-0`
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.bitnami.com/bitnami | postgresql | 16.6.3 |
-| https://charts.bitnami.com/bitnami | redis | 20.11.5 |
+| https://charts.bitnami.com/bitnami | redis | 20.12.0 |
 | https://charts.min.io/ | minio | 5.4.0 |
 
 ## Uninstall Helm Chart


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the n8n chart to use the latest image version 1.88.0 from n8nio/n8n. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated