### PR TITLE
[actualbudget] Update actualbudget chart to 25.7.1

### DIFF
--- a/charts/actualbudget/Chart.yaml
+++ b/charts/actualbudget/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.1
+version: 1.7.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "25.7.0"
+appVersion: "25.7.1"
 kubeVersion: ">=1.16.0-0"
 home: https://actualbudget.org/
 maintainers:
@@ -50,13 +50,13 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update actualbudget/actual-server image version to 25.7.0
+      description: Update actualbudget/actual-server image version to 25.7.1
       links:
         - name: Upstream Project
           url: https://hub.docker.com/r/actualbudget/actual-server
   artifacthub.io/images: |
     - name: actualbudget
-      image: actualbudget/actual-server:25.7.0
+      image: actualbudget/actual-server:25.7.1
       platforms:
         - linux/amd64
         - linux/arm64

--- a/charts/actualbudget/README.md
+++ b/charts/actualbudget/README.md
@@ -4,7 +4,7 @@
 
 A local-first personal finance app
 
-![Version: 1.7.1](https://img.shields.io/badge/Version-1.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 25.7.0](https://img.shields.io/badge/AppVersion-25.7.0-informational?style=flat-square)
+![Version: 1.7.2](https://img.shields.io/badge/Version-1.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 25.7.1](https://img.shields.io/badge/AppVersion-25.7.1-informational?style=flat-square)
 
 ## Official Documentation
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the actualbudget chart to use the latest image version 25.7.1 from actualbudget/actual-server. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated