### PR TITLE
[outline] Update outline chart to 1.1.0

### DIFF
--- a/charts/outline/Chart.lock
+++ b/charts/outline/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 23.2.2
+  version: 23.2.12
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 18.1.3
+  version: 18.1.9
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:97076207b22dd69aae75f599be1b350a9b366125b1d7f32883b2f69ee0c4f4dd
-generated: "2025-10-30T02:50:20.898818039Z"
+digest: sha256:c4ce652e7c6195943017d87d172a8e54b627b70eca138fd1be264a2ca33cf7bb
+generated: "2025-11-17T02:44:25.382943459Z"

--- a/charts/outline/Chart.yaml
+++ b/charts/outline/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.2
+version: 0.7.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.1"
+appVersion: "1.1.0"
 kubeVersion: ">=1.23.0-0"
 home: https://www.getoutline.com/
 maintainers:
@@ -53,23 +53,23 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update outlinewiki/outline image version to 1.0.1
+      description: Update outlinewiki/outline image version to 1.1.0
       links:
         - name: Upstream Project
           url: https://hub.docker.com/r/outlinewiki/outline
     - kind: changed
-      description: Update dependency redis from 23.2.1 to 23.2.2
+      description: Update dependency redis from 23.2.2 to 23.2.12
       links:
         - name: ArtifactHub
           url: https://artifacthub.io/packages/helm/bitnami/redis
     - kind: changed
-      description: Update dependency postgresql from 18.1.1 to 18.1.3
+      description: Update dependency postgresql from 18.1.3 to 18.1.9
       links:
         - name: ArtifactHub
           url: https://artifacthub.io/packages/helm/bitnami/postgresql
   artifacthub.io/images: |
     - name: outline
-      image: outlinewiki/outline:1.0.1
+      image: outlinewiki/outline:1.1.0
       platforms:
         - linux/amd64
         - linux/arm64
@@ -88,11 +88,11 @@ annotations:
     url: https://keybase.io/communitycharts/pgp_keys.asc
 dependencies:
   - name: redis
-    version: 23.2.2
+    version: 23.2.12
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: postgresql
-    version: 18.1.3
+    version: 18.1.9
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: minio

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for the fastest knowledge base for growing teams. Beautiful, realtime collaborative, feature packed, and markdown compatible.
 
-![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)
+![Version: 0.7.3](https://img.shields.io/badge/Version-0.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -516,8 +516,8 @@ Kubernetes: `>=1.23.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 18.1.3 |
-| https://charts.bitnami.com/bitnami | redis | 23.2.2 |
+| https://charts.bitnami.com/bitnami | postgresql | 18.1.9 |
+| https://charts.bitnami.com/bitnami | redis | 23.2.12 |
 | https://charts.min.io/ | minio | 5.4.0 |
 
 ## Uninstall Helm Chart


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the outline chart to use the latest image version 1.1.0 from outlinewiki/outline. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated