### PR TITLE
[mlflow] Update mlflow chart to 3.1.3

### DIFF
--- a/charts/mlflow/Chart.lock
+++ b/charts/mlflow/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.7.13
+  version: 16.7.21
 - name: mysql
   repository: https://charts.bitnami.com/bitnami
-  version: 13.0.2
-digest: sha256:c6989c5a5e2273b002b155e957780616e84e28be0147196efe89fa012593ce44
-generated: "2025-06-25T19:33:01.924935+02:00"
+  version: 14.0.0
+digest: sha256:24933057cf776b9de9577999074bb81526d2c9ebcb9901aaa905a458a7063e79
+generated: "2025-07-23T21:08:32.097027039Z"

--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.0
+version: 1.3.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.1.1"
+appVersion: "3.1.3"
 kubeVersion: ">=1.16.0-0"
 home: https://mlflow.org
 maintainers:
@@ -52,28 +52,23 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update burakince/mlflow image version to 3.1.1
+      description: Update burakince/mlflow image version to 3.1.3
       links:
         - name: Upstream Project
           url: https://hub.docker.com/r/burakince/mlflow
-    - kind: added
-      description: Add group attribute key for Active Directory users
-      links:
-        - name: Github Issue
-          url: https://github.com/burakince/mlflow/issues/221
     - kind: changed
-      description: Update bitnami/postgresql chart version to 16.7.13
+      description: Update dependency postgresql from 16.7.13 to 16.7.21
       links:
         - name: ArtifactHub
-          url: https://artifacthub.io/packages/helm/bitnami/postgresql/16.7.13
+          url: https://artifacthub.io/packages/helm/bitnami/postgresql
     - kind: changed
-      description: Update bitnami/mysql chart version to 13.0.2
+      description: Update dependency mysql from 13.0.2 to 14.0.0
       links:
         - name: ArtifactHub
-          url: https://artifacthub.io/packages/helm/bitnami/mysql/13.0.2
+          url: https://artifacthub.io/packages/helm/bitnami/mysql
   artifacthub.io/images: |
     - name: mlflow
-      image: burakince/mlflow:3.1.0
+      image: burakince/mlflow:3.1.3
   artifacthub.io/license: MIT
   artifacthub.io/maintainers: |
     - name: burakince
@@ -106,10 +101,10 @@ annotations:
     url: https://keybase.io/communitycharts/pgp_keys.asc
 dependencies:
   - name: postgresql
-    version: 16.7.13
+    version: 16.7.21
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: mysql
-    version: 13.0.2
+    version: 14.0.0
     repository: https://charts.bitnami.com/bitnami
     condition: mysql.enabled

--- a/charts/mlflow/README.md
+++ b/charts/mlflow/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for Mlflow open source platform for the machine learning lifecycle
 
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.1](https://img.shields.io/badge/AppVersion-3.1.1-informational?style=flat-square)
+![Version: 1.3.1](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.3](https://img.shields.io/badge/AppVersion-3.1.3-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -557,8 +557,8 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | mysql | 13.0.2 |
-| https://charts.bitnami.com/bitnami | postgresql | 16.7.13 |
+| https://charts.bitnami.com/bitnami | mysql | 14.0.0 |
+| https://charts.bitnami.com/bitnami | postgresql | 16.7.21 |
 
 ## Uninstall Helm Chart
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the mlflow chart to use the latest image version 3.1.3 from burakince/mlflow. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated