### PR TITLE
[n8n ] Fix default license serverUrl

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.15.11
+version: 1.15.12
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -995,14 +995,14 @@ helm upgrade [RELEASE_NAME] community-charts/n8n
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
 | ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":[{"host":"n8n.local","paths":[{"path":"/","pathType":"Prefix"}]}],"tls":[]}` | This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/ |
-| license | object | `{"activationKey":"","autoNenew":{"enabled":true,"offsetInHours":72},"enabled":false,"existingActivationKeySecret":"","serverUrl":"http://license.n8n.io/v1","tenantId":1}` | n8n enterprise license configurations |
+| license | object | `{"activationKey":"","autoNenew":{"enabled":true,"offsetInHours":72},"enabled":false,"existingActivationKeySecret":"","serverUrl":"https://license.n8n.io/v1","tenantId":1}` | n8n enterprise license configurations |
 | license.activationKey | string | `""` | Activation key to initialize license. Not applicable if the n8n instance was already activated. For more information please refer to the following link: https://docs.n8n.io/enterprise-key/ |
 | license.autoNenew | object | `{"enabled":true,"offsetInHours":72}` | The auto new license configuration |
 | license.autoNenew.enabled | bool | `true` | Enables (true) or disables (false) autorenewal for licenses. If disabled, you need to manually renew the license every 10 days by navigating to Settings > Usage and plan, and pressing F5. Failure to renew the license will disable Enterprise features. |
 | license.autoNenew.offsetInHours | int | `72` | Time in hours before expiry a license should automatically renew. |
 | license.enabled | bool | `false` | Whether to enable the enterprise license |
 | license.existingActivationKeySecret | string | `""` | The name of an existing secret with license activation key. The secret must contain a key with the name N8N_LICENSE_ACTIVATION_KEY. |
-| license.serverUrl | string | `"http://license.n8n.io/v1"` | Server URL to retrieve license. |
+| license.serverUrl | string | `"https://license.n8n.io/v1"` | Server URL to retrieve license. |
 | license.tenantId | int | `1` | Tenant ID associated with the license. Only set this variable if explicitly instructed by n8n. |
 | livenessProbe | object | `{}` | DEPRECATED: Use main, worker, and webhook blocks livenessProbe field instead. This field will be removed in a future release. |
 | log | object | `{"file":{"location":"logs/n8n.log","maxcount":"100","maxsize":16},"level":"info","output":["console"],"scopes":[]}` | n8n log configurations |

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -294,7 +294,7 @@ license:
     # -- Time in hours before expiry a license should automatically renew.
     offsetInHours: 72
   # -- Server URL to retrieve license.
-  serverUrl: "http://license.n8n.io/v1"
+  serverUrl: "https://license.n8n.io/v1"
   # -- Tenant ID associated with the license. Only set this variable if explicitly instructed by n8n.
   tenantId: 1
 


### PR DESCRIPTION
#### What this PR does / why we need it:

According to official documentation license serverUrl shoud be with HTTPS, and with HTTP it's not working. I had such errors with HTTP serverUrl:

```
[license SDK] license activation failed: Connection Error: Unexpected non-whitespace character after JSON at position 4 (line 1 column 5)
Failed to activate license: Connection Error: Unexpected non-whitespace character after JSON at position 4 (line 1 column 5)
```

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated
