### PR TITLE
[n8n] Update n8n chart to 1.99.1

### DIFF
--- a/charts/n8n/Chart.lock
+++ b/charts/n8n/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 21.2.4
+  version: 21.2.5
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.7.12
+  version: 16.7.13
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:b5139489c4a01dc3ea5746a8d3e3117d2b949b1d200c0c06a05741e368b2d670
-generated: "2025-06-18T20:57:26.142548557Z"
+digest: sha256:25c5d287817e4a2f0207cb253321728e81e9ca91ceb0e391b4c3c9ce2d237d07
+generated: "2025-06-23T16:27:42.824151989Z"

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.6
+version: 1.8.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.98.2"
+appVersion: "1.99.1"
 kubeVersion: ">=1.23.0-0"
 home: https://n8n.io
 maintainers:
@@ -48,14 +48,14 @@ annotations:
       url: https://docs.n8n.io/
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
-    - kind: fixed
-      description: Fix npm registry secret volume mount when only npmRegistry.enabled is true
+    - kind: changed
+      description: Update n8nio/n8n image version to 1.99.1
       links:
-        - name: Github PR
-          url: https://github.com/community-charts/helm-charts/pull/135
+        - name: Upstream Project
+          url: https://github.com/n8n-io/n8n
   artifacthub.io/images: |
     - name: n8n
-      image: n8nio/n8n:1.98.2
+      image: n8nio/n8n:1.99.1
       platforms:
         - linux/amd64
         - linux/arm64
@@ -107,11 +107,11 @@ annotations:
     url: https://keybase.io/communitycharts/pgp_keys.asc
 dependencies:
   - name: redis
-    version: 21.2.4
+    version: 21.2.5
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: postgresql
-    version: 16.7.12
+    version: 16.7.13
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: minio

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.8.6](https://img.shields.io/badge/Version-1.8.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.98.2](https://img.shields.io/badge/AppVersion-1.98.2-informational?style=flat-square)
+![Version: 1.8.7](https://img.shields.io/badge/Version-1.8.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.99.1](https://img.shields.io/badge/AppVersion-1.99.1-informational?style=flat-square)
 
 ## Get Helm Repository Info
 
@@ -678,8 +678,8 @@ Kubernetes: `>=1.23.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 16.7.12 |
-| https://charts.bitnami.com/bitnami | redis | 21.2.4 |
+| https://charts.bitnami.com/bitnami | postgresql | 16.7.13 |
+| https://charts.bitnami.com/bitnami | redis | 21.2.5 |
 | https://charts.min.io/ | minio | 5.4.0 |
 
 ## Uninstall Helm Chart


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the n8n chart to use the latest image version 1.99.1 from n8nio/n8n. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated