### PR TITLE
[n8n] Update n8n chart to 1.94.1

### DIFF
--- a/charts/n8n/Chart.lock
+++ b/charts/n8n/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 21.1.3
+  version: 21.1.8
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.7.4
+  version: 16.7.5
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:7e9a2be0ce06aef6b9058a8aed23ec9671de31d8c10accef2d6f9d370ad12907
-generated: "2025-05-20T02:46:34.616450826Z"
+digest: sha256:89d9bfaae6ee69419b3bfd883d2527734d4ca79dd026ff47ecfa15a0dedd1e46
+generated: "2025-05-28T02:29:36.018898793Z"

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.0
+version: 1.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.93.0"
+appVersion: "1.94.1"
 
 kubeVersion: ">=1.23.0-0"
 
@@ -57,13 +57,13 @@ annotations:
       url: https://docs.n8n.io/
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - Move liveness probe and readiness probe to main, worker, and webhook blocks
+    - Update n8nio/n8n image version to 1.94.1
     - Add deprecation notices for root level volumes, volumeMounts, extraEnvVars, and extraSecretNamesForEnvFrom fields
     - Add startup probe to worker and webhook blocks
     - Add wait-for-main init container to worker and webhook blocks and make it configurable
   artifacthub.io/images: |
     - name: n8n
-      image: n8nio/n8n:1.93.0
+      image: n8nio/n8n:1.94.1
       platforms:
         - linux/amd64
         - linux/arm64
@@ -116,12 +116,12 @@ annotations:
 
 dependencies:
   - name: redis
-    version: 21.1.3
+    version: 21.1.8
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
 
   - name: postgresql
-    version: 16.7.4
+    version: 16.7.5
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
 

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.93.0](https://img.shields.io/badge/AppVersion-1.93.0-informational?style=flat-square)
+![Version: 1.7.1](https://img.shields.io/badge/Version-1.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.94.1](https://img.shields.io/badge/AppVersion-1.94.1-informational?style=flat-square)
 
 ## Get Helm Repository Info
 
@@ -666,8 +666,8 @@ Kubernetes: `>=1.23.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 16.7.4 |
-| https://charts.bitnami.com/bitnami | redis | 21.1.3 |
+| https://charts.bitnami.com/bitnami | postgresql | 16.7.5 |
+| https://charts.bitnami.com/bitnami | redis | 21.1.8 |
 | https://charts.min.io/ | minio | 5.4.0 |
 
 ## Uninstall Helm Chart


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the n8n chart to use the latest image version 1.94.1 from n8nio/n8n. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated