### PR TITLE
[pypiserver] Update pypiserver chart to v2.4.0

### DIFF
--- a/charts/pypiserver/Chart.yaml
+++ b/charts/pypiserver/Chart.yaml
@@ -2,7 +2,6 @@ apiVersion: v2
 name: pypiserver
 description: A Helm chart for PyPI Server
 icon: https://raw.githubusercontent.com/pypiserver/pypiserver/refs/heads/main/docs/__resources__/pypiserver_logo.png
-
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives
@@ -12,37 +11,29 @@ icon: https://raw.githubusercontent.com/pypiserver/pypiserver/refs/heads/main/do
 # a dependency of application charts to inject those utilities and functions into the rendering
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.7
-
+version: 0.1.8
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v2.3.2"
-
+appVersion: "v2.4.0"
 kubeVersion: ">=1.13.0-0"
-
 home: https://github.com/pypiserver/pypiserver
-
 maintainers:
   - name: burakince
     email: burak.ince@linux.org.tr
     url: https://www.burakince.com
-
 sources:
   - https://github.com/community-charts/helm-charts
   - https://github.com/pypiserver/pypiserver
-
 keywords:
   - pypi
   - self-hosted
   - package-management
   - pypi-server
-
 annotations:
   artifacthub.io/links: |
     - name: Chart Source
@@ -52,11 +43,15 @@ annotations:
     - name: Upstream Project
       url: https://github.com/pypiserver/pypiserver
   artifacthub.io/containsSecurityUpdates: "false"
-  artifacthub.io/changes: |
-    - Fix wrong schema for ingress tls
+  artifacthub.io/changes: |-
+    - kind: changed
+      description: Update pypiserver/pypiserver image version to v2.4.0
+      links:
+        - name: Upstream Project
+          url: https://hub.docker.com/r/pypiserver/pypiserver
   artifacthub.io/images: |
     - name: pypiserver
-      image: pypiserver/pypiserver:v2.3.2
+      image: pypiserver/pypiserver:v2.4.0
       platforms:
         - linux/amd64
         - linux/arm64
@@ -69,5 +64,4 @@ annotations:
   artifacthub.io/signKey: |
     fingerprint: 939B1A0ED8AAA8E722ACCDB3B6A012EE8A76426A
     url: https://keybase.io/communitycharts/pgp_keys.asc
-
 dependencies: []

--- a/charts/pypiserver/README.md
+++ b/charts/pypiserver/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for PyPI Server
 
-![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.3.2](https://img.shields.io/badge/AppVersion-v2.3.2-informational?style=flat-square)
+![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.4.0](https://img.shields.io/badge/AppVersion-v2.4.0-informational?style=flat-square)
 
 ## Official Documentation
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the pypiserver chart to use the latest image version v2.4.0 from pypiserver/pypiserver. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated