### PR TITLE
[mlflow] Update mlflow chart to 2.22.0

### DIFF
--- a/charts/mlflow/Chart.lock
+++ b/charts/mlflow/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.6.0
+  version: 16.6.5
 - name: mysql
   repository: https://charts.bitnami.com/bitnami
-  version: 12.3.2
-digest: sha256:ab4ac89b915e486e340ce5d0ee3c3af98d14aa443038f026c97a65100ecaa25b
-generated: "2025-04-04T02:45:24.977121478Z"
+  version: 12.3.4
+digest: sha256:1b72de10ddd6625e94abbf2162e7aff5c8092de99bf19275d5a08c6e8faf4bba
+generated: "2025-04-25T02:46:37.382201888Z"

--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.16.4
+version: 0.16.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.21.3"
+appVersion: "2.22.0"
 
 kubeVersion: ">=1.16.0-0"
 
@@ -58,10 +58,10 @@ annotations:
       url: https://github.com/burakince/mlflow
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - Update burakince/mlflow image version to 2.21.3
+    - Update burakince/mlflow image version to 2.22.0
   artifacthub.io/images: |
     - name: mlflow
-      image: burakince/mlflow:2.21.3
+      image: burakince/mlflow:2.22.0
   artifacthub.io/license: MIT
   artifacthub.io/maintainers: |
     - name: burakince
@@ -95,11 +95,11 @@ annotations:
 
 dependencies:
   - name: postgresql
-    version: 16.6.0
+    version: 16.6.5
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
 
   - name: mysql
-    version: 12.3.2
+    version: 12.3.4
     repository: https://charts.bitnami.com/bitnami
     condition: mysql.enabled

--- a/charts/mlflow/README.md
+++ b/charts/mlflow/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for Mlflow open source platform for the machine learning lifecycle
 
-![Version: 0.16.4](https://img.shields.io/badge/Version-0.16.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.21.3](https://img.shields.io/badge/AppVersion-2.21.3-informational?style=flat-square)
+![Version: 0.16.5](https://img.shields.io/badge/Version-0.16.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.22.0](https://img.shields.io/badge/AppVersion-2.22.0-informational?style=flat-square)
 
 ## Get Helm Repository Info
 
@@ -472,8 +472,8 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | mysql | 12.3.2 |
-| https://charts.bitnami.com/bitnami | postgresql | 16.6.0 |
+| https://charts.bitnami.com/bitnami | mysql | 12.3.4 |
+| https://charts.bitnami.com/bitnami | postgresql | 16.6.5 |
 
 ## Uninstall Helm Chart
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the mlflow chart to use the latest image version 2.22.0 from burakince/mlflow. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated