### PR TITLE
[mlflow] Update mlflow chart to 3.1.1

### DIFF
--- a/charts/mlflow/Chart.lock
+++ b/charts/mlflow/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.7.10
+  version: 16.7.13
 - name: mysql
   repository: https://charts.bitnami.com/bitnami
-  version: 13.0.1
-digest: sha256:1f01d02f3f27ab0ebf07d961c97d129bacccf61e4cfc0f43c34870a74194da1a
-generated: "2025-06-06T22:01:14.902148917Z"
+  version: 13.0.2
+digest: sha256:c6989c5a5e2273b002b155e957780616e84e28be0147196efe89fa012593ce44
+generated: "2025-06-25T19:33:01.924935+02:00"

--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.3.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.1.0"
+appVersion: "3.1.1"
 kubeVersion: ">=1.16.0-0"
 home: https://mlflow.org
 maintainers:
@@ -51,11 +51,16 @@ annotations:
       url: https://github.com/burakince/mlflow
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
+    - kind: changed
+      description: Update burakince/mlflow image version to 3.1.1
+      links:
+        - name: Upstream Project
+          url: https://hub.docker.com/r/burakince/mlflow
     - kind: added
-      description: Log level configuration added
+      description: Add group attribute key for Active Directory users
       links:
         - name: Github Issue
-          url: https://github.com/community-charts/helm-charts/issues/137
+          url: https://github.com/burakince/mlflow/issues/221
   artifacthub.io/images: |
     - name: mlflow
       image: burakince/mlflow:3.1.0

--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -61,6 +61,16 @@ annotations:
       links:
         - name: Github Issue
           url: https://github.com/burakince/mlflow/issues/221
+    - kind: changed
+      description: Update bitnami/postgresql chart version to 16.7.13
+      links:
+        - name: ArtifactHub
+          url: https://artifacthub.io/packages/helm/bitnami/postgresql/16.7.13
+    - kind: changed
+      description: Update bitnami/mysql chart version to 13.0.2
+      links:
+        - name: ArtifactHub
+          url: https://artifacthub.io/packages/helm/bitnami/mysql/13.0.2
   artifacthub.io/images: |
     - name: mlflow
       image: burakince/mlflow:3.1.0
@@ -96,10 +106,10 @@ annotations:
     url: https://keybase.io/communitycharts/pgp_keys.asc
 dependencies:
   - name: postgresql
-    version: 16.7.10
+    version: 16.7.13
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: mysql
-    version: 13.0.1
+    version: 13.0.2
     repository: https://charts.bitnami.com/bitnami
     condition: mysql.enabled

--- a/charts/mlflow/README.md
+++ b/charts/mlflow/README.md
@@ -557,8 +557,8 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | mysql | 13.0.1 |
-| https://charts.bitnami.com/bitnami | postgresql | 16.7.10 |
+| https://charts.bitnami.com/bitnami | mysql | 13.0.2 |
+| https://charts.bitnami.com/bitnami | postgresql | 16.7.13 |
 
 ## Uninstall Helm Chart
 

