### PR TITLE
[outline] Fix external postgres port config

### DIFF
--- a/charts/outline/Chart.yaml
+++ b/charts/outline/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.2
+version: 0.4.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -52,21 +52,11 @@ annotations:
       url: https://docs.getoutline.com/s/hosting/
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
-    - kind: changed
-      description: Update outlinewiki/outline image version to 0.85.1
+    - kind: fixed
+      description: Use of non-default postgresql port for external postgresql database.
       links:
         - name: Upstream Project
           url: https://hub.docker.com/r/outlinewiki/outline
-    - kind: changed
-      description: Update dependency redis from 21.2.6 to 21.2.11
-      links:
-        - name: ArtifactHub
-          url: https://artifacthub.io/packages/helm/bitnami/redis
-    - kind: changed
-      description: Update dependency postgresql from 16.7.15 to 16.7.19
-      links:
-        - name: ArtifactHub
-          url: https://artifacthub.io/packages/helm/bitnami/postgresql
   artifacthub.io/images: |
     - name: outline
       image: outlinewiki/outline:0.85.1

--- a/charts/outline/Chart.yaml
+++ b/charts/outline/Chart.yaml
@@ -57,6 +57,8 @@ annotations:
       links:
         - name: Upstream Project
           url: https://hub.docker.com/r/outlinewiki/outline
+    - kind: fixed
+      description: Fix documentation to use `fileStorage.s3.bucketUrl` rather than `fileStorage.s3.baseUrl`
   artifacthub.io/images: |
     - name: outline
       image: outlinewiki/outline:0.85.1

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for the fastest knowledge base for growing teams. Beautiful, realtime collaborative, feature packed, and markdown compatible.
 
-![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.85.1](https://img.shields.io/badge/AppVersion-0.85.1-informational?style=flat-square)
+![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.85.1](https://img.shields.io/badge/AppVersion-0.85.1-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -278,7 +278,7 @@ fileStorage:
   s3:
     bucket: outline
     region: us-east-1
-    baseUrl: "https://your-s3-compatible-endpoint"
+    bucketUrl: "https://your-s3-compatible-endpoint"
     accessKeyId: "your-access-key"
     secretAccessKey: "your-secret-key"
     forcePathStyle: true

--- a/charts/outline/README.md.gotmpl
+++ b/charts/outline/README.md.gotmpl
@@ -278,7 +278,7 @@ fileStorage:
   s3:
     bucket: outline
     region: us-east-1
-    baseUrl: "https://your-s3-compatible-endpoint"
+    bucketUrl: "https://your-s3-compatible-endpoint"
     accessKeyId: "your-access-key"
     secretAccessKey: "your-secret-key"
     forcePathStyle: true

--- a/charts/outline/templates/_helpers.tpl
+++ b/charts/outline/templates/_helpers.tpl
@@ -46,7 +46,7 @@ Create redis port
 */}}
 {{- define "outline.redis.port" -}}
 {{- if .Values.redis.enabled }}
-{{- printf "%d" (default .Values.redis.master.service.ports.redis 6379 | int) }}
+{{- printf "%d" (default 6379 .Values.redis.master.service.ports.redis | int) }}
 {{- else }}
 {{- printf "%d" (required "externalRedis.port is required" .Values.externalRedis.port | int) }}
 {{- end }}
@@ -86,9 +86,9 @@ Create PostgreSQL port
 */}}
 {{- define "outline.postgresql.port" -}}
 {{- if .Values.postgresql.enabled }}
-{{- printf "%d" (default .Values.postgresql.primary.service.ports.postgresql 5432 | int) }}
+{{- printf "%d" (default 5432 .Values.postgresql.primary.service.ports.postgresql | int) }}
 {{- else }}
-{{- printf "%d" (default .Values.externalPostgresql.port 5432 | int) }}
+{{- printf "%d" (default 5432 .Values.externalPostgresql.port | int) }}
 {{- end }}
 {{- end }}
 

--- a/charts/outline/unittests/deployment_test.yaml
+++ b/charts/outline/unittests/deployment_test.yaml
@@ -598,6 +598,21 @@ tests:
             name: PGHOST
             value: outline-postgresql
 
+  - it: should set postgresql port from bitnami's configuration when postgresql.enabled is true and postgresql.primary.service.ports.postgresql is set
+    set:
+      postgresql:
+        enabled: true
+        primary:
+          service:
+            ports:
+              postgresql: 20185
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "outline")].env
+          content:
+            name: PGPORT
+            value: "20185"
+
   - it: should set postgresql database by postgresql.auth.database when postgresql.enabled is true
     set:
       postgresql:
@@ -638,6 +653,21 @@ tests:
           content:
             name: REDIS_USERNAME
             value: "default"
+
+  - it: should set redis port from bitnami's config when redis.enabled is true and redis.master.service.ports.redis is set
+    set:
+      redis:
+        enabled: true
+        master:
+          service:
+            ports:
+              redis: 22000
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "outline")].env
+          content:
+            name: REDIS_PORT
+            value: "22000"
 
   - it: should set file storage directory and volume for it when fileStorage.mode is local and persistence is enabled
     set:

--- a/charts/outline/unittests/deployment_test.yaml
+++ b/charts/outline/unittests/deployment_test.yaml
@@ -574,6 +574,19 @@ tests:
                 name: fake-existing-secret
                 optional: true
 
+  - it: should set postgresql port from external configuration when postgresql.enabled is false and externalPostgresql.port is set
+    set:
+      postgresql:
+        enabled: false
+      externalPostgresql:
+        port: 20185
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "outline")].env
+          content:
+            name: PGPORT
+            value: "20185"
+
   - it: should set postgresql host by release name when postgresql.enabled is true
     set:
       postgresql:


### PR DESCRIPTION
#### What this PR does / why we need it:

The helm default command takes the default value as first parameter and the optional value as 2nd parameter.

This was used wrongly on 3 occasions. Therefore, it's not possible to use another port than the default one.

#### Checklist
- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
