### PR TITLE
[n8n] Update n8n chart to 1.98.2

### DIFF
--- a/charts/n8n/Chart.lock
+++ b/charts/n8n/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 21.2.3
+  version: 21.2.4
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.7.11
+  version: 16.7.12
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:dccce6c81d59ea6e5f1d4dfae345957b1371a0695dd55a13e215cbd91e990cd9
-generated: "2025-06-16T20:56:52.907012305Z"
+digest: sha256:b5139489c4a01dc3ea5746a8d3e3117d2b949b1d200c0c06a05741e368b2d670
+generated: "2025-06-18T20:57:26.142548557Z"

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.4
+version: 1.8.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.98.1"
+appVersion: "1.98.2"
 kubeVersion: ">=1.23.0-0"
 home: https://n8n.io
 maintainers:
@@ -49,13 +49,13 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update n8nio/n8n image version to 1.98.1
+      description: Update n8nio/n8n image version to 1.98.2
       links:
         - name: Upstream Project
           url: https://github.com/n8n-io/n8n
   artifacthub.io/images: |
     - name: n8n
-      image: n8nio/n8n:1.98.1
+      image: n8nio/n8n:1.98.2
       platforms:
         - linux/amd64
         - linux/arm64
@@ -107,11 +107,11 @@ annotations:
     url: https://keybase.io/communitycharts/pgp_keys.asc
 dependencies:
   - name: redis
-    version: 21.2.3
+    version: 21.2.4
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: postgresql
-    version: 16.7.11
+    version: 16.7.12
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: minio

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.8.4](https://img.shields.io/badge/Version-1.8.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.98.1](https://img.shields.io/badge/AppVersion-1.98.1-informational?style=flat-square)
+![Version: 1.8.5](https://img.shields.io/badge/Version-1.8.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.98.2](https://img.shields.io/badge/AppVersion-1.98.2-informational?style=flat-square)
 
 ## Get Helm Repository Info
 
@@ -678,8 +678,8 @@ Kubernetes: `>=1.23.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 16.7.11 |
-| https://charts.bitnami.com/bitnami | redis | 21.2.3 |
+| https://charts.bitnami.com/bitnami | postgresql | 16.7.12 |
+| https://charts.bitnami.com/bitnami | redis | 21.2.4 |
 | https://charts.min.io/ | minio | 5.4.0 |
 
 ## Uninstall Helm Chart


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the n8n chart to use the latest image version 1.98.2 from n8nio/n8n. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated