### PR TITLE
[drone] Update drone chart to 2.27.0

### DIFF
--- a/charts/drone/Chart.yaml
+++ b/charts/drone/Chart.yaml
@@ -2,7 +2,6 @@ apiVersion: v2
 name: drone
 description: A Helm chart for Drone Server and Drone Kubernetes Runner
 icon: https://raw.githubusercontent.com/drone/brand/master/logos/png/dark/drone-logo-png-dark-128.png
-
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives
@@ -12,31 +11,24 @@ icon: https://raw.githubusercontent.com/drone/brand/master/logos/png/dark/drone-
 # a dependency of application charts to inject those utilities and functions into the rendering
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
-
+version: 0.1.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.26.0"
-
+appVersion: "2.27.0"
 kubeVersion: ">=1.13.0-0"
-
 home: https://www.drone.io
-
 maintainers:
   - name: burakince
     email: burak.ince@linux.org.tr
     url: https://www.burakince.com
-
 sources:
   - https://github.com/community-charts/helm-charts
   - https://github.com/drone
-
 keywords:
   - kubernetes
   - drone
@@ -49,7 +41,6 @@ keywords:
   - continuous-deployment
   - continuous-integration
   - code-pipeline
-
 annotations:
   artifacthub.io/links: |
     - name: Chart Source
@@ -59,13 +50,13 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update drone/drone image version to 2.26.0
+      description: Update drone/drone image version to 2.27.0
       links:
         - name: Upstream Project
           url: https://hub.docker.com/r/drone/drone
   artifacthub.io/images: |
     - name: drone
-      image: drone/drone:2.26.0
+      image: drone/drone:2.27.0
       platforms:
         - linux/amd64
         - linux/arm64
@@ -87,5 +78,4 @@ annotations:
   artifacthub.io/signKey: |
     fingerprint: 939B1A0ED8AAA8E722ACCDB3B6A012EE8A76426A
     url: https://keybase.io/communitycharts/pgp_keys.asc
-
 dependencies: []

--- a/charts/drone/README.md
+++ b/charts/drone/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for Drone Server and Drone Kubernetes Runner
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.26.0](https://img.shields.io/badge/AppVersion-2.26.0-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.27.0](https://img.shields.io/badge/AppVersion-2.27.0-informational?style=flat-square)
 
 ## Official Documentation
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the drone chart to use the latest image version 2.27.0 from drone/drone. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated