### PR TITLE
[n8n] Update n8n chart to 1.97.1

### DIFF
--- a/charts/n8n/Chart.lock
+++ b/charts/n8n/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 21.1.11
+  version: 21.2.3
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.7.8
+  version: 16.7.10
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:d425041cb1cee76527da3b0824fa579176f934171b47c9293a93b554ce76c2e5
-generated: "2025-06-02T20:05:11.420379598Z"
+digest: sha256:57960508235f310fed37eeb11c4f4eeebb8934726ed1c90b062915b35ae9d8bb
+generated: "2025-06-11T16:44:56.646044418Z"

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.2
+version: 1.8.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.95.3"
+appVersion: "1.97.1"
 kubeVersion: ">=1.23.0-0"
 home: https://n8n.io
 maintainers:
@@ -49,13 +49,13 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update n8nio/n8n image version to 1.95.3
+      description: Update n8nio/n8n image version to 1.97.1
       links:
         - name: Upstream Project
           url: https://github.com/n8n-io/n8n
   artifacthub.io/images: |
     - name: n8n
-      image: n8nio/n8n:1.95.3
+      image: n8nio/n8n:1.97.1
       platforms:
         - linux/amd64
         - linux/arm64
@@ -107,11 +107,11 @@ annotations:
     url: https://keybase.io/communitycharts/pgp_keys.asc
 dependencies:
   - name: redis
-    version: 21.1.11
+    version: 21.2.3
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: postgresql
-    version: 16.7.8
+    version: 16.7.10
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: minio

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.8.2](https://img.shields.io/badge/Version-1.8.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.95.3](https://img.shields.io/badge/AppVersion-1.95.3-informational?style=flat-square)
+![Version: 1.8.3](https://img.shields.io/badge/Version-1.8.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.97.1](https://img.shields.io/badge/AppVersion-1.97.1-informational?style=flat-square)
 
 ## Get Helm Repository Info
 
@@ -678,8 +678,8 @@ Kubernetes: `>=1.23.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 16.7.8 |
-| https://charts.bitnami.com/bitnami | redis | 21.1.11 |
+| https://charts.bitnami.com/bitnami | postgresql | 16.7.10 |
+| https://charts.bitnami.com/bitnami | redis | 21.2.3 |
 | https://charts.min.io/ | minio | 5.4.0 |
 
 ## Uninstall Helm Chart


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the n8n chart to use the latest image version 1.97.1 from n8nio/n8n. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated