### PR TITLE
[n8n] Update n8n chart to 1.100.1

### DIFF
--- a/charts/n8n/Chart.lock
+++ b/charts/n8n/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 21.2.5
+  version: 21.2.6
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.7.13
+  version: 16.7.14
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:25c5d287817e4a2f0207cb253321728e81e9ca91ceb0e391b4c3c9ce2d237d07
-generated: "2025-06-23T16:27:42.824151989Z"
+digest: sha256:32547592a1086356665fd3839ea8ca7d78909f04a649d36a2bd4de9d02479c8f
+generated: "2025-07-01T02:44:45.288785926Z"

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.12.0
+version: 1.12.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.99.1"
+appVersion: "1.100.1"
 kubeVersion: ">=1.23.0-0"
 home: https://n8n.io
 maintainers:
@@ -50,19 +50,24 @@ annotations:
       url: https://docs.n8n.io/
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
-    - kind: added
-      description: Added persistence support
+    - kind: changed
+      description: Update n8nio/n8n image version to 1.100.1
       links:
-        - name: GitHub Issue
-          url: https://github.com/community-charts/helm-charts/issues/94
-    - kind: added
-      description: Added hostAliases support
+        - name: Upstream Project
+          url: https://github.com/n8n-io/n8n
+    - kind: changed
+      description: Update dependency redis from 21.2.5 to 21.2.6
       links:
-        - name: GitHub Issue
-          url: https://github.com/community-charts/helm-charts/issues/125
+        - name: ArtifactHub
+          url: https://artifacthub.io/packages/helm/bitnami/redis
+    - kind: changed
+      description: Update dependency postgresql from 16.7.13 to 16.7.14
+      links:
+        - name: ArtifactHub
+          url: https://artifacthub.io/packages/helm/bitnami/postgresql
   artifacthub.io/images: |
     - name: n8n
-      image: n8nio/n8n:1.99.1
+      image: n8nio/n8n:1.100.1
       platforms:
         - linux/amd64
         - linux/arm64
@@ -114,11 +119,11 @@ annotations:
     url: https://keybase.io/communitycharts/pgp_keys.asc
 dependencies:
   - name: redis
-    version: 21.2.5
+    version: 21.2.6
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: postgresql
-    version: 16.7.13
+    version: 16.7.14
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: minio

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.12.0](https://img.shields.io/badge/Version-1.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.99.1](https://img.shields.io/badge/AppVersion-1.99.1-informational?style=flat-square)
+![Version: 1.12.1](https://img.shields.io/badge/Version-1.12.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.100.1](https://img.shields.io/badge/AppVersion-1.100.1-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -880,8 +880,8 @@ Kubernetes: `>=1.23.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 16.7.13 |
-| https://charts.bitnami.com/bitnami | redis | 21.2.5 |
+| https://charts.bitnami.com/bitnami | postgresql | 16.7.14 |
+| https://charts.bitnami.com/bitnami | redis | 21.2.6 |
 | https://charts.min.io/ | minio | 5.4.0 |
 
 ## Uninstall Helm Chart


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the n8n chart to use the latest image version 1.100.1 from n8nio/n8n. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated