### PR TITLE
feat(n8n): add high availability support for MCP webhook server

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.16.12
+version: 1.17.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -50,6 +50,8 @@ annotations:
       url: https://docs.n8n.io/
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
+    - kind: added
+      description: Add high availability support for MCP webhook server (configurable replicas, HPA, PDB)
     - kind: changed
       description: Update n8nio/n8n image version to 2.0.3
       links:

--- a/charts/n8n/templates/deployment-mcp-webhook.yaml
+++ b/charts/n8n/templates/deployment-mcp-webhook.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
     {{- include "n8n.mcp-webhook.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  {{- if not .Values.webhook.mcp.autoscaling.enabled }}
+  replicas: {{ .Values.webhook.mcp.count }}
+  {{- end }}
   strategy:
     type: {{ .Values.strategy.type }}
     {{- if eq .Values.strategy.type "RollingUpdate" }}

--- a/charts/n8n/templates/hpa.yaml
+++ b/charts/n8n/templates/hpa.yaml
@@ -46,3 +46,27 @@ spec:
     {{- toYaml .Values.webhook.autoscaling.behavior | nindent 4 }}
   {{- end }}
 {{- end }}
+{{- if and .Values.webhook.mcp.enabled .Values.webhook.mcp.autoscaling.enabled (eq .Values.db.type "postgresdb") (eq .Values.webhook.mode "queue") (or (gt (int .Values.webhook.count) 1) (.Values.webhook.autoscaling.enabled) (.Values.webhook.allNodes)) }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "n8n.mcp-webhook.fullname" . }}
+  labels:
+    {{- include "n8n.mcp-webhook.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "n8n.mcp-webhook.fullname" . }}
+  minReplicas: {{ .Values.webhook.mcp.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.webhook.mcp.autoscaling.maxReplicas }}
+  {{- with .Values.webhook.mcp.autoscaling.metrics }}
+  metrics:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if and .Values.webhook.mcp.autoscaling.behavior (gt (len .Values.webhook.mcp.autoscaling.behavior) 0) }}
+  behavior:
+    {{- toYaml .Values.webhook.mcp.autoscaling.behavior | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/n8n/templates/pdb.yaml
+++ b/charts/n8n/templates/pdb.yaml
@@ -55,3 +55,22 @@ spec:
     matchLabels:
       {{- include "n8n.worker.selectorLabels" . | nindent 6 }}
 {{- end }}
+{{- if and .Values.webhook.mcp.enabled .Values.webhook.mcp.pdb.enabled (eq .Values.db.type "postgresdb") (eq .Values.webhook.mode "queue") (or (gt (int .Values.webhook.count) 1) (.Values.webhook.autoscaling.enabled) (.Values.webhook.allNodes)) (or .Values.webhook.mcp.autoscaling.enabled (gt (int .Values.webhook.mcp.count) 1)) }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "n8n.mcp-webhook.fullname" . }}
+  labels:
+    {{- include "n8n.mcp-webhook.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.webhook.mcp.pdb.minAvailable }}
+  minAvailable: {{ .Values.webhook.mcp.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.webhook.mcp.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.webhook.mcp.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "n8n.mcp-webhook.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/n8n/unittests/__snapshot__/deployment-mcp-webhook_test.yaml.snap
+++ b/charts/n8n/unittests/__snapshot__/deployment-mcp-webhook_test.yaml.snap
@@ -176,7 +176,7 @@ should match snapshot of postgres ssl certificate values:
         helm.sh/chart: n8n-1.0.0
       name: n8n-mcp-webhook
     spec:
-      replicas: 1
+      replicas: 2
       selector:
         matchLabels:
           app.kubernetes.io/component: mcp

--- a/charts/n8n/unittests/deployment-mcp-webhook_test.yaml
+++ b/charts/n8n/unittests/deployment-mcp-webhook_test.yaml
@@ -38,14 +38,27 @@ tests:
           count: 0
         template: deployment-mcp-webhook.yaml
 
-  - it: should not set replica count when webhook count is set
+  - it: should set replica count from webhook.mcp.count
     set:
       webhook:
-        count: 3
+        mcp:
+          count: 3
     asserts:
       - equal:
           path: spec.replicas
-          value: 1
+          value: 3
+        template: deployment-mcp-webhook.yaml
+
+  - it: should not set replica count when webhook.mcp.autoscaling is enabled
+    set:
+      webhook:
+        mcp:
+          count: 3
+          autoscaling:
+            enabled: true
+    asserts:
+      - isNull:
+          path: spec.replicas
         template: deployment-mcp-webhook.yaml
 
   - it: should set strategy to Recreate when strategy.type is Recreate

--- a/charts/n8n/unittests/hpa_test.yaml
+++ b/charts/n8n/unittests/hpa_test.yaml
@@ -157,3 +157,49 @@ tests:
           enabled: true
     asserts:
       - matchSnapshot: { }
+
+  - it: should create hpa resource for mcp webhook node when webhook.mcp.autoscaling.enabled is true
+    set:
+      db:
+        type: postgresdb
+      webhook:
+        mode: queue
+        count: 2
+        mcp:
+          enabled: true
+          autoscaling:
+            enabled: true
+            minReplicas: 2
+            maxReplicas: 5
+            metrics:
+              - type: Resource
+                resource:
+                  name: cpu
+                  target:
+                    type: Utilization
+                    averageUtilization: 80
+    documentSelector:
+      path: metadata.name
+      value: n8n-mcp-webhook
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: n8n-mcp-webhook
+      - equal:
+          path: spec.minReplicas
+          value: 2
+      - equal:
+          path: spec.maxReplicas
+          value: 5
+      - equal:
+          path: spec.metrics[0].type
+          value: Resource
+      - equal:
+          path: spec.metrics[0].resource.name
+          value: cpu
+      - equal:
+          path: spec.metrics[0].resource.target.type
+          value: Utilization
+      - equal:
+          path: spec.metrics[0].resource.target.averageUtilization
+          value: 80

--- a/charts/n8n/unittests/pdb_test.yaml
+++ b/charts/n8n/unittests/pdb_test.yaml
@@ -168,3 +168,63 @@ tests:
       - equal:
           path: spec.selector.matchLabels["app.kubernetes.io/component"]
           value: worker
+
+  - it: should create pdb resource for mcp webhook node when webhook.mcp.count is bigger than 1
+    set:
+      db:
+        type: postgresdb
+      webhook:
+        mode: queue
+        count: 2
+        mcp:
+          enabled: true
+          count: 2
+          pdb:
+            enabled: true
+            minAvailable: 1
+    documentSelector:
+      path: metadata.name
+      value: n8n-mcp-webhook
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: n8n
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: n8n-mcp-webhook
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: mcp
+      - equal:
+          path: spec.minAvailable
+          value: 1
+
+  - it: should create pdb resource for mcp webhook node when webhook.mcp.autoscaling.enabled is true
+    set:
+      db:
+        type: postgresdb
+      webhook:
+        mode: queue
+        count: 2
+        mcp:
+          enabled: true
+          count: 1
+          autoscaling:
+            enabled: true
+          pdb:
+            enabled: true
+            minAvailable: 1
+    documentSelector:
+      path: metadata.name
+      value: n8n-mcp-webhook
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: n8n
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: n8n-mcp-webhook
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: mcp
+

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -2178,6 +2178,88 @@
               "title": "enabled",
               "type": "boolean"
             },
+            "count": {
+              "default": 2,
+              "description": "Number of MCP webhook pods to run. Ignored when autoscaling is enabled.",
+              "required": [],
+              "title": "count",
+              "type": "integer",
+              "minimum": 1
+            },
+            "autoscaling": {
+              "additionalProperties": false,
+              "description": "Autoscaling configuration for MCP webhook pods",
+              "properties": {
+                "enabled": {
+                  "default": false,
+                  "description": "If true, the number of MCP webhooks will be automatically scaled based on default metrics",
+                  "required": [],
+                  "title": "enabled",
+                  "type": "boolean"
+                },
+                "minReplicas": {
+                  "default": 2,
+                  "description": "Minimum number of MCP webhook replicas",
+                  "required": [],
+                  "title": "minReplicas",
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "maxReplicas": {
+                  "default": 10,
+                  "description": "Maximum number of MCP webhook replicas",
+                  "required": [],
+                  "title": "maxReplicas",
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "metrics": {
+                  "type": "array",
+                  "description": "Metrics to use for autoscaling",
+                  "items": {
+                    "type": "object"
+                  }
+                },
+                "behavior": {
+                  "additionalProperties": true,
+                  "description": "Behavior configuration for the autoscaler",
+                  "type": "object"
+                }
+              },
+              "required": ["enabled", "minReplicas", "maxReplicas"],
+              "title": "autoscaling",
+              "type": "object"
+            },
+            "pdb": {
+              "additionalProperties": false,
+              "description": "PodDisruptionBudget configuration for MCP webhook pods",
+              "properties": {
+                "enabled": {
+                  "default": true,
+                  "description": "Whether to enable the PodDisruptionBudget",
+                  "required": [],
+                  "title": "enabled",
+                  "type": "boolean"
+                },
+                "minAvailable": {
+                  "default": 1,
+                  "description": "Minimum number of available replicas",
+                  "required": [],
+                  "title": "minAvailable",
+                  "type": ["integer", "string", "null"]
+                },
+                "maxUnavailable": {
+                  "default": null,
+                  "description": "Maximum number of unavailable replicas",
+                  "required": [],
+                  "title": "maxUnavailable",
+                  "type": ["integer", "string", "null"]
+                }
+              },
+              "required": ["enabled"],
+              "title": "pdb",
+              "type": "object"
+            },
             "resources": {
               "additionalProperties": true,
               "description": "This block is for setting up the resource management for the mcp webhook pod more information can be found here: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
@@ -2410,7 +2492,7 @@
               "type": "array"
             }
           },
-          "required": ["enabled", "resources", "startupProbe", "livenessProbe", "readinessProbe", "extraEnvVars", "extraSecretNamesForEnvFrom", "volumes", "volumeMounts", "initContainers", "extraContainers", "affinity", "hostAliases"],
+          "required": ["enabled", "count", "autoscaling", "pdb", "resources", "startupProbe", "livenessProbe", "readinessProbe", "extraEnvVars", "extraSecretNamesForEnvFrom", "volumes", "volumeMounts", "initContainers", "extraContainers", "affinity", "hostAliases"],
           "title": "mcp",
           "type": "object"
         },

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -596,6 +596,41 @@ webhook:
     # -- Whether to enable MCP webhook
     enabled: true
 
+    # -- Number of MCP webhook pods to run. Ignored when autoscaling is enabled.
+    count: 2
+
+    # -- If true, the number of MCP webhooks will be automatically scaled based on default metrics. On default, it will scale based on CPU. For more information can be found here: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/
+    autoscaling:
+      # -- Whether autoscaling is enabled.
+      enabled: false
+
+      # -- The minimum number of replicas.
+      minReplicas: 2
+
+      # -- The maximum number of replicas.
+      maxReplicas: 10
+
+      # -- The metrics to use for autoscaling.
+      metrics:
+        - type: Resource
+          resource:
+            name: cpu
+            target:
+              type: Utilization
+              averageUtilization: 80
+
+      # -- The behavior of the autoscaler.
+      behavior: {}
+
+    # -- Whether to enable the PodDisruptionBudget for the MCP webhook pod
+    pdb:
+      # -- Whether to enable the PodDisruptionBudget
+      enabled: true
+      # -- Minimum number of available replicas
+      minAvailable: 1
+      # -- Maximum number of unavailable replicas
+      maxUnavailable: null
+
     # -- This block is for setting up the resource management for the mcp webhook pod more information can be found here: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
     resources: {}
 


### PR DESCRIPTION
The MCP webhook server was hardcoded to a single replica, which creates availability concerns during node drains, pod evictions, or unexpected failures. This change enables running multiple MCP webhook pods for high availability.

## New Configuration Options
```yaml
webhook:
  mcp:
    count: 2
    autoscaling:
      enabled: false
      minReplicas: 2
      maxReplicas: 10
      metrics:
        - type: Resource
          resource:
            name: cpu
            target:
              type: Utilization
              averageUtilization: 80
    pdb:
      enabled: true
      minAvailable: 1
```

Test Plan

- Helm lint passes
- All 775 unit tests pass
- Deploy with webhook.mcp.count=3 and verify 3 MCP pods created
- Deploy with webhook.mcp.autoscaling.enabled=true and verify HPA created
- Verify PDB created when count > 1

#### Special notes for your reviewer:

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated
