### PR TITLE
[n8n] fix PostgreSQL TLS variables

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.16.10
+version: 1.16.11
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/n8n/templates/configmap.yaml
+++ b/charts/n8n/templates/configmap.yaml
@@ -29,13 +29,13 @@ data:
   {{- if .Values.db.postgresdb.ssl.enabled }}
   DB_POSTGRESDB_SSL_ENABLED: {{ .Values.db.postgresdb.ssl.enabled | quote }}
   {{- if eq (include "n8n.postgres.ssl.hasCA" .) "true" }}
-  DB_POSTGRESDB_SSL_CA: "/home/node/certs/ca/ca.crt"
+  DB_POSTGRESDB_SSL_CA_FILE: "/home/node/certs/ca/ca.crt"
   {{- end }}
   {{- if eq (include "n8n.postgres.ssl.hasCert" .) "true" }}
-  DB_POSTGRESDB_SSL_CERT: "/home/node/certs/cert/cert.crt"
+  DB_POSTGRESDB_SSL_CERT_FILE: "/home/node/certs/cert/cert.crt"
   {{- end }}
   {{- if eq (include "n8n.postgres.ssl.hasKey" .) "true" }}
-  DB_POSTGRESDB_SSL_KEY: "/home/node/certs/key/cert.key"
+  DB_POSTGRESDB_SSL_KEY_FILE: "/home/node/certs/key/cert.key"
   {{- end }}
   {{- end }}
 {{- else }}

--- a/charts/n8n/unittests/__snapshot__/deployment-mcp-webhook_test.yaml.snap
+++ b/charts/n8n/unittests/__snapshot__/deployment-mcp-webhook_test.yaml.snap
@@ -9,10 +9,10 @@ should match snapshot of postgres ssl certificate values:
       DB_POSTGRESDB_POOL_SIZE: "2"
       DB_POSTGRESDB_PORT: "5432"
       DB_POSTGRESDB_SCHEMA: public
-      DB_POSTGRESDB_SSL_CA: /home/node/certs/ca/ca.crt
-      DB_POSTGRESDB_SSL_CERT: /home/node/certs/cert/cert.crt
+      DB_POSTGRESDB_SSL_CA_FILE: /home/node/certs/ca/ca.crt
+      DB_POSTGRESDB_SSL_CERT_FILE: /home/node/certs/cert/cert.crt
       DB_POSTGRESDB_SSL_ENABLED: "true"
-      DB_POSTGRESDB_SSL_KEY: /home/node/certs/key/cert.key
+      DB_POSTGRESDB_SSL_KEY_FILE: /home/node/certs/key/cert.key
       DB_TYPE: postgresdb
     kind: ConfigMap
     metadata:
@@ -190,7 +190,7 @@ should match snapshot of postgres ssl certificate values:
       template:
         metadata:
           annotations:
-            checksum/config: 9275478349b0d1960495024022e4b3e64e5681684b296cdd8cf49b9267e20bcd
+            checksum/config: 0ff0613143403777975a27de8ffe9fc4c1ac99ba8d69c68ed8a7ef1c2c85b7f6
           labels:
             app.kubernetes.io/component: mcp
             app.kubernetes.io/instance: n8n

--- a/charts/n8n/unittests/__snapshot__/deployment-webhook_test.yaml.snap
+++ b/charts/n8n/unittests/__snapshot__/deployment-webhook_test.yaml.snap
@@ -9,10 +9,10 @@ should match snapshot of postgres ssl certificate values:
       DB_POSTGRESDB_POOL_SIZE: "2"
       DB_POSTGRESDB_PORT: "5432"
       DB_POSTGRESDB_SCHEMA: public
-      DB_POSTGRESDB_SSL_CA: /home/node/certs/ca/ca.crt
-      DB_POSTGRESDB_SSL_CERT: /home/node/certs/cert/cert.crt
+      DB_POSTGRESDB_SSL_CA_FILE: /home/node/certs/ca/ca.crt
+      DB_POSTGRESDB_SSL_CERT_FILE: /home/node/certs/cert/cert.crt
       DB_POSTGRESDB_SSL_ENABLED: "true"
-      DB_POSTGRESDB_SSL_KEY: /home/node/certs/key/cert.key
+      DB_POSTGRESDB_SSL_KEY_FILE: /home/node/certs/key/cert.key
       DB_TYPE: postgresdb
     kind: ConfigMap
     metadata:
@@ -190,7 +190,7 @@ should match snapshot of postgres ssl certificate values:
       template:
         metadata:
           annotations:
-            checksum/config: 9275478349b0d1960495024022e4b3e64e5681684b296cdd8cf49b9267e20bcd
+            checksum/config: 0ff0613143403777975a27de8ffe9fc4c1ac99ba8d69c68ed8a7ef1c2c85b7f6
           labels:
             app.kubernetes.io/component: webhook
             app.kubernetes.io/instance: n8n

--- a/charts/n8n/unittests/__snapshot__/deployment-worker_test.yaml.snap
+++ b/charts/n8n/unittests/__snapshot__/deployment-worker_test.yaml.snap
@@ -358,10 +358,10 @@ should match snapshot of postgres ssl certificate values:
       DB_POSTGRESDB_POOL_SIZE: "2"
       DB_POSTGRESDB_PORT: "5432"
       DB_POSTGRESDB_SCHEMA: public
-      DB_POSTGRESDB_SSL_CA: /home/node/certs/ca/ca.crt
-      DB_POSTGRESDB_SSL_CERT: /home/node/certs/cert/cert.crt
+      DB_POSTGRESDB_SSL_CA_FILE: /home/node/certs/ca/ca.crt
+      DB_POSTGRESDB_SSL_CERT_FILE: /home/node/certs/cert/cert.crt
       DB_POSTGRESDB_SSL_ENABLED: "true"
-      DB_POSTGRESDB_SSL_KEY: /home/node/certs/key/cert.key
+      DB_POSTGRESDB_SSL_KEY_FILE: /home/node/certs/key/cert.key
       DB_TYPE: postgresdb
     kind: ConfigMap
     metadata:
@@ -538,7 +538,7 @@ should match snapshot of postgres ssl certificate values:
       template:
         metadata:
           annotations:
-            checksum/config: 4b91f5a9264f8a417ef03702235da2bf32fdbb10f4520969f8c1381184c7d4d2
+            checksum/config: f9a4f43bd8975f1e1492f138a98cf0e7b8c48efa593438c6f159dbe792e399de
           labels:
             app.kubernetes.io/component: worker
             app.kubernetes.io/instance: n8n

--- a/charts/n8n/unittests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/n8n/unittests/__snapshot__/deployment_test.yaml.snap
@@ -801,10 +801,10 @@ should match snapshot of postgres ssl certificate values:
       DB_POSTGRESDB_POOL_SIZE: "2"
       DB_POSTGRESDB_PORT: "5432"
       DB_POSTGRESDB_SCHEMA: public
-      DB_POSTGRESDB_SSL_CA: /home/node/certs/ca/ca.crt
-      DB_POSTGRESDB_SSL_CERT: /home/node/certs/cert/cert.crt
+      DB_POSTGRESDB_SSL_CA_FILE: /home/node/certs/ca/ca.crt
+      DB_POSTGRESDB_SSL_CERT_FILE: /home/node/certs/cert/cert.crt
       DB_POSTGRESDB_SSL_ENABLED: "true"
-      DB_POSTGRESDB_SSL_KEY: /home/node/certs/key/cert.key
+      DB_POSTGRESDB_SSL_KEY_FILE: /home/node/certs/key/cert.key
       DB_TYPE: postgresdb
     kind: ConfigMap
     metadata:
@@ -963,7 +963,7 @@ should match snapshot of postgres ssl certificate values:
       template:
         metadata:
           annotations:
-            checksum/config: b9968f93f265e5024a55c0d954ae1ab89d083de575b8bb39815245d357f8cc85
+            checksum/config: 1f17a2acbe71ee51c6187c249ab61cc51f61af648068dca1a321b3b12406c849
           labels:
             app.kubernetes.io/component: main
             app.kubernetes.io/instance: n8n

--- a/charts/n8n/unittests/__snapshot__/statefulset-worker_test.yaml.snap
+++ b/charts/n8n/unittests/__snapshot__/statefulset-worker_test.yaml.snap
@@ -369,10 +369,10 @@ should match snapshot of postgres ssl certificate values:
       DB_POSTGRESDB_POOL_SIZE: "2"
       DB_POSTGRESDB_PORT: "5432"
       DB_POSTGRESDB_SCHEMA: public
-      DB_POSTGRESDB_SSL_CA: /home/node/certs/ca/ca.crt
-      DB_POSTGRESDB_SSL_CERT: /home/node/certs/cert/cert.crt
+      DB_POSTGRESDB_SSL_CA_FILE: /home/node/certs/ca/ca.crt
+      DB_POSTGRESDB_SSL_CERT_FILE: /home/node/certs/cert/cert.crt
       DB_POSTGRESDB_SSL_ENABLED: "true"
-      DB_POSTGRESDB_SSL_KEY: /home/node/certs/key/cert.key
+      DB_POSTGRESDB_SSL_KEY_FILE: /home/node/certs/key/cert.key
       DB_TYPE: postgresdb
     kind: ConfigMap
     metadata:
@@ -590,7 +590,7 @@ should match snapshot of postgres ssl certificate values:
       template:
         metadata:
           annotations:
-            checksum/config: 4b91f5a9264f8a417ef03702235da2bf32fdbb10f4520969f8c1381184c7d4d2
+            checksum/config: f9a4f43bd8975f1e1492f138a98cf0e7b8c48efa593438c6f159dbe792e399de
           labels:
             app.kubernetes.io/component: worker
             app.kubernetes.io/instance: n8n

--- a/charts/n8n/unittests/__snapshot__/statefulset_test.yaml.snap
+++ b/charts/n8n/unittests/__snapshot__/statefulset_test.yaml.snap
@@ -280,10 +280,10 @@ should match snapshot of postgres ssl certificate values:
       DB_POSTGRESDB_POOL_SIZE: "2"
       DB_POSTGRESDB_PORT: "5432"
       DB_POSTGRESDB_SCHEMA: public
-      DB_POSTGRESDB_SSL_CA: /home/node/certs/ca/ca.crt
-      DB_POSTGRESDB_SSL_CERT: /home/node/certs/cert/cert.crt
+      DB_POSTGRESDB_SSL_CA_FILE: /home/node/certs/ca/ca.crt
+      DB_POSTGRESDB_SSL_CERT_FILE: /home/node/certs/cert/cert.crt
       DB_POSTGRESDB_SSL_ENABLED: "true"
-      DB_POSTGRESDB_SSL_KEY: /home/node/certs/key/cert.key
+      DB_POSTGRESDB_SSL_KEY_FILE: /home/node/certs/key/cert.key
       DB_TYPE: postgresdb
     kind: ConfigMap
     metadata:
@@ -469,7 +469,7 @@ should match snapshot of postgres ssl certificate values:
       template:
         metadata:
           annotations:
-            checksum/config: b9968f93f265e5024a55c0d954ae1ab89d083de575b8bb39815245d357f8cc85
+            checksum/config: 1f17a2acbe71ee51c6187c249ab61cc51f61af648068dca1a321b3b12406c849
           labels:
             app.kubernetes.io/component: main
             app.kubernetes.io/instance: n8n

--- a/charts/n8n/unittests/configmap_test.yaml
+++ b/charts/n8n/unittests/configmap_test.yaml
@@ -195,7 +195,7 @@ tests:
       value: n8n-database-configmap
     asserts:
       - equal:
-          path: data.DB_POSTGRESDB_SSL_CA
+          path: data.DB_POSTGRESDB_SSL_CA_FILE
           value: /home/node/certs/ca/ca.crt
 
   - it: should set postgresql ssl CA certificate when ssl enabled and existingCertificateAuthorityFileSecret.name is set
@@ -212,7 +212,7 @@ tests:
       value: n8n-database-configmap
     asserts:
       - equal:
-          path: data.DB_POSTGRESDB_SSL_CA
+          path: data.DB_POSTGRESDB_SSL_CA_FILE
           value: /home/node/certs/ca/ca.crt
 
   - it: should set postgresql ssl certificate when ssl enabled and base64EncodedCertFile is set
@@ -228,7 +228,7 @@ tests:
       value: n8n-database-configmap
     asserts:
       - equal:
-          path: data.DB_POSTGRESDB_SSL_CERT
+          path: data.DB_POSTGRESDB_SSL_CERT_FILE
           value: /home/node/certs/cert/cert.crt
 
   - it: should set postgresql ssl certificate when ssl enabled and existingCertFileSecret.name is set
@@ -245,7 +245,7 @@ tests:
       value: n8n-database-configmap
     asserts:
       - equal:
-          path: data.DB_POSTGRESDB_SSL_CERT
+          path: data.DB_POSTGRESDB_SSL_CERT_FILE
           value: /home/node/certs/cert/cert.crt
 
   - it: should set postgresql ssl certificate private key when ssl enabled and base64EncodedPrivateKeyFile is set
@@ -261,7 +261,7 @@ tests:
       value: n8n-database-configmap
     asserts:
       - equal:
-          path: data.DB_POSTGRESDB_SSL_KEY
+          path: data.DB_POSTGRESDB_SSL_KEY_FILE
           value: /home/node/certs/key/cert.key
 
   - it: should set postgresql ssl certificate private key when ssl enabled and existingPrivateKeyFileSecret.name is set
@@ -278,7 +278,7 @@ tests:
       value: n8n-database-configmap
     asserts:
       - equal:
-          path: data.DB_POSTGRESDB_SSL_KEY
+          path: data.DB_POSTGRESDB_SSL_KEY_FILE
           value: /home/node/certs/key/cert.key
 
   - it: should set vacum on startup when db type set to sqlite


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes the handling of custom PostgreSQL CA, Cert and Key parameters. The Chart passed the file paths using the normal variables which expect the actual contents.

Now the `_FILE`  variables are used which cause n8n to load the file contents instead.

#### Which issue this PR fixes
- fixes #276

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)

@burakince 