### PR TITLE
[pypiserver] Update pypiserver chart to v2.4.1

### DIFF
--- a/charts/pypiserver/Chart.yaml
+++ b/charts/pypiserver/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.8
+version: 0.1.9
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v2.4.0"
+appVersion: "v2.4.1"
 kubeVersion: ">=1.13.0-0"
 home: https://github.com/pypiserver/pypiserver
 maintainers:
@@ -45,13 +45,13 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update pypiserver/pypiserver image version to v2.4.0
+      description: Update pypiserver/pypiserver image version to v2.4.1
       links:
         - name: Upstream Project
           url: https://hub.docker.com/r/pypiserver/pypiserver
   artifacthub.io/images: |
     - name: pypiserver
-      image: pypiserver/pypiserver:v2.4.0
+      image: pypiserver/pypiserver:v2.4.1
       platforms:
         - linux/amd64
         - linux/arm64

--- a/charts/pypiserver/README.md
+++ b/charts/pypiserver/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for PyPI Server
 
-![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.4.0](https://img.shields.io/badge/AppVersion-v2.4.0-informational?style=flat-square)
+![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.4.1](https://img.shields.io/badge/AppVersion-v2.4.1-informational?style=flat-square)
 
 ## Official Documentation
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the pypiserver chart to use the latest image version v2.4.1 from pypiserver/pypiserver. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated