### PR TITLE
[cloudflared] Update cloudflared chart to 2025.6.0

### DIFF
--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -2,7 +2,6 @@ apiVersion: v2
 name: cloudflared
 description: A Helm chart for cloudflare tunnel
 icon: https://raw.githubusercontent.com/cloudflare/color/refs/heads/master/static/thinking/logo.png
-
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives
@@ -12,31 +11,24 @@ icon: https://raw.githubusercontent.com/cloudflare/color/refs/heads/master/stati
 # a dependency of application charts to inject those utilities and functions into the rendering
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.5
-
+version: 2.0.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2025.5.0"
-
+appVersion: "2025.6.0"
 kubeVersion: ">=1.21.0-0"
-
 home: https://github.com/cloudflare/cloudflared
-
 maintainers:
   - name: burakince
     email: burak.ince@linux.org.tr
     url: https://www.burakince.com
-
 sources:
   - https://github.com/community-charts/helm-charts
   - https://github.com/cloudflare/cloudflared
-
 keywords:
   - kubernetes
   - reverse-proxy
@@ -47,7 +39,6 @@ keywords:
   - tunnel
   - zero-trust-network-access
   - cloudflare-tunnel
-
 annotations:
   artifacthub.io/alternativeName: cloudflare
   artifacthub.io/links: |
@@ -58,11 +49,15 @@ annotations:
     - name: Official Documentation
       url: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/
   artifacthub.io/containsSecurityUpdates: "false"
-  artifacthub.io/changes: |
-    - Update cloudflare/cloudflared image version to 2025.5.0
+  artifacthub.io/changes: |-
+    - kind: changed
+      description: Update cloudflare/cloudflared image version to 2025.6.0
+      links:
+        - name: Upstream Project
+          url: https://hub.docker.com/r/cloudflare/cloudflared
   artifacthub.io/images: |
     - name: cloudflared
-      image: cloudflare/cloudflared:2025.5.0
+      image: cloudflare/cloudflared:2025.6.0
       platforms:
         - linux/amd64
         - linux/arm64
@@ -78,5 +73,4 @@ annotations:
   artifacthub.io/signKey: |
     fingerprint: 939B1A0ED8AAA8E722ACCDB3B6A012EE8A76426A
     url: https://keybase.io/communitycharts/pgp_keys.asc
-
 dependencies: []

--- a/charts/cloudflared/README.md
+++ b/charts/cloudflared/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for cloudflare tunnel
 
-![Version: 2.0.5](https://img.shields.io/badge/Version-2.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2025.5.0](https://img.shields.io/badge/AppVersion-2025.5.0-informational?style=flat-square)
+![Version: 2.0.6](https://img.shields.io/badge/Version-2.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2025.6.0](https://img.shields.io/badge/AppVersion-2025.6.0-informational?style=flat-square)
 
 ## Get Helm Repository Info
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the cloudflared chart to use the latest image version 2025.6.0 from cloudflare/cloudflared. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated