### PR TITLE
Add support for existing database secrets in MLflow authentication configuration

### DIFF
--- a/charts/mlflow/rendered-with-secret.yaml
+++ b/charts/mlflow/rendered-with-secret.yaml
@@ -1,0 +1,232 @@
+---
+# Source: mlflow/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-release-mlflow
+  labels:
+    helm.sh/chart: mlflow-1.4.1
+    app: mlflow
+    app.kubernetes.io/name: mlflow
+    app.kubernetes.io/instance: test-release
+    version: "3.2.0"
+    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: mlflow/templates/auth_secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-release-mlflow-auth-config-secret
+  labels:
+    app: mlflow
+    chart: mlflow-1.4.1
+    release: test-release
+    heritage: Helm
+type: Opaque
+stringData:
+  basic_auth.ini: |-
+    [mlflow]
+    default_permission = READ
+    database_uri = postgresql://$(AUTH_PGUSER):$(AUTH_PGPASSWORD)@postgresql--auth-instance1.abcdef1234.eu-central-1.rds.amazonaws.com:5432/auth
+    admin_username = admin
+    admin_password = S3cr3+
+    authorization_function = mlflow.server.auth:authenticate_request_basic_auth
+---
+# Source: mlflow/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-release-mlflow-env-secret
+  labels:
+    app: mlflow
+    chart: mlflow-1.4.1
+    release: test-release
+    heritage: Helm
+type: Opaque
+data:
+---
+# Source: mlflow/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-release-mlflow-env-configmap
+  labels:
+    app: mlflow
+    chart: mlflow-1.4.1
+    release: test-release
+    heritage: Helm
+data:
+  PGHOST: postgresql-instance1.cg034hpkmmjt.eu-central-1.rds.amazonaws.com
+  PGPORT: "5432"
+  PGDATABASE: mlflow
+  MLFLOW_CONFIGURE_LOGGING: "true"
+  MLFLOW_LOGGING_LEVEL: "INFO"
+---
+# Source: mlflow/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-release-mlflow
+  labels:
+    helm.sh/chart: mlflow-1.4.1
+    app: mlflow
+    app.kubernetes.io/name: mlflow
+    app.kubernetes.io/instance: test-release
+    version: "3.2.0"
+    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5000
+      targetPort: 5000
+      protocol: TCP
+      name: http
+  selector:
+    app: mlflow
+    app.kubernetes.io/name: mlflow
+    app.kubernetes.io/instance: test-release
+---
+# Source: mlflow/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-release-mlflow
+  labels:
+    helm.sh/chart: mlflow-1.4.1
+    app: mlflow
+    app.kubernetes.io/name: mlflow
+    app.kubernetes.io/instance: test-release
+    version: "3.2.0"
+    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  selector:
+    matchLabels:
+      app: mlflow
+      app.kubernetes.io/name: mlflow
+      app.kubernetes.io/instance: test-release
+  template:
+    metadata:
+      annotations:
+        checksum/config: c475bbc1a9606d12423b8e9382dfd4334d84bdf74c0638eb2fbe5e62e25dbb7f
+      labels:
+        app: mlflow
+        app.kubernetes.io/name: mlflow
+        app.kubernetes.io/instance: test-release
+    spec:
+      serviceAccountName: test-release-mlflow
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: mlflow
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: false
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+          image: "burakince/mlflow:3.2.0"
+          imagePullPolicy: IfNotPresent
+          command: ["mlflow"]
+          args:
+            - server
+            - --host=0.0.0.0
+            - --port=5000
+            - --backend-store-uri=postgresql://
+            - --default-artifact-root=./mlruns
+            - --app-name=basic-auth
+            - --gunicorn-opts='--log-level=info'
+          ports:
+            - name: http
+              containerPort: 5000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            failureThreshold: 5
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            failureThreshold: 5
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 3
+          resources:
+            {}
+          env:
+            - name: MLFLOW_VERSION
+              value: "3.2.0"
+            - name: MLFLOW_AUTH_CONFIG_PATH
+              value: /etc/mlflow/auth/basic_auth.ini
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-database-secret
+                  key: password
+            - name: PGUSER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-database-secret
+                  key: username
+            - name: AUTH_PGUSER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-database-secret-auth
+                  key: username
+            - name: AUTH_PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-database-secret-auth
+                  key: password
+          envFrom:
+            - configMapRef:
+                name: test-release-mlflow-env-configmap
+            - secretRef:
+                name: test-release-mlflow-env-secret
+            - secretRef:
+                name: test-release-mlflow-flask-server-secret-key
+          volumeMounts:
+            - name: auth-config-secret
+              mountPath: "/etc/mlflow/auth"
+              readOnly: true
+      volumes:
+        - name: auth-config-secret
+          secret:
+            secretName: test-release-mlflow-auth-config-secret
+---
+# Source: mlflow/templates/flask_secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-release-mlflow-flask-server-secret-key
+  namespace: default
+  labels:
+    app: mlflow
+    chart: mlflow-1.4.1
+    release: test-release
+    heritage: Helm
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+type: Opaque
+data:
+  MLFLOW_FLASK_SERVER_SECRET_KEY: "MWExN2NmMWRlOGJhZjk0YWMxZGIzYzA5MDc0OWRhNGU="

--- a/charts/mlflow/rendered-without-secret.yaml
+++ b/charts/mlflow/rendered-without-secret.yaml
@@ -1,0 +1,222 @@
+---
+# Source: mlflow/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-release-mlflow
+  labels:
+    helm.sh/chart: mlflow-1.4.1
+    app: mlflow
+    app.kubernetes.io/name: mlflow
+    app.kubernetes.io/instance: test-release
+    version: "3.2.0"
+    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: mlflow/templates/auth_secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-release-mlflow-auth-config-secret
+  labels:
+    app: mlflow
+    chart: mlflow-1.4.1
+    release: test-release
+    heritage: Helm
+type: Opaque
+stringData:
+  basic_auth.ini: |-
+    [mlflow]
+    default_permission = READ
+    database_uri = postgresql://mlflowauth:A4m1nPa33w0rd!@postgresql--auth-instance1.abcdef1234.eu-central-1.rds.amazonaws.com:5432/auth
+    admin_username = admin
+    admin_password = S3cr3+
+    authorization_function = mlflow.server.auth:authenticate_request_basic_auth
+---
+# Source: mlflow/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-release-mlflow-env-secret
+  labels:
+    app: mlflow
+    chart: mlflow-1.4.1
+    release: test-release
+    heritage: Helm
+type: Opaque
+data:
+---
+# Source: mlflow/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-release-mlflow-env-configmap
+  labels:
+    app: mlflow
+    chart: mlflow-1.4.1
+    release: test-release
+    heritage: Helm
+data:
+  PGHOST: postgresql-instance1.cg034hpkmmjt.eu-central-1.rds.amazonaws.com
+  PGPORT: "5432"
+  PGDATABASE: mlflow
+  MLFLOW_CONFIGURE_LOGGING: "true"
+  MLFLOW_LOGGING_LEVEL: "INFO"
+---
+# Source: mlflow/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-release-mlflow
+  labels:
+    helm.sh/chart: mlflow-1.4.1
+    app: mlflow
+    app.kubernetes.io/name: mlflow
+    app.kubernetes.io/instance: test-release
+    version: "3.2.0"
+    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5000
+      targetPort: 5000
+      protocol: TCP
+      name: http
+  selector:
+    app: mlflow
+    app.kubernetes.io/name: mlflow
+    app.kubernetes.io/instance: test-release
+---
+# Source: mlflow/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-release-mlflow
+  labels:
+    helm.sh/chart: mlflow-1.4.1
+    app: mlflow
+    app.kubernetes.io/name: mlflow
+    app.kubernetes.io/instance: test-release
+    version: "3.2.0"
+    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  selector:
+    matchLabels:
+      app: mlflow
+      app.kubernetes.io/name: mlflow
+      app.kubernetes.io/instance: test-release
+  template:
+    metadata:
+      annotations:
+        checksum/config: c475bbc1a9606d12423b8e9382dfd4334d84bdf74c0638eb2fbe5e62e25dbb7f
+      labels:
+        app: mlflow
+        app.kubernetes.io/name: mlflow
+        app.kubernetes.io/instance: test-release
+    spec:
+      serviceAccountName: test-release-mlflow
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: mlflow
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: false
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+          image: "burakince/mlflow:3.2.0"
+          imagePullPolicy: IfNotPresent
+          command: ["mlflow"]
+          args:
+            - server
+            - --host=0.0.0.0
+            - --port=5000
+            - --backend-store-uri=postgresql://
+            - --default-artifact-root=./mlruns
+            - --app-name=basic-auth
+            - --gunicorn-opts='--log-level=info'
+          ports:
+            - name: http
+              containerPort: 5000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            failureThreshold: 5
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            failureThreshold: 5
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 3
+          resources:
+            {}
+          env:
+            - name: MLFLOW_VERSION
+              value: "3.2.0"
+            - name: MLFLOW_AUTH_CONFIG_PATH
+              value: /etc/mlflow/auth/basic_auth.ini
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-database-secret
+                  key: password
+            - name: PGUSER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-database-secret
+                  key: username
+          envFrom:
+            - configMapRef:
+                name: test-release-mlflow-env-configmap
+            - secretRef:
+                name: test-release-mlflow-env-secret
+            - secretRef:
+                name: test-release-mlflow-flask-server-secret-key
+          volumeMounts:
+            - name: auth-config-secret
+              mountPath: "/etc/mlflow/auth"
+              readOnly: true
+      volumes:
+        - name: auth-config-secret
+          secret:
+            secretName: test-release-mlflow-auth-config-secret
+---
+# Source: mlflow/templates/flask_secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-release-mlflow-flask-server-secret-key
+  namespace: default
+  labels:
+    app: mlflow
+    chart: mlflow-1.4.1
+    release: test-release
+    heritage: Helm
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+type: Opaque
+data:
+  MLFLOW_FLASK_SERVER_SECRET_KEY: "OGUzNGMzMzhjOGVhMTk3YjIxZjEzZTBkZTY2ZDYxNGE="

--- a/charts/mlflow/templates/auth_secret.yaml
+++ b/charts/mlflow/templates/auth_secret.yaml
@@ -19,12 +19,16 @@ stringData:
     {{- if .Values.auth.postgres.driver }}
       {{- $dbConnectionDriver = printf "+%s" .Values.auth.postgres.driver }}
     {{- end }}
-    {{- $pgUser := required "auth.postgres.user must be specified" .Values.auth.postgres.user }}
-    {{- $pgPassword := required "auth.postgres.password must be specified" .Values.auth.postgres.password }}
     {{- $pgHost := required "auth.postgres.host must be specified" .Values.auth.postgres.host }}
     {{- $pgPort := required "auth.postgres.port must be specified" .Values.auth.postgres.port | toString }}
     {{- $pgDatabase := required "auth.postgres.database must be specified" .Values.auth.postgres.database }}
-    {{- $databaseUri = printf "postgresql%s://%s:%s@%s:%s/%s" $dbConnectionDriver $pgUser $pgPassword $pgHost $pgPort $pgDatabase }}
+    {{- if .Values.auth.existingDatabaseSecret.name }}
+      {{- $databaseUri = printf "postgresql%s://$(AUTH_PGUSER):$(AUTH_PGPASSWORD)@%s:%s/%s" $dbConnectionDriver $pgHost $pgPort $pgDatabase }}
+    {{- else }}
+      {{- $pgUser := required "auth.postgres.user must be specified" .Values.auth.postgres.user }}
+      {{- $pgPassword := required "auth.postgres.password must be specified" .Values.auth.postgres.password }}
+      {{- $databaseUri = printf "postgresql%s://%s:%s@%s:%s/%s" $dbConnectionDriver $pgUser $pgPassword $pgHost $pgPort $pgDatabase }}
+    {{- end }}
   {{- else }}
     {{- $sqliteFile := .Values.auth.sqliteFile }}
     {{- if .Values.auth.sqliteFullPath }}

--- a/charts/mlflow/templates/auth_secret.yaml
+++ b/charts/mlflow/templates/auth_secret.yaml
@@ -23,7 +23,7 @@ stringData:
     {{- $pgPort := required "auth.postgres.port must be specified" .Values.auth.postgres.port | toString }}
     {{- $pgDatabase := required "auth.postgres.database must be specified" .Values.auth.postgres.database }}
     {{- if .Values.auth.existingDatabaseSecret.name }}
-      {{- $databaseUri = printf "postgresql%s://$(AUTH_PGUSER):$(AUTH_PGPASSWORD)@%s:%s/%s" $dbConnectionDriver $pgHost $pgPort $pgDatabase }}
+      {{- $databaseUri = printf "postgresql%s://auth_user:auth_password@%s:%s/%s" $dbConnectionDriver $pgHost $pgPort $pgDatabase }}
     {{- else }}
       {{- $pgUser := required "auth.postgres.user must be specified" .Values.auth.postgres.user }}
       {{- $pgPassword := required "auth.postgres.password must be specified" .Values.auth.postgres.password }}

--- a/charts/mlflow/templates/deployment.yaml
+++ b/charts/mlflow/templates/deployment.yaml
@@ -60,9 +60,36 @@ spec:
       serviceAccountName: {{ include "mlflow.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-    {{- if or (and (or .Values.backendStore.postgres.enabled .Values.backendStore.mysql.enabled .Values.postgresql.enabled .Values.mysql.enabled) (or .Values.backendStore.databaseConnectionCheck .Values.backendStore.databaseMigration) ) .Values.initContainers }}
+    {{- if or (and (or .Values.backendStore.postgres.enabled .Values.backendStore.mysql.enabled .Values.postgresql.enabled .Values.mysql.enabled) (or .Values.backendStore.databaseConnectionCheck .Values.backendStore.databaseMigration) ) .Values.initContainers (and .Values.auth.enabled .Values.auth.postgres.enabled .Values.auth.existingDatabaseSecret.name) }}
       initContainers:
     {{- end }}
+      {{- if and .Values.auth.enabled .Values.auth.postgres.enabled .Values.auth.existingDatabaseSecret.name }}
+        - name: auth-config-substitution
+          image: "busybox:1.32"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              sed "s/auth_user/$AUTH_PGUSER/g; s/auth_password/$AUTH_PGPASSWORD/g" /etc/mlflow/auth-template/basic_auth.ini > /etc/mlflow/auth/basic_auth.ini
+          env:
+            - name: AUTH_PGUSER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.existingDatabaseSecret.name }}
+                  key: {{ .Values.auth.existingDatabaseSecret.usernameKey }}
+            - name: AUTH_PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.existingDatabaseSecret.name }}
+                  key: {{ .Values.auth.existingDatabaseSecret.passwordKey }}
+          volumeMounts:
+            - name: auth-config-secret
+              mountPath: /etc/mlflow/auth-template
+              readOnly: true
+            - name: auth-config-volume
+              mountPath: /etc/mlflow/auth
+      {{- end }}
       {{- if and (or .Values.backendStore.postgres.enabled .Values.backendStore.mysql.enabled .Values.postgresql.enabled .Values.mysql.enabled) .Values.backendStore.databaseConnectionCheck }}
         - name: dbchecker
           image: "busybox:1.32"
@@ -338,18 +365,6 @@ spec:
                   key: {{ .Values.backendStore.existingDatabaseSecret.usernameKey }}
             {{- end }}
           {{- end }}
-          {{- if and .Values.auth.enabled .Values.auth.postgres.enabled .Values.auth.existingDatabaseSecret.name }}
-            - name: AUTH_PGUSER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.auth.existingDatabaseSecret.name }}
-                  key: {{ .Values.auth.existingDatabaseSecret.usernameKey }}
-            - name: AUTH_PGPASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.auth.existingDatabaseSecret.name }}
-                  key: {{ .Values.auth.existingDatabaseSecret.passwordKey }}
-          {{- end }}
           {{- if and .Values.artifactRoot.s3.enabled .Values.artifactRoot.s3.existingSecret.name }}
             {{- if .Values.artifactRoot.s3.existingSecret.keyOfAccessKeyId }}
             - name: AWS_ACCESS_KEY_ID
@@ -384,9 +399,15 @@ spec:
           {{- if or .Values.extraVolumeMounts .Values.auth.enabled .Values.ldapAuth.enabled }}
           volumeMounts:
             {{- if .Values.auth.enabled }}
+              {{- if and .Values.auth.postgres.enabled .Values.auth.existingDatabaseSecret.name }}
+            - name: auth-config-volume
+              mountPath: {{ .Values.auth.configPath | trimSuffix "/" | quote }}
+              readOnly: true
+              {{- else }}
             - name: auth-config-secret
               mountPath: {{ .Values.auth.configPath | trimSuffix "/" | quote }}
               readOnly: true
+              {{- end }}
             {{- else if .Values.ldapAuth.enabled }}
             - name: auth-config-secret
               mountPath: "/etc/mlflow/auth"
@@ -434,6 +455,10 @@ spec:
         - name: auth-config-secret
           secret:
             secretName: {{ template "mlflow.fullname" . }}-auth-config-secret
+        {{- if and .Values.auth.enabled .Values.auth.postgres.enabled .Values.auth.existingDatabaseSecret.name }}
+        - name: auth-config-volume
+          emptyDir: {}
+        {{- end }}
           {{- if or .Values.ldapAuth.encodedTrustedCACertificate .Values.ldapAuth.externalSecretForTrustedCACertificate }}
         - name: trusted-ca-cert-secret
           secret:

--- a/charts/mlflow/templates/deployment.yaml
+++ b/charts/mlflow/templates/deployment.yaml
@@ -338,6 +338,18 @@ spec:
                   key: {{ .Values.backendStore.existingDatabaseSecret.usernameKey }}
             {{- end }}
           {{- end }}
+          {{- if and .Values.auth.enabled .Values.auth.postgres.enabled .Values.auth.existingDatabaseSecret.name }}
+            - name: AUTH_PGUSER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.existingDatabaseSecret.name }}
+                  key: {{ .Values.auth.existingDatabaseSecret.usernameKey }}
+            - name: AUTH_PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.existingDatabaseSecret.name }}
+                  key: {{ .Values.auth.existingDatabaseSecret.passwordKey }}
+          {{- end }}
           {{- if and .Values.artifactRoot.s3.enabled .Values.artifactRoot.s3.existingSecret.name }}
             {{- if .Values.artifactRoot.s3.existingSecret.keyOfAccessKeyId }}
             - name: AWS_ACCESS_KEY_ID

--- a/charts/mlflow/test-values-with-secret.yaml
+++ b/charts/mlflow/test-values-with-secret.yaml
@@ -1,0 +1,31 @@
+# Test values file for MLFlow with auth.existingDatabaseSecret
+auth:
+  enabled: true
+  adminUsername: "admin"
+  adminPassword: "S3cr3+"
+  postgres:
+    enabled: true
+    host: "postgresql--auth-instance1.abcdef1234.eu-central-1.rds.amazonaws.com"
+    port: 5432
+    database: "auth"
+    # Note: user and password are not set here since we're using existingDatabaseSecret
+    user: ""
+    password: ""
+  existingDatabaseSecret:
+    name: "postgres-database-secret-auth"
+    usernameKey: "username"
+    passwordKey: "password"
+
+# Also configure backend store for completeness
+backendStore:
+  postgres:
+    enabled: true
+    host: "postgresql-instance1.cg034hpkmmjt.eu-central-1.rds.amazonaws.com"
+    port: 5432
+    database: "mlflow"
+    user: ""
+    password: ""
+  existingDatabaseSecret:
+    name: "postgres-database-secret"
+    usernameKey: "username"
+    passwordKey: "password"

--- a/charts/mlflow/test-values-without-secret.yaml
+++ b/charts/mlflow/test-values-without-secret.yaml
@@ -1,0 +1,28 @@
+# Test values file for MLFlow WITHOUT auth.existingDatabaseSecret (old insecure way)
+auth:
+  enabled: true
+  adminUsername: "admin"
+  adminPassword: "S3cr3+"
+  postgres:
+    enabled: true
+    host: "postgresql--auth-instance1.abcdef1234.eu-central-1.rds.amazonaws.com"
+    port: 5432
+    database: "auth"
+    # Hardcoded credentials (insecure)
+    user: "mlflowauth"
+    password: "A4m1nPa33w0rd!"
+
+# Also configure backend store for comparison
+backendStore:
+  postgres:
+    enabled: true
+    host: "postgresql-instance1.cg034hpkmmjt.eu-central-1.rds.amazonaws.com"
+    port: 5432
+    database: "mlflow"
+    # Using existing secret for backend (secure)
+    user: ""
+    password: ""
+  existingDatabaseSecret:
+    name: "postgres-database-secret"
+    usernameKey: "username"
+    passwordKey: "password"

--- a/charts/mlflow/values.schema.json
+++ b/charts/mlflow/values.schema.json
@@ -1493,6 +1493,35 @@
           ],
           "title": "postgres",
           "type": "object"
+        },
+        "existingDatabaseSecret": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "default": "",
+              "description": "The name of the existing database secret.",
+              "required": [],
+              "title": "name",
+              "type": "string"
+            },
+            "usernameKey": {
+              "default": "username",
+              "description": "The key of the username in the existing database secret.",
+              "required": [],
+              "title": "usernameKey",
+              "type": "string"
+            },
+            "passwordKey": {
+              "default": "password",
+              "description": "The key of the password in the existing database secret.",
+              "required": [],
+              "title": "passwordKey",
+              "type": "string"
+            }
+          },
+          "required": ["name", "usernameKey", "passwordKey"],
+          "title": "existingDatabaseSecret",
+          "type": "object"
         }
       },
       "required": [
@@ -1506,7 +1535,8 @@
         "sqliteFullPath",
         "configPath",
         "configFile",
-        "postgres"
+        "postgres",
+        "existingDatabaseSecret"
       ],
       "title": "auth",
       "type": "object"

--- a/charts/mlflow/values.yaml
+++ b/charts/mlflow/values.yaml
@@ -283,6 +283,15 @@ auth:
     # -- postgres database connection driver. e.g.: "psycopg2"
     driver: ""
 
+  # -- Specifies if you want to use an existing database secret for auth.
+  existingDatabaseSecret:
+    # -- The name of the existing database secret.
+    name: ""
+    # -- The key of the username in the existing database secret.
+    usernameKey: "username"
+    # -- The key of the password in the existing database secret.
+    passwordKey: "password"
+
 # -- Basic Authentication with LDAP backend
 ldapAuth:
   # -- Specifies if you want to enable mlflow LDAP authentication. auth and ldapAuth can't be enabled at same time.


### PR DESCRIPTION
Fixes issue #200

### Overview

This PR adds support for using existing Kubernetes secrets to configure the MLflow authentication database connection, enabling users to securely manage database credentials externally rather than embedding them directly in Helm values.

Users can now configure MLflow authentication to use an external PostgreSQL database with credentials stored in a separate Kubernetes secret:

```yaml
  auth:
    enabled: true
    postgres:
      enabled: true
      host: "my-postgres-host"
      port: 5432
      database: "auth_db"
    existingDatabaseSecret:
      name: "my-auth-db-secret"
      usernameKey: "username"
      passwordKey: "password"
```

### Implementation

The solution uses an init container approach to securely inject database credentials:

1. Template preprocessing: Auth configuration template uses placeholders for credentials
2. Init container: Reads actual credentials from the Kubernetes secret and substitutes them into the auth configuration
3. Credential isolation: Auth database credentials are kept separate from backend store credentials, preventing conflicts