--- a/charts/mlflow/README.md
+++ b/charts/mlflow/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for Mlflow open source platform for the machine learning lifecycle
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.0](https://img.shields.io/badge/AppVersion-3.1.0-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.1](https://img.shields.io/badge/AppVersion-3.1.1-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -670,12 +670,13 @@ helm upgrade [RELEASE_NAME] community-charts/mlflow
 | ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` | Ingress path type |
 | ingress.tls | list | `[]` | Ingress tls configuration for https access |
 | initContainers | list | `[]` | Init Containers for Mlflow Pod |
-| ldapAuth | object | `{"adminGroupDistinguishedName":"","enabled":false,"encodedTrustedCACertificate":"","externalSecretForTrustedCACertificate":"","groupAttribute":"dn","lookupBind":"","searchBaseDistinguishedName":"","searchFilter":"(&(objectclass=groupOfUniqueNames)(uniquemember=%s))","tlsVerification":"required","uri":"","userGroupDistinguishedName":""}` | Basic Authentication with LDAP backend |
+| ldapAuth | object | `{"adminGroupDistinguishedName":"","enabled":false,"encodedTrustedCACertificate":"","externalSecretForTrustedCACertificate":"","groupAttribute":"dn","groupAttributeKey":"","lookupBind":"","searchBaseDistinguishedName":"","searchFilter":"(&(objectclass=groupOfUniqueNames)(uniquemember=%s))","tlsVerification":"required","uri":"","userGroupDistinguishedName":""}` | Basic Authentication with LDAP backend |
 | ldapAuth.adminGroupDistinguishedName | string | `""` | LDAP DN for the admin group. e.g.: "cn=test-admin,ou=groups,dc=mlflow,dc=test" |
 | ldapAuth.enabled | bool | `false` | Specifies if you want to enable mlflow LDAP authentication. auth and ldapAuth can't be enabled at same time. |
 | ldapAuth.encodedTrustedCACertificate | string | `""` | Base64 encoded trusted CA certificate for LDAP server connection. |
 | ldapAuth.externalSecretForTrustedCACertificate | string | `""` | External secret name for trusted CA certificate for LDAP server connection. |
 | ldapAuth.groupAttribute | string | `"dn"` | LDAP group attribute. |
+| ldapAuth.groupAttributeKey | string | `""` | Optional group attribute key for Active Directory users. e.g.: "attributes" |
 | ldapAuth.lookupBind | string | `""` | LDAP Loopup Bind. e.g.: "uid=%s,ou=people,dc=mlflow,dc=test" |
 | ldapAuth.searchBaseDistinguishedName | string | `""` | LDAP base DN for the search. e.g.: "ou=groups,dc=mlflow,dc=test" |
 | ldapAuth.searchFilter | string | `"(&(objectclass=groupOfUniqueNames)(uniquemember=%s))"` | LDAP query filter for search |

--- a/charts/mlflow/templates/secret.yaml
+++ b/charts/mlflow/templates/secret.yaml
@@ -43,6 +43,9 @@ data:
   LDAP_TLS_VERIFY: {{ .Values.ldapAuth.tlsVerification | b64enc }}
   LDAP_LOOKUP_BIND: {{ .Values.ldapAuth.lookupBind | b64enc }}
   LDAP_GROUP_ATTRIBUTE: {{ .Values.ldapAuth.groupAttribute | b64enc }}
+  {{- if .Values.ldapAuth.groupAttributeKey }}
+  LDAP_GROUP_ATTRIBUTE_KEY: {{ .Values.ldapAuth.groupAttributeKey | b64enc }}
+  {{- end }}
   LDAP_GROUP_SEARCH_BASE_DN: {{ .Values.ldapAuth.searchBaseDistinguishedName | b64enc }}
   LDAP_GROUP_SEARCH_FILTER: {{ .Values.ldapAuth.searchFilter | b64enc }}
   LDAP_GROUP_ADMIN_DN: {{ .Values.ldapAuth.adminGroupDistinguishedName | b64enc }}

--- a/charts/mlflow/unittests/secret_test.yaml
+++ b/charts/mlflow/unittests/secret_test.yaml
@@ -99,15 +99,16 @@ tests:
 
   - it: should use ldap configurations when ldap auth enabled
     set:
-      ldapAuth.enabled: true
-      ldapAuth.uri: "ldap://lldap:3890/dc=mlflow,dc=test"
-      ldapAuth.tlsVerification: optional
-      ldapAuth.lookupBind: "uid=%s,ou=people,dc=mlflow,dc=test"
-      ldapAuth.groupAttribute: "dn"
-      ldapAuth.searchBaseDistinguishedName: "ou=groups,dc=mlflow,dc=test"
-      ldapAuth.searchFilter: "(&(objectclass=groupOfUniqueNames)(uniquemember=%s))"
-      ldapAuth.adminGroupDistinguishedName: "cn=test-admin,ou=groups,dc=mlflow,dc=test"
-      ldapAuth.userGroupDistinguishedName: "cn=test-user,ou=groups,dc=mlflow,dc=test"
+      ldapAuth:
+        enabled: true
+        uri: "ldap://lldap:3890/dc=mlflow,dc=test"
+        tlsVerification: optional
+        lookupBind: "uid=%s,ou=people,dc=mlflow,dc=test"
+        groupAttribute: "dn"
+        searchBaseDistinguishedName: "ou=groups,dc=mlflow,dc=test"
+        searchFilter: "(&(objectclass=groupOfUniqueNames)(uniquemember=%s))"
+        adminGroupDistinguishedName: "cn=test-admin,ou=groups,dc=mlflow,dc=test"
+        userGroupDistinguishedName: "cn=test-user,ou=groups,dc=mlflow,dc=test"
     asserts:
       - equal:
           path: data.LDAP_URI
@@ -124,6 +125,59 @@ tests:
       - equal:
           path: data.LDAP_GROUP_ATTRIBUTE
           value: dn
+          decodeBase64: true
+      - notExists:
+          path: data.LDAP_GROUP_ATTRIBUTE_KEY
+      - equal:
+          path: data.LDAP_GROUP_SEARCH_BASE_DN
+          value: ou=groups,dc=mlflow,dc=test
+          decodeBase64: true
+      - equal:
+          path: data.LDAP_GROUP_SEARCH_FILTER
+          value: (&(objectclass=groupOfUniqueNames)(uniquemember=%s))
+          decodeBase64: true
+      - equal:
+          path: data.LDAP_GROUP_ADMIN_DN
+          value: cn=test-admin,ou=groups,dc=mlflow,dc=test
+          decodeBase64: true
+      - equal:
+          path: data.LDAP_GROUP_USER_DN
+          value: cn=test-user,ou=groups,dc=mlflow,dc=test
+          decodeBase64: true
+
+  - it: should have group attribute key when ldap auth enabled and group attribute key set for Active Directory users
+    set:
+      ldapAuth:
+        enabled: true
+        uri: "ldap://lldap:3890/dc=mlflow,dc=test"
+        tlsVerification: optional
+        lookupBind: "uid=%s,ou=people,dc=mlflow,dc=test"
+        groupAttribute: "dn"
+        groupAttributeKey: "attributes"
+        searchBaseDistinguishedName: "ou=groups,dc=mlflow,dc=test"
+        searchFilter: "(&(objectclass=groupOfUniqueNames)(uniquemember=%s))"
+        adminGroupDistinguishedName: "cn=test-admin,ou=groups,dc=mlflow,dc=test"
+        userGroupDistinguishedName: "cn=test-user,ou=groups,dc=mlflow,dc=test"
+    asserts:
+      - equal:
+          path: data.LDAP_URI
+          value: ldap://lldap:3890/dc=mlflow,dc=test
+          decodeBase64: true
+      - equal:
+          path: data.LDAP_TLS_VERIFY
+          value: optional
+          decodeBase64: true
+      - equal:
+          path: data.LDAP_LOOKUP_BIND
+          value: uid=%s,ou=people,dc=mlflow,dc=test
+          decodeBase64: true
+      - equal:
+          path: data.LDAP_GROUP_ATTRIBUTE
+          value: dn
+          decodeBase64: true
+      - equal:
+          path: data.LDAP_GROUP_ATTRIBUTE_KEY
+          value: attributes
           decodeBase64: true
       - equal:
           path: data.LDAP_GROUP_SEARCH_BASE_DN

--- a/charts/mlflow/values.schema.json
+++ b/charts/mlflow/values.schema.json
@@ -1516,6 +1516,13 @@
           "title": "groupAttribute",
           "type": "string"
         },
+        "groupAttributeKey": {
+          "default": "",
+          "description": "Optional group attribute key for Active Directory users. e.g.: attributes",
+          "required": [],
+          "title": "groupAttributeKey",
+          "type": "string"
+        },
         "searchBaseDistinguishedName": {
           "default": "",
           "description": "LDAP base DN for the search. e.g.: ou=groups,dc=mlflow,dc=test",
@@ -1565,6 +1572,7 @@
         "tlsVerification",
         "lookupBind",
         "groupAttribute",
+        "groupAttributeKey",
         "searchBaseDistinguishedName",
         "searchFilter",
         "adminGroupDistinguishedName",

--- a/charts/mlflow/values.yaml
+++ b/charts/mlflow/values.yaml
@@ -287,6 +287,8 @@ ldapAuth:
   lookupBind: ""
   # -- LDAP group attribute.
   groupAttribute: "dn"
+  # -- Optional group attribute key for Active Directory users. e.g.: "attributes"
+  groupAttributeKey: ""
   # -- LDAP base DN for the search. e.g.: "ou=groups,dc=mlflow,dc=test"
   searchBaseDistinguishedName: ""
   # -- LDAP query filter for search


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the mlflow chart to use the latest image version 3.1.1 from burakince/mlflow. This ensures the chart stays current with the latest upstream release.
Additionally we started to support `LDAP_GROUP_ATTRIBUTE_KEY` environment variable for Active Directory users.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated