### PR TITLE
[n8n] Update n8n chart to 1.116.2

### DIFF
--- a/charts/n8n/Chart.lock
+++ b/charts/n8n/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 23.1.3
+  version: 23.2.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 18.0.15
+  version: 18.1.1
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:24a2d405d712e12f037fcc4772bf19265471f97e8ef1e76ede0ae530d1a0c9d3
-generated: "2025-10-15T02:30:36.26009137Z"
+digest: sha256:6de80b62829e40799917ff03a9a0a8e16f9dd9842a8402074da7f88133e701ff
+generated: "2025-10-22T02:37:36.376308153Z"

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.15.16
+version: 1.15.17
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.115.3"
+appVersion: "1.116.2"
 kubeVersion: ">=1.23.0-0"
 home: https://n8n.io
 maintainers:
@@ -51,18 +51,23 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update n8nio/n8n image version to 1.115.3
+      description: Update n8nio/n8n image version to 1.116.2
       links:
         - name: Upstream Project
           url: https://github.com/n8n-io/n8n
     - kind: changed
-      description: Update dependency postgresql from 18.0.14 to 18.0.15
+      description: Update dependency redis from 23.1.3 to 23.2.1
+      links:
+        - name: ArtifactHub
+          url: https://artifacthub.io/packages/helm/bitnami/redis
+    - kind: changed
+      description: Update dependency postgresql from 18.0.15 to 18.1.1
       links:
         - name: ArtifactHub
           url: https://artifacthub.io/packages/helm/bitnami/postgresql
   artifacthub.io/images: |
     - name: n8n
-      image: n8nio/n8n:1.115.3
+      image: n8nio/n8n:1.116.2
       platforms:
         - linux/amd64
         - linux/arm64
@@ -114,11 +119,11 @@ annotations:
     url: https://keybase.io/communitycharts/pgp_keys.asc
 dependencies:
   - name: redis
-    version: 23.1.3
+    version: 23.2.1
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: postgresql
-    version: 18.0.15
+    version: 18.1.1
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: minio

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.15.16](https://img.shields.io/badge/Version-1.15.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.115.3](https://img.shields.io/badge/AppVersion-1.115.3-informational?style=flat-square)
+![Version: 1.15.17](https://img.shields.io/badge/Version-1.15.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.116.2](https://img.shields.io/badge/AppVersion-1.116.2-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -891,8 +891,8 @@ Kubernetes: `>=1.23.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 18.0.15 |
-| https://charts.bitnami.com/bitnami | redis | 23.1.3 |
+| https://charts.bitnami.com/bitnami | postgresql | 18.1.1 |
+| https://charts.bitnami.com/bitnami | redis | 23.2.1 |
 | https://charts.min.io/ | minio | 5.4.0 |
 
 ## Uninstall Helm Chart


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the n8n chart to use the latest image version 1.116.2 from n8nio/n8n. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated