### PR TITLE
[n8n] Update n8n chart to 1.123.5

### DIFF
--- a/charts/n8n/Chart.lock
+++ b/charts/n8n/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 24.0.0
+  version: 24.0.4
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 18.1.13
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:1e43d08318c4d574bfc5d88f6bff04daec624ffabe090b16687cda4adda9feea
-generated: "2025-11-26T02:45:05.815503357Z"
+digest: sha256:78ff1c5ff961e70f7b394d498119c4a52fcab60cbe28253617a2cb7135561f74
+generated: "2025-12-11T02:48:40.753704531Z"

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.16.9
+version: 1.16.10
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.123.4"
+appVersion: "1.123.5"
 kubeVersion: ">=1.23.0-0"
 home: https://n8n.io
 maintainers:
@@ -51,13 +51,18 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update n8nio/n8n image version to 1.123.4
+      description: Update n8nio/n8n image version to 1.123.5
       links:
         - name: Upstream Project
           url: https://github.com/n8n-io/n8n
+    - kind: changed
+      description: Update dependency redis from 24.0.0 to 24.0.4
+      links:
+        - name: ArtifactHub
+          url: https://artifacthub.io/packages/helm/bitnami/redis
   artifacthub.io/images: |
     - name: n8n
-      image: n8nio/n8n:1.123.4
+      image: n8nio/n8n:1.123.5
       platforms:
         - linux/amd64
         - linux/arm64
@@ -109,7 +114,7 @@ annotations:
     url: https://keybase.io/communitycharts/pgp_keys.asc
 dependencies:
   - name: redis
-    version: 24.0.0
+    version: 24.0.4
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: postgresql

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.16.9](https://img.shields.io/badge/Version-1.16.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.123.4](https://img.shields.io/badge/AppVersion-1.123.4-informational?style=flat-square)
+![Version: 1.16.10](https://img.shields.io/badge/Version-1.16.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.123.5](https://img.shields.io/badge/AppVersion-1.123.5-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -892,7 +892,7 @@ Kubernetes: `>=1.23.0-0`
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.bitnami.com/bitnami | postgresql | 18.1.13 |
-| https://charts.bitnami.com/bitnami | redis | 24.0.0 |
+| https://charts.bitnami.com/bitnami | redis | 24.0.4 |
 | https://charts.min.io/ | minio | 5.4.0 |
 
 ## Uninstall Helm Chart


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the n8n chart to use the latest image version 1.123.5 from n8nio/n8n. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated