### PR TITLE
[cloudflared] Update cloudflared chart to 2026.1.1

### DIFF
--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.4
+version: 2.2.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2025.11.1"
+appVersion: "2026.1.1"
 kubeVersion: ">=1.21.0-0"
 home: https://github.com/cloudflare/cloudflared
 maintainers:
@@ -53,13 +53,13 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update cloudflare/cloudflared image version to 2025.11.1
+      description: Update cloudflare/cloudflared image version to 2026.1.1
       links:
         - name: Upstream Project
           url: https://hub.docker.com/r/cloudflare/cloudflared
   artifacthub.io/images: |
     - name: cloudflared
-      image: cloudflare/cloudflared:2025.11.1
+      image: cloudflare/cloudflared:2026.1.1
       platforms:
         - linux/amd64
         - linux/arm64

--- a/charts/cloudflared/README.md
+++ b/charts/cloudflared/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for cloudflare tunnel
 
-![Version: 2.2.4](https://img.shields.io/badge/Version-2.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2025.11.1](https://img.shields.io/badge/AppVersion-2025.11.1-informational?style=flat-square)
+![Version: 2.2.5](https://img.shields.io/badge/Version-2.2.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.1.1](https://img.shields.io/badge/AppVersion-2026.1.1-informational?style=flat-square)
 
 ## Official Documentation
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the cloudflared chart to use the latest image version 2026.1.1 from cloudflare/cloudflared. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated