### PR TITLE
[cloudflared] Remove NET_RAW capability from container securityContext

### DIFF
--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.3
+version: 2.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -52,11 +52,10 @@ annotations:
       url: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
+    - kind: removed
+      description: NET_RAW removed from default security context capabilities
     - kind: changed
-      description: Update cloudflare/cloudflared image version to 2025.9.0
-      links:
-        - name: Upstream Project
-          url: https://hub.docker.com/r/cloudflare/cloudflared
+      description: Always set TUNNEL_ORIGIN_CERT environment variable with correct certificate file location
   artifacthub.io/images: |
     - name: cloudflared
       image: cloudflare/cloudflared:2025.9.0

--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.2
+version: 2.1.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/cloudflared/README.md
+++ b/charts/cloudflared/README.md
@@ -172,7 +172,7 @@ helm upgrade [RELEASE_NAME] community-charts/cloudflared
 | replica.allNodes | bool | `true` | This will use DaemonSet to deploy cloudflared to all nodes |
 | replica.count | int | `1` | If previous flag disabled, this will use Deployment to deploy cloudflared only number of following count |
 | resources | object | `{}` | This block is for setting up the resource management for the pod more information can be found here: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
-| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"add":["NET_RAW"],"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532}` | This is for setting Security Context to a Container. For more information checkout: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"add":[],"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532}` | This is for setting Security Context to a Container. For more information checkout: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
 | serviceAccount | object | `{"annotations":{},"automount":true,"create":true,"name":""}` | This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/ |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials? |

--- a/charts/cloudflared/README.md
+++ b/charts/cloudflared/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for cloudflare tunnel
 
-![Version: 2.1.3](https://img.shields.io/badge/Version-2.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2025.9.0](https://img.shields.io/badge/AppVersion-2025.9.0-informational?style=flat-square)
+![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2025.9.0](https://img.shields.io/badge/AppVersion-2025.9.0-informational?style=flat-square)
 
 ## Official Documentation
 

--- a/charts/cloudflared/templates/deployment.yaml
+++ b/charts/cloudflared/templates/deployment.yaml
@@ -53,11 +53,9 @@ spec:
             - name: active-con-stat
               containerPort: 2000
               protocol: TCP
-        {{- if and .Values.tunnelSecrets.existingPemFileSecret.name (ne .Values.tunnelSecrets.existingPemFileSecret.key "cert.pem") }}
           env:
             - name: TUNNEL_ORIGIN_CERT
-              value: {{ printf "/etc/cloudflared/creds/%s" .Values.tunnelSecrets.existingPemFileSecret.key }}
-        {{- end }}
+              value: {{ printf "/etc/cloudflared/creds/%s" (default "cert.pem" .Values.tunnelSecrets.existingPemFileSecret.key) | quote }}
           livenessProbe:
             httpGet:
               path: /ready

--- a/charts/cloudflared/unittests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/cloudflared/unittests/__snapshot__/deployment_test.yaml.snap
@@ -1,0 +1,106 @@
+should match snapshot of default values:
+  1: |
+    apiVersion: v1
+    data:
+      config.yaml: "\ntunnel: unittest\ncredentials-file: /etc/cloudflared/creds/credentials.json\noriginRequest:\n  connectTimeout: 30s\n\ningress: \n  - hostname: example.com\n    service: http://traefik.kube-system.svc.cluster.local:80\n  - service: http_status:404\n\nmetrics: 0.0.0.0:2000\nmetrics-update-freq: 5s\n\nautoupdate-freq: 24h\nno-autoupdate: true\n\ngrace-period: 30s\n\nretries: 5\n\n# auto, http2, h2mux, quic\nprotocol: auto\n\n# info, warn, error, fatal, panic\nloglevel: info\ntransport-loglevel: warn\n"
+    kind: ConfigMap
+    metadata:
+      name: cloudflared
+  2: |
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        app: cloudflared
+        app.kubernetes.io/instance: cloudflared
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: cloudflared
+        app.kubernetes.io/version: 1.0.0
+        helm.sh/chart: cloudflared-1.0.0
+      name: cloudflared
+    spec:
+      selector:
+        matchLabels:
+          app: cloudflared
+          app.kubernetes.io/instance: cloudflared
+          app.kubernetes.io/name: cloudflared
+      template:
+        metadata:
+          annotations:
+            checksum/config: 6914168e330d7d7832f59de17cb31e7f60be876dd10f1e52413ad6057a1f8076
+          labels:
+            app: cloudflared
+            app.kubernetes.io/instance: cloudflared
+            app.kubernetes.io/name: cloudflared
+        spec:
+          containers:
+            - args:
+                - tunnel
+                - --config
+                - /etc/cloudflared/config/config.yaml
+                - run
+              env:
+                - name: TUNNEL_ORIGIN_CERT
+                  value: /etc/cloudflared/creds/cert.pem
+              image: cloudflare/cloudflared:1.0.0
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 1
+                httpGet:
+                  path: /ready
+                  port: 2000
+                initialDelaySeconds: 10
+                periodSeconds: 10
+              name: cloudflared
+              ports:
+                - containerPort: 2000
+                  name: active-con-stat
+                  protocol: TCP
+              resources: {}
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  add: []
+                  drop:
+                    - ALL
+                privileged: false
+                readOnlyRootFilesystem: true
+                runAsGroup: 65532
+                runAsNonRoot: true
+                runAsUser: 65532
+              volumeMounts:
+                - mountPath: /etc/cloudflared/config
+                  name: config
+                  readOnly: true
+                - mountPath: /etc/cloudflared/creds
+                  name: creds
+                  readOnly: true
+          nodeSelector:
+            kubernetes.io/os: linux
+          securityContext:
+            fsGroup: 65532
+            fsGroupChangePolicy: OnRootMismatch
+            sysctls:
+              - name: net.ipv4.ping_group_range
+                value: 0 2147483647
+          serviceAccountName: cloudflared
+          terminationGracePeriodSeconds: 30
+          tolerations:
+            - effect: NoSchedule
+              operator: Exists
+          volumes:
+            - name: creds
+              projected:
+                sources:
+                  - secret:
+                      name: tunnel-credentials
+            - configMap:
+                items:
+                  - key: config.yaml
+                    path: config.yaml
+                name: cloudflared
+              name: config
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 1
+        type: RollingUpdate

--- a/charts/cloudflared/unittests/deployment_test.yaml
+++ b/charts/cloudflared/unittests/deployment_test.yaml
@@ -94,7 +94,7 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.volumes
-          content: 
+          content:
             name: creds
             projected:
               sources:
@@ -113,7 +113,7 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.volumes
-          content: 
+          content:
             name: creds
             projected:
               sources:
@@ -134,7 +134,7 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.volumes
-          content: 
+          content:
             name: creds
             projected:
               sources:
@@ -156,7 +156,7 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.volumes
-          content: 
+          content:
             name: creds
             projected:
               sources:
@@ -166,7 +166,7 @@ tests:
                     name: my-config-json-file-secret
         template: deployment.yaml
 
-  - it: should set TUNNEL_ORIGIN_CERT environment variable when existingPemFileSecret name set and key is different than cert.pem
+  - it: should set TUNNEL_ORIGIN_CERT environment variable
     set:
       tunnelConfig:
         name: unittest
@@ -183,3 +183,16 @@ tests:
             name: TUNNEL_ORIGIN_CERT
             value: /etc/cloudflared/creds/custom.pem
         template: deployment.yaml
+
+  - it: should match snapshot of default values
+    set:
+      tunnelConfig:
+        name: unittest
+    release:
+      name: cloudflared
+      namespace: cloudflare
+    chart:
+      version: 1.0.0
+      appVersion: 1.0.0
+    asserts:
+      - matchSnapshot: { }

--- a/charts/cloudflared/values.yaml
+++ b/charts/cloudflared/values.yaml
@@ -63,8 +63,7 @@ securityContext:
   capabilities:
     drop:
       - ALL
-    add:
-      - NET_RAW
+    add: []
   readOnlyRootFilesystem: true
   runAsNonRoot: true
   privileged: false


### PR DESCRIPTION
Removes the `NET_RAW` capability from the default container `securityContext` to comply with PodSecurity "baseline:latest" policies.

<!--
Thank you for contributing to community-charts/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in community-charts/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated
