### PR TITLE
[n8n] Update n8n chart to 1.119.1

### DIFF
--- a/charts/n8n/Chart.lock
+++ b/charts/n8n/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 23.2.6
+  version: 23.2.12
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 18.1.4
+  version: 18.1.8
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:69881035cd9f9183fcca869d3742ca6e28de8949f13e2aad3c4dd39ee36bd8be
-generated: "2025-11-06T12:30:12.561729529Z"
+digest: sha256:b620bc8d4f95ac08cb6e7b59d6f0bfef5e3dcb38c1cb0739d55eeed79c41e9c0
+generated: "2025-11-11T22:50:29.322946165Z"

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.16.0
+version: 1.16.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.118.2"
+appVersion: "1.119.1"
 kubeVersion: ">=1.23.0-0"
 home: https://n8n.io
 maintainers:
@@ -50,14 +50,24 @@ annotations:
       url: https://docs.n8n.io/
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
-    - kind: fixed
-      description: Default license server url schema definition fixed
+    - kind: changed
+      description: Update n8nio/n8n image version to 1.119.1
       links:
-        - name: GitHub PR
-          url: https://github.com/community-charts/helm-charts/pull/260
+        - name: Upstream Project
+          url: https://github.com/n8n-io/n8n
+    - kind: changed
+      description: Update dependency redis from 23.2.6 to 23.2.12
+      links:
+        - name: ArtifactHub
+          url: https://artifacthub.io/packages/helm/bitnami/redis
+    - kind: changed
+      description: Update dependency postgresql from 18.1.4 to 18.1.8
+      links:
+        - name: ArtifactHub
+          url: https://artifacthub.io/packages/helm/bitnami/postgresql
   artifacthub.io/images: |
     - name: n8n
-      image: n8nio/n8n:1.118.2
+      image: n8nio/n8n:1.119.1
       platforms:
         - linux/amd64
         - linux/arm64
@@ -109,11 +119,11 @@ annotations:
     url: https://keybase.io/communitycharts/pgp_keys.asc
 dependencies:
   - name: redis
-    version: 23.2.6
+    version: 23.2.12
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: postgresql
-    version: 18.1.4
+    version: 18.1.8
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: minio

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.16.0](https://img.shields.io/badge/Version-1.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.118.2](https://img.shields.io/badge/AppVersion-1.118.2-informational?style=flat-square)
+![Version: 1.16.1](https://img.shields.io/badge/Version-1.16.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.119.1](https://img.shields.io/badge/AppVersion-1.119.1-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -891,8 +891,8 @@ Kubernetes: `>=1.23.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 18.1.4 |
-| https://charts.bitnami.com/bitnami | redis | 23.2.6 |
+| https://charts.bitnami.com/bitnami | postgresql | 18.1.8 |
+| https://charts.bitnami.com/bitnami | redis | 23.2.12 |
 | https://charts.min.io/ | minio | 5.4.0 |
 
 ## Uninstall Helm Chart


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the n8n chart to use the latest image version 1.119.1 from n8nio/n8n. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated