### PR TITLE
[cloudflared] Update cloudflared chart to 2025.4.2

### DIFF
--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.3
+version: 2.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2025.4.0"
+appVersion: "2025.4.2"
 
 kubeVersion: ">=1.21.0-0"
 
@@ -58,10 +58,10 @@ annotations:
       url: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - Update cloudflare/cloudflared image version to 2025.4.0
+    - Update cloudflare/cloudflared image version to 2025.4.2
   artifacthub.io/images: |
     - name: cloudflared
-      image: cloudflare/cloudflared:2025.4.0
+      image: cloudflare/cloudflared:2025.4.2
       platforms:
         - linux/amd64
         - linux/arm64

--- a/charts/cloudflared/README.md
+++ b/charts/cloudflared/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for cloudflare tunnel
 
-![Version: 2.0.3](https://img.shields.io/badge/Version-2.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2025.4.0](https://img.shields.io/badge/AppVersion-2025.4.0-informational?style=flat-square)
+![Version: 2.0.4](https://img.shields.io/badge/Version-2.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2025.4.2](https://img.shields.io/badge/AppVersion-2025.4.2-informational?style=flat-square)
 
 ## Get Helm Repository Info
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the cloudflared chart to use the latest image version 2025.4.2 from cloudflare/cloudflared. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated