### PR TITLE
[n8n] Set default value for externalPostgresql.password to avoid ArgoCD diffs

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.15.19
+version: 1.15.20
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -972,7 +972,7 @@ helm upgrade [RELEASE_NAME] community-charts/n8n
 | externalPostgresql.database | string | `"n8n"` | The name of the external PostgreSQL database. For more information: https://docs.n8n.io/hosting/configuration/supported-databases-settings/#required-permissions |
 | externalPostgresql.existingSecret | string | `""` | The name of an existing secret with PostgreSQL (must contain key `postgres-password`) and credentials. When it's set, the `externalPostgresql.password` parameter is ignored |
 | externalPostgresql.host | string | `""` | External PostgreSQL server host |
-| externalPostgresql.password | string | `""` | External PostgreSQL password |
+| externalPostgresql.password | string | `"postgres"` | External PostgreSQL password |
 | externalPostgresql.port | int | `5432` | External PostgreSQL server port |
 | externalPostgresql.username | string | `"postgres"` | External PostgreSQL username |
 | externalRedis | object | `{"clusterNodes":[],"database":0,"dualStack":false,"existingSecret":"","host":"","password":"","port":6379,"tls":{"enabled":false},"username":""}` | External Redis parameters |

--- a/charts/n8n/unittests/__snapshot__/deployment-worker_test.yaml.snap
+++ b/charts/n8n/unittests/__snapshot__/deployment-worker_test.yaml.snap
@@ -305,7 +305,7 @@ should match snapshot of default values:
   12: |
     apiVersion: v1
     data:
-      postgres-password: ""
+      postgres-password: cG9zdGdyZXM=
     kind: Secret
     metadata:
       labels:
@@ -690,7 +690,7 @@ should match snapshot of postgres ssl certificate values:
   12: |
     apiVersion: v1
     data:
-      postgres-password: ""
+      postgres-password: cG9zdGdyZXM=
     kind: Secret
     metadata:
       labels:
@@ -1047,7 +1047,7 @@ should match snapshot of worker persistence:
   12: |
     apiVersion: v1
     data:
-      postgres-password: ""
+      postgres-password: cG9zdGdyZXM=
     kind: Secret
     metadata:
       labels:

--- a/charts/n8n/unittests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/n8n/unittests/__snapshot__/deployment_test.yaml.snap
@@ -1083,7 +1083,7 @@ should match snapshot of postgres ssl certificate values:
   11: |
     apiVersion: v1
     data:
-      postgres-password: ""
+      postgres-password: cG9zdGdyZXM=
     kind: Secret
     metadata:
       labels:

--- a/charts/n8n/unittests/__snapshot__/secret_test.yaml.snap
+++ b/charts/n8n/unittests/__snapshot__/secret_test.yaml.snap
@@ -21,7 +21,7 @@ should match snapshot of postgresql ssl fake certificate values:
   1: |
     apiVersion: v1
     data:
-      postgres-password: ""
+      postgres-password: cG9zdGdyZXM=
     kind: Secret
     metadata:
       labels:

--- a/charts/n8n/unittests/__snapshot__/statefulset-worker_test.yaml.snap
+++ b/charts/n8n/unittests/__snapshot__/statefulset-worker_test.yaml.snap
@@ -160,7 +160,7 @@ should match snapshot of default values:
   11: |
     apiVersion: v1
     data:
-      postgres-password: ""
+      postgres-password: cG9zdGdyZXM=
     kind: Secret
     metadata:
       labels:
@@ -524,7 +524,7 @@ should match snapshot of postgres ssl certificate values:
   11: |
     apiVersion: v1
     data:
-      postgres-password: ""
+      postgres-password: cG9zdGdyZXM=
     kind: Secret
     metadata:
       labels:
@@ -915,7 +915,7 @@ should match snapshot of worker persistence:
   11: |
     apiVersion: v1
     data:
-      postgres-password: ""
+      postgres-password: cG9zdGdyZXM=
     kind: Secret
     metadata:
       labels:

--- a/charts/n8n/unittests/__snapshot__/statefulset_test.yaml.snap
+++ b/charts/n8n/unittests/__snapshot__/statefulset_test.yaml.snap
@@ -418,7 +418,7 @@ should match snapshot of postgres ssl certificate values:
   10: |
     apiVersion: v1
     data:
-      postgres-password: ""
+      postgres-password: cG9zdGdyZXM=
     kind: Secret
     metadata:
       labels:

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -1089,7 +1089,7 @@ externalPostgresql:
   # -- External PostgreSQL username
   username: "postgres"
   # -- External PostgreSQL password
-  password: ""
+  password: "postgres"
   # -- External PostgreSQL server port
   port: 5432
   # -- The name of the external PostgreSQL database. For more information: https://docs.n8n.io/hosting/configuration/supported-databases-settings/#required-permissions


### PR DESCRIPTION
#### What this PR does / why we need it

This PR updates the default value of `externalPostgresql.password` in `values.yaml` for the **n8n** chart.

Previously, the password field was set to an empty string (`""`), which caused ArgoCD to detect a diff even when the value wasn’t being used (since Helm renders it as an empty secret).  
By setting a default non-empty value (`postgres`), the unwanted diff in ArgoCD is avoided, improving GitOps stability.

#### Which issue this PR fixes

N/A (internal behavior improvement)
<!-- or, if there’s an issue -->
<!-- fixes #<issue_number> -->

#### Special notes for your reviewer

This change only updates the default `values.yaml` value and doesn’t affect actual deployment behavior when `externalPostgresql.enabled` is `false` or when a user overrides the password.

#### Checklist
- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped (`appVersion` unchanged)
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[n8n]`)
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated (if necessary)

---

#### Example diff

```diff
   # -- External PostgreSQL password
-  password: ""
+  password: "postgres"


<img width="1347" height="333" alt="Screenshot 2025-11-03 at 13 29 37" src="https://github.com/user-attachments/assets/a8df546d-d5eb-49c0-98ba-fd1244b62e0d" />

