### PR TITLE
[mlflow] Update mlflow chart to 3.3.1

### DIFF
--- a/charts/mlflow/Chart.lock
+++ b/charts/mlflow/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.7.21
+  version: 16.7.26
 - name: mysql
   repository: https://charts.bitnami.com/bitnami
-  version: 14.0.0
-digest: sha256:24933057cf776b9de9577999074bb81526d2c9ebcb9901aaa905a458a7063e79
-generated: "2025-07-23T21:08:32.097027039Z"
+  version: 14.0.3
+digest: sha256:a344bf1334bad5007b47c17436a2ae9454e5b459bd74ee000a60969685d661df
+generated: "2025-08-25T22:01:27.315668462Z"

--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.0
+version: 1.6.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.2.0"
+appVersion: "3.3.1"
 kubeVersion: ">=1.16.0-0"
 home: https://mlflow.org
 maintainers:
@@ -52,20 +52,23 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Auth and LDAP Auth external secret load functionality replaced with init containers
+      description: Update burakince/mlflow image version to 3.3.1
       links:
-        - name: GitHub Issue
-          url: https://github.com/community-charts/helm-charts/issues/200
-        - name: GitHub Issue
-          url: https://github.com/community-charts/helm-charts/issues/217
-    - kind: fixed
-      description: Empty Security Context and Pod Security Context definitions will remove security context definitions
+        - name: Upstream Project
+          url: https://hub.docker.com/r/burakince/mlflow
+    - kind: changed
+      description: Update dependency postgresql from 16.7.21 to 16.7.26
       links:
-        - name: GitHub Issue
-          url: https://github.com/community-charts/helm-charts/issues/219
+        - name: ArtifactHub
+          url: https://artifacthub.io/packages/helm/bitnami/postgresql
+    - kind: changed
+      description: Update dependency mysql from 14.0.0 to 14.0.3
+      links:
+        - name: ArtifactHub
+          url: https://artifacthub.io/packages/helm/bitnami/mysql
   artifacthub.io/images: |
     - name: mlflow
-      image: burakince/mlflow:3.2.0
+      image: burakince/mlflow:3.3.1
   artifacthub.io/license: MIT
   artifacthub.io/maintainers: |
     - name: burakince
@@ -98,10 +101,10 @@ annotations:
     url: https://keybase.io/communitycharts/pgp_keys.asc
 dependencies:
   - name: postgresql
-    version: 16.7.21
+    version: 16.7.26
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: mysql
-    version: 14.0.0
+    version: 14.0.3
     repository: https://charts.bitnami.com/bitnami
     condition: mysql.enabled

--- a/charts/mlflow/README.md
+++ b/charts/mlflow/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for Mlflow open source platform for the machine learning lifecycle
 
-![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.2.0](https://img.shields.io/badge/AppVersion-3.2.0-informational?style=flat-square)
+![Version: 1.6.1](https://img.shields.io/badge/Version-1.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.3.1](https://img.shields.io/badge/AppVersion-3.3.1-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -586,8 +586,8 @@ Kubernetes: `>=1.16.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | mysql | 14.0.0 |
-| https://charts.bitnami.com/bitnami | postgresql | 16.7.21 |
+| https://charts.bitnami.com/bitnami | mysql | 14.0.3 |
+| https://charts.bitnami.com/bitnami | postgresql | 16.7.26 |
 
 ## Uninstall Helm Chart
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the mlflow chart to use the latest image version 3.3.1 from burakince/mlflow. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated