### PR TITLE
[mlflow] fix: ignore static prefix for health endpoint

### DIFF
--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.0
+version: 1.8.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.1
+version: 1.8.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -51,11 +51,11 @@ annotations:
       url: https://github.com/burakince/mlflow
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
-    - kind: added
-      description: Add resources to dbchecker and ini-file-initializer init containers using resources definition.
+    - kind: fixed
+      description: Fix liveness and readiness probes to always use /health regardless of staticPrefix
       links:
         - name: GitHub Issue
-          url: https://github.com/community-charts/helm-charts/issues/265
+          url: https://github.com/community-charts/helm-charts/issues/290
   artifacthub.io/images: |
     - name: mlflow
       image: burakince/mlflow:3.6.0

--- a/charts/mlflow/README.md
+++ b/charts/mlflow/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for Mlflow open source platform for the machine learning lifecycle
 
-![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.6.0](https://img.shields.io/badge/AppVersion-3.6.0-informational?style=flat-square)
+![Version: 1.8.3](https://img.shields.io/badge/Version-1.8.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.6.0](https://img.shields.io/badge/AppVersion-3.6.0-informational?style=flat-square)
 
 ## Official Documentation
 

--- a/charts/mlflow/templates/_helpers.tpl
+++ b/charts/mlflow/templates/_helpers.tpl
@@ -63,11 +63,6 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
-{{- define "mlflow.health" -}}
-{{- $basPath := default "/" .Values.extraArgs.staticPrefix }}
-{{- printf "%s/health" ($basPath | trimSuffix "/" )}}
-{{- end }}
-
 {{/*
 Generate random hex similar to `openssl rand -hex 16` command.
 Usage: {{ include "mlflow.generateRandomHex" 32 }}

--- a/charts/mlflow/templates/deployment.yaml
+++ b/charts/mlflow/templates/deployment.yaml
@@ -342,14 +342,14 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: {{ include "mlflow.health" . }}
+              path: /health
               port: {{ .Values.service.containerPortName }}
           {{- with .Values.livenessProbe }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           readinessProbe:
             httpGet:
-              path: {{ include "mlflow.health" . }}
+              path: /health
               port: {{ .Values.service.containerPortName }}
           {{- with .Values.readinessProbe }}
             {{- toYaml . | nindent 12 }}

--- a/charts/mlflow/unittests/deployment_test.yaml
+++ b/charts/mlflow/unittests/deployment_test.yaml
@@ -389,8 +389,8 @@ tests:
   - it: should show extra environment variables when we pass any
     set:
       extraEnvVars:
-         MLFLOW_S3_IGNORE_TLS: true
-         AWS_DEFAULT_REGION: eu-central-1
+        MLFLOW_S3_IGNORE_TLS: true
+        AWS_DEFAULT_REGION: eu-central-1
     asserts:
       - contains:
           path: spec.template.spec.containers[?(@.name == "mlflow")].env
@@ -417,18 +417,18 @@ tests:
               name: mysupersecret
         template: deployment.yaml
 
-  - it: should check liveness and rediness with static prefix when we set static prefix from extra arguments
+  - it: should check that liveness and rediness is not affected if static prefix is set
     set:
       extraArgs:
         staticPrefix: /mlflow
     asserts:
       - equal:
           path: spec.template.spec.containers[?(@.name == "mlflow")].livenessProbe.httpGet.path
-          value: /mlflow/health
+          value: /health
         template: deployment.yaml
       - equal:
           path: spec.template.spec.containers[?(@.name == "mlflow")].readinessProbe.httpGet.path
-          value: /mlflow/health
+          value: /health
         template: deployment.yaml
 
   - it: should check that the db checker init container is present if enabled with postgres
@@ -1547,7 +1547,7 @@ tests:
       version: 1.0.0
       appVersion: 1.0.0
     asserts:
-      - matchSnapshot: { }
+      - matchSnapshot: {}
 
   - it: should match snapshot with additional values
     set:
@@ -1624,7 +1624,7 @@ tests:
       version: 1.0.0
       appVersion: 1.0.0
     asserts:
-      - matchSnapshot: { }
+      - matchSnapshot: {}
 
   - it: should match snapshot with additional values when postgresql is enabled
     set:
@@ -1701,7 +1701,7 @@ tests:
       version: 1.0.0
       appVersion: 1.0.0
     asserts:
-      - matchSnapshot: { }
+      - matchSnapshot: {}
 
   - it: should match snapshot with additional values when bitnami postgresql is enabled
     set:
@@ -1778,7 +1778,7 @@ tests:
       version: 1.0.0
       appVersion: 1.0.0
     asserts:
-      - matchSnapshot: { }
+      - matchSnapshot: {}
 
   - it: should match snapshot with additional values when mysql is enabled
     set:
@@ -1855,7 +1855,7 @@ tests:
       version: 1.0.0
       appVersion: 1.0.0
     asserts:
-      - matchSnapshot: { }
+      - matchSnapshot: {}
 
   - it: should match snapshot with additional values when bitnami mysql is enabled
     set:
@@ -1932,7 +1932,7 @@ tests:
       version: 1.0.0
       appVersion: 1.0.0
     asserts:
-      - matchSnapshot: { }
+      - matchSnapshot: {}
 
   - it: should match snapshot with additional values when auth and auth.postgres are enabled
     set:
@@ -2017,7 +2017,7 @@ tests:
       version: 1.0.0
       appVersion: 1.0.0
     asserts:
-      - matchSnapshot: { }
+      - matchSnapshot: {}
 
   - it: should match snapshot with additional values when mssql is enabled
     set:
@@ -2094,7 +2094,7 @@ tests:
       version: 1.0.0
       appVersion: 1.0.0
     asserts:
-      - matchSnapshot: { }
+      - matchSnapshot: {}
 
   - it: should set resources for init containers when resources are defined
     set:


### PR DESCRIPTION
<!--
Thank you for contributing to community-charts/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in community-charts/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This PR updates the liveness and readiness probe configuration to use the `/health` endpoint instead of `/<static-prefix>/health`. This fix is necessary for using `--static-prefix` correctly, as MLflow does not use the static prefix to define the health endpoint. See #290.

#### Which issue this PR fixes

- Fixes #290 

#### Special notes for your reviewer:

@burakince 

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated
