### PR TITLE
[n8n] Update n8n chart to 1.90.2

### DIFF
--- a/charts/n8n/Chart.lock
+++ b/charts/n8n/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 20.13.0
+  version: 20.13.4
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.6.3
+  version: 16.6.6
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:10b0994cbdca26505de23a78c037de288d7e036b23d1b5e11f7bed33376721db
-generated: "2025-04-23T02:47:00.699633348Z"
+digest: sha256:8861362cfd798b202a9e224f3ce58a69df22d391460ad8a7f9f278776af23033
+generated: "2025-05-01T02:28:33.177350009Z"

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.8
+version: 1.5.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.89.2"
+appVersion: "1.90.2"
 
 kubeVersion: ">=1.23.0-0"
 
@@ -57,10 +57,10 @@ annotations:
       url: https://docs.n8n.io/
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - Update n8nio/n8n image version to 1.89.2
+    - Update n8nio/n8n image version to 1.90.2
   artifacthub.io/images: |
     - name: n8n
-      image: n8nio/n8n:1.89.2
+      image: n8nio/n8n:1.90.2
       platforms:
         - linux/amd64
         - linux/arm64
@@ -113,12 +113,12 @@ annotations:
 
 dependencies:
   - name: redis
-    version: 20.13.0
+    version: 20.13.4
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
 
   - name: postgresql
-    version: 16.6.3
+    version: 16.6.6
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
 

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.5.8](https://img.shields.io/badge/Version-1.5.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.89.2](https://img.shields.io/badge/AppVersion-1.89.2-informational?style=flat-square)
+![Version: 1.5.9](https://img.shields.io/badge/Version-1.5.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.90.2](https://img.shields.io/badge/AppVersion-1.90.2-informational?style=flat-square)
 
 ## Get Helm Repository Info
 
@@ -502,8 +502,8 @@ Kubernetes: `>=1.23.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 16.6.3 |
-| https://charts.bitnami.com/bitnami | redis | 20.13.0 |
+| https://charts.bitnami.com/bitnami | postgresql | 16.6.6 |
+| https://charts.bitnami.com/bitnami | redis | 20.13.4 |
 | https://charts.min.io/ | minio | 5.4.0 |
 
 ## Uninstall Helm Chart


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the n8n chart to use the latest image version 1.90.2 from n8nio/n8n. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated