### PR TITLE
[n8n] Update n8n chart to 1.109.1

### DIFF
--- a/charts/n8n/Chart.lock
+++ b/charts/n8n/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 22.0.6
+  version: 22.0.7
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 16.7.27
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:4b5cf380183110cddbec897efbd3c647b07959b3ccaf811f8d6ce75640f1161e
-generated: "2025-08-27T16:04:19.319196373Z"
+digest: sha256:39c9a8b6a4583d109d9406f7a537bc7f5404adf9a8001789508d0bf600e013ad
+generated: "2025-09-02T02:55:56.623004167Z"

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.15.2
+version: 1.15.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.108.2"
+appVersion: "1.109.1"
 kubeVersion: ">=1.23.0-0"
 home: https://n8n.io
 maintainers:
@@ -51,23 +51,18 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update n8nio/n8n image version to 1.108.2
+      description: Update n8nio/n8n image version to 1.109.1
       links:
         - name: Upstream Project
           url: https://github.com/n8n-io/n8n
     - kind: changed
-      description: Update dependency redis from 22.0.4 to 22.0.6
+      description: Update dependency redis from 22.0.6 to 22.0.7
       links:
         - name: ArtifactHub
           url: https://artifacthub.io/packages/helm/bitnami/redis
-    - kind: changed
-      description: Update dependency postgresql from 16.7.26 to 16.7.27
-      links:
-        - name: ArtifactHub
-          url: https://artifacthub.io/packages/helm/bitnami/postgresql
   artifacthub.io/images: |
     - name: n8n
-      image: n8nio/n8n:1.108.2
+      image: n8nio/n8n:1.109.1
       platforms:
         - linux/amd64
         - linux/arm64
@@ -119,7 +114,7 @@ annotations:
     url: https://keybase.io/communitycharts/pgp_keys.asc
 dependencies:
   - name: redis
-    version: 22.0.6
+    version: 22.0.7
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: postgresql

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.15.2](https://img.shields.io/badge/Version-1.15.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.108.2](https://img.shields.io/badge/AppVersion-1.108.2-informational?style=flat-square)
+![Version: 1.15.3](https://img.shields.io/badge/Version-1.15.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.109.1](https://img.shields.io/badge/AppVersion-1.109.1-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -892,7 +892,7 @@ Kubernetes: `>=1.23.0-0`
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.bitnami.com/bitnami | postgresql | 16.7.27 |
-| https://charts.bitnami.com/bitnami | redis | 22.0.6 |
+| https://charts.bitnami.com/bitnami | redis | 22.0.7 |
 | https://charts.min.io/ | minio | 5.4.0 |
 
 ## Uninstall Helm Chart


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the n8n chart to use the latest image version 1.109.1 from n8nio/n8n. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated