### PR TITLE
[mlflow] Change default security context to non-root mlflow user

### DIFF
--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.17.3
+version: 0.18.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -50,10 +50,10 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update burakince/mlflow image version to 2.22.1
+      description: Update default security context to non-root mlflow user
       links:
-        - name: Upstream Project
-          url: https://hub.docker.com/r/burakince/mlflow
+        - name: Upstream Project Dockerfile Change
+          url: https://github.com/burakince/mlflow/blob/9972e361e9315b7be558f52225110ef6afbd6b5c/Dockerfile#L59
   artifacthub.io/images: |
     - name: mlflow
       image: burakince/mlflow:2.22.1

--- a/charts/mlflow/README.md
+++ b/charts/mlflow/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for Mlflow open source platform for the machine learning lifecycle
 
-![Version: 0.17.3](https://img.shields.io/badge/Version-0.17.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.22.1](https://img.shields.io/badge/AppVersion-2.22.1-informational?style=flat-square)
+![Version: 0.18.0](https://img.shields.io/badge/Version-0.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.22.1](https://img.shields.io/badge/AppVersion-2.22.1-informational?style=flat-square)
 
 ## Get Helm Repository Info
 
@@ -656,14 +656,14 @@ helm upgrade [RELEASE_NAME] community-charts/mlflow
 | nameOverride | string | `""` | String to override the default generated name |
 | nodeSelector | object | `{}` | For more information checkout: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | podAnnotations | object | `{}` | Annotations for the pod |
-| podSecurityContext | object | `{}` | This is for setting Security Context to a Pod. For more information checkout: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
+| podSecurityContext | object | `{"fsGroup":1001,"fsGroupChangePolicy":"OnRootMismatch"}` | This is for setting Security Context to a Pod. For more information checkout: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
 | postgresql | object | `{"architecture":"standalone","auth":{"database":"mlflow","password":"","username":""},"enabled":false,"primary":{"persistence":{"enabled":true,"existingClaim":""},"service":{"ports":{"postgresql":5432}}}}` | Bitnami PostgreSQL configuration. For more information checkout: https://github.com/bitnami/charts/tree/main/bitnami/postgresql |
 | postgresql.auth.database | string | `"mlflow"` | The name of the PostgreSQL database. |
 | postgresql.enabled | bool | `false` | Enable postgresql |
 | readinessProbe | object | `{"failureThreshold":5,"initialDelaySeconds":10,"periodSeconds":30,"timeoutSeconds":3}` | Readiness probe configurations. Please look to [here](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes). |
 | replicaCount | int | `1` | Numbers of replicas |
 | resources | object | `{}` | This block is for setting up the resource management for the pod more information can be found here: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
-| securityContext | object | `{}` | This is for setting Security Context to a Container. For more information checkout: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":false,"runAsGroup":1001,"runAsNonRoot":true,"runAsUser":1001}` | This is for setting Security Context to a Container. For more information checkout: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
 | service | object | `{"annotations":{},"name":"http","port":5000,"type":"ClusterIP"}` | This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/ |
 | service.annotations | object | `{}` | Additional service annotations |
 | service.name | string | `"http"` | Default Service name |

--- a/charts/mlflow/unittests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/mlflow/unittests/__snapshot__/deployment_test.yaml.snap
@@ -74,8 +74,19 @@ should match snapshot of default values:
                 periodSeconds: 30
                 timeoutSeconds: 3
               resources: {}
-              securityContext: {}
-          securityContext: {}
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                privileged: false
+                readOnlyRootFilesystem: false
+                runAsGroup: 1001
+                runAsNonRoot: true
+                runAsUser: 1001
+          securityContext:
+            fsGroup: 1001
+            fsGroupChangePolicy: OnRootMismatch
           serviceAccountName: mlflow
 should match snapshot with additional values:
   1: |
@@ -183,8 +194,15 @@ should match snapshot with additional values:
                   cpu: 100m
                   memory: 128Mi
               securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                privileged: false
+                readOnlyRootFilesystem: false
+                runAsGroup: 1001
                 runAsNonRoot: true
-                runAsUser: 1000
+                runAsUser: 1001
               volumeMounts:
                 - mountPath: /etc/mlflow/auth
                   name: auth-config-secret
@@ -228,8 +246,15 @@ should match snapshot with additional values:
                   cpu: 100m
                   memory: 128Mi
               securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                privileged: false
+                readOnlyRootFilesystem: false
+                runAsGroup: 1001
                 runAsNonRoot: true
-                runAsUser: 1000
+                runAsUser: 1001
               volumeMounts:
                 - mountPath: /opt/mlflow/migrations.py
                   name: migrations-config
@@ -240,7 +265,8 @@ should match snapshot with additional values:
           nodeSelector:
             disktype: ssd
           securityContext:
-            fsGroup: 2000
+            fsGroup: 1001
+            fsGroupChangePolicy: OnRootMismatch
           serviceAccountName: mlflow
           tolerations:
             - effect: NoSchedule
@@ -375,8 +401,15 @@ should match snapshot with additional values when bitnami mysql is enabled:
                   cpu: 100m
                   memory: 128Mi
               securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                privileged: false
+                readOnlyRootFilesystem: false
+                runAsGroup: 1001
                 runAsNonRoot: true
-                runAsUser: 1000
+                runAsUser: 1001
               volumeMounts:
                 - mountPath: /etc/mlflow/auth
                   name: auth-config-secret
@@ -434,8 +467,15 @@ should match snapshot with additional values when bitnami mysql is enabled:
                   cpu: 100m
                   memory: 128Mi
               securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                privileged: false
+                readOnlyRootFilesystem: false
+                runAsGroup: 1001
                 runAsNonRoot: true
-                runAsUser: 1000
+                runAsUser: 1001
               volumeMounts:
                 - mountPath: /opt/mlflow/migrations.py
                   name: migrations-config
@@ -446,7 +486,8 @@ should match snapshot with additional values when bitnami mysql is enabled:
           nodeSelector:
             disktype: ssd
           securityContext:
-            fsGroup: 2000
+            fsGroup: 1001
+            fsGroupChangePolicy: OnRootMismatch
           serviceAccountName: mlflow
           tolerations:
             - effect: NoSchedule
@@ -581,8 +622,15 @@ should match snapshot with additional values when bitnami postgresql is enabled:
                   cpu: 100m
                   memory: 128Mi
               securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                privileged: false
+                readOnlyRootFilesystem: false
+                runAsGroup: 1001
                 runAsNonRoot: true
-                runAsUser: 1000
+                runAsUser: 1001
               volumeMounts:
                 - mountPath: /etc/mlflow/auth
                   name: auth-config-secret
@@ -640,8 +688,15 @@ should match snapshot with additional values when bitnami postgresql is enabled:
                   cpu: 100m
                   memory: 128Mi
               securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                privileged: false
+                readOnlyRootFilesystem: false
+                runAsGroup: 1001
                 runAsNonRoot: true
-                runAsUser: 1000
+                runAsUser: 1001
               volumeMounts:
                 - mountPath: /opt/mlflow/migrations.py
                   name: migrations-config
@@ -652,7 +707,8 @@ should match snapshot with additional values when bitnami postgresql is enabled:
           nodeSelector:
             disktype: ssd
           securityContext:
-            fsGroup: 2000
+            fsGroup: 1001
+            fsGroupChangePolicy: OnRootMismatch
           serviceAccountName: mlflow
           tolerations:
             - effect: NoSchedule
@@ -781,8 +837,15 @@ should match snapshot with additional values when mysql is enabled:
                   cpu: 100m
                   memory: 128Mi
               securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                privileged: false
+                readOnlyRootFilesystem: false
+                runAsGroup: 1001
                 runAsNonRoot: true
-                runAsUser: 1000
+                runAsUser: 1001
               volumeMounts:
                 - mountPath: /etc/mlflow/auth
                   name: auth-config-secret
@@ -826,8 +889,15 @@ should match snapshot with additional values when mysql is enabled:
                   cpu: 100m
                   memory: 128Mi
               securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                privileged: false
+                readOnlyRootFilesystem: false
+                runAsGroup: 1001
                 runAsNonRoot: true
-                runAsUser: 1000
+                runAsUser: 1001
               volumeMounts:
                 - mountPath: /opt/mlflow/migrations.py
                   name: migrations-config
@@ -838,7 +908,8 @@ should match snapshot with additional values when mysql is enabled:
           nodeSelector:
             disktype: ssd
           securityContext:
-            fsGroup: 2000
+            fsGroup: 1001
+            fsGroupChangePolicy: OnRootMismatch
           serviceAccountName: mlflow
           tolerations:
             - effect: NoSchedule
@@ -967,8 +1038,15 @@ should match snapshot with additional values when postgresql is enabled:
                   cpu: 100m
                   memory: 128Mi
               securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                privileged: false
+                readOnlyRootFilesystem: false
+                runAsGroup: 1001
                 runAsNonRoot: true
-                runAsUser: 1000
+                runAsUser: 1001
               volumeMounts:
                 - mountPath: /etc/mlflow/auth
                   name: auth-config-secret
@@ -1012,8 +1090,15 @@ should match snapshot with additional values when postgresql is enabled:
                   cpu: 100m
                   memory: 128Mi
               securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                privileged: false
+                readOnlyRootFilesystem: false
+                runAsGroup: 1001
                 runAsNonRoot: true
-                runAsUser: 1000
+                runAsUser: 1001
               volumeMounts:
                 - mountPath: /opt/mlflow/migrations.py
                   name: migrations-config
@@ -1024,7 +1109,8 @@ should match snapshot with additional values when postgresql is enabled:
           nodeSelector:
             disktype: ssd
           securityContext:
-            fsGroup: 2000
+            fsGroup: 1001
+            fsGroupChangePolicy: OnRootMismatch
           serviceAccountName: mlflow
           tolerations:
             - effect: NoSchedule

--- a/charts/mlflow/unittests/deployment_test.yaml
+++ b/charts/mlflow/unittests/deployment_test.yaml
@@ -1118,10 +1118,10 @@ tests:
       podAnnotations:
         test-key: test-value
       podSecurityContext:
-        fsGroup: 2000
+        fsGroup: 1001
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
+        runAsUser: 1001
       initContainers:
         - name: init-myservice
           image: busybox:1.28
@@ -1193,10 +1193,10 @@ tests:
       podAnnotations:
         test-key: test-value
       podSecurityContext:
-        fsGroup: 2000
+        fsGroup: 1001
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
+        runAsUser: 1001
       initContainers:
         - name: init-myservice
           image: busybox:1.28
@@ -1268,10 +1268,10 @@ tests:
       podAnnotations:
         test-key: test-value
       podSecurityContext:
-        fsGroup: 2000
+        fsGroup: 1001
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
+        runAsUser: 1001
       initContainers:
         - name: init-myservice
           image: busybox:1.28
@@ -1343,10 +1343,10 @@ tests:
       podAnnotations:
         test-key: test-value
       podSecurityContext:
-        fsGroup: 2000
+        fsGroup: 1001
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
+        runAsUser: 1001
       initContainers:
         - name: init-myservice
           image: busybox:1.28
@@ -1418,10 +1418,10 @@ tests:
       podAnnotations:
         test-key: test-value
       podSecurityContext:
-        fsGroup: 2000
+        fsGroup: 1001
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
+        runAsUser: 1001
       initContainers:
         - name: init-myservice
           image: busybox:1.28

--- a/charts/mlflow/values.yaml
+++ b/charts/mlflow/values.yaml
@@ -52,17 +52,21 @@ serviceAccount:
 podAnnotations: {}
 
 # -- This is for setting Security Context to a Pod. For more information checkout: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  fsGroup: 1001
+  fsGroupChangePolicy: "OnRootMismatch"
 
 # -- This is for setting Security Context to a Container. For more information checkout: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: false
+  runAsNonRoot: true
+  privileged: false
+  runAsUser: 1001
+  runAsGroup: 1001
 
 # -- This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:


### PR DESCRIPTION
<!--
Thank you for contributing to community-charts/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in community-charts/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
Upstream docker image started to to non-root mlflow user. We can add [non-root user UID and GID](https://github.com/burakince/mlflow/tree/2.22.1?tab=readme-ov-file#security-context) to default pod and container security contexes.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated
