### PR TITLE
fix(mlflow): fix logging with uvicornOpts and waitressOpts

### DIFF
--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.1
+version: 1.8.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/mlflow/templates/deployment.yaml
+++ b/charts/mlflow/templates/deployment.yaml
@@ -321,7 +321,7 @@ spec:
           {{- else if .Values.ldapAuth.enabled }}
             - --app-name=basic-auth
           {{- end }}
-          {{- if and .Values.log.enabled (not (hasKey .Values.extraArgs "gunicornOpts")) }}
+          {{- if and .Values.log.enabled (not (hasKey .Values.extraArgs "gunicornOpts")) (not (hasKey .Values.extraArgs "uvicornOpts")) }}
             - {{ printf "--gunicorn-opts='--log-level=%s'" .Values.log.level }}
           {{- end }}
           {{- range $key, $value := .Values.extraArgs }}
@@ -329,6 +329,10 @@ spec:
             - {{ printf "--gunicorn-opts='%s'" (regexReplaceAll "--log-level=[^\\s]*" $value (printf "--log-level=%s" $.Values.log.level)) }}
             {{- else if and $.Values.log.enabled (eq $key "gunicornOpts") (not (contains "--log-level" $value)) }}
             - {{ printf "--gunicorn-opts='--log-level=%s %s'" $.Values.log.level $value }}
+            {{- else if and $.Values.log.enabled (eq $key "uvicornOpts") (contains "--log-level" $value) }}
+            - {{ printf "--uvicorn-opts='%s'" (regexReplaceAll "--log-level=[^\\s]*" $value (printf "--log-level=%s" $.Values.log.level)) }}
+            {{- else if and $.Values.log.enabled (eq $key "uvicornOpts") (not (contains "--log-level" $value)) }}
+            - {{ printf "--uvicorn-opts='--log-level=%s %s'" $.Values.log.level $value }}
             {{- else }}
             - {{ printf "--%s=%s" (kebabcase $key) $value }}
             {{- end }}

--- a/charts/mlflow/templates/deployment.yaml
+++ b/charts/mlflow/templates/deployment.yaml
@@ -321,18 +321,20 @@ spec:
           {{- else if .Values.ldapAuth.enabled }}
             - --app-name=basic-auth
           {{- end }}
-          {{- if and .Values.log.enabled (not (hasKey .Values.extraArgs "gunicornOpts")) (not (hasKey .Values.extraArgs "uvicornOpts")) }}
-            - {{ printf "--gunicorn-opts='--log-level=%s'" .Values.log.level }}
+          {{- $serverOptsKey := "gunicornOpts" }}
+          {{- if hasKey .Values.extraArgs "uvicornOpts" }}
+            {{- $serverOptsKey = "uvicornOpts" }}
+          {{- else if hasKey .Values.extraArgs "waitressOpts" }}
+            {{- $serverOptsKey = "waitressOpts" }}
+          {{- end }}
+          {{- if and .Values.log.enabled (not (hasKey .Values.extraArgs $serverOptsKey)) }}
+            - {{ printf "--%s='--log-level=%s'" (kebabcase $serverOptsKey) .Values.log.level }}
           {{- end }}
           {{- range $key, $value := .Values.extraArgs }}
-            {{- if and $.Values.log.enabled (eq $key "gunicornOpts") (contains "--log-level" $value) }}
-            - {{ printf "--gunicorn-opts='%s'" (regexReplaceAll "--log-level=[^\\s]*" $value (printf "--log-level=%s" $.Values.log.level)) }}
-            {{- else if and $.Values.log.enabled (eq $key "gunicornOpts") (not (contains "--log-level" $value)) }}
-            - {{ printf "--gunicorn-opts='--log-level=%s %s'" $.Values.log.level $value }}
-            {{- else if and $.Values.log.enabled (eq $key "uvicornOpts") (contains "--log-level" $value) }}
-            - {{ printf "--uvicorn-opts='%s'" (regexReplaceAll "--log-level=[^\\s]*" $value (printf "--log-level=%s" $.Values.log.level)) }}
-            {{- else if and $.Values.log.enabled (eq $key "uvicornOpts") (not (contains "--log-level" $value)) }}
-            - {{ printf "--uvicorn-opts='--log-level=%s %s'" $.Values.log.level $value }}
+            {{- if and $.Values.log.enabled (eq $key $serverOptsKey) (contains "--log-level" $value) }}
+            - {{ printf "--%s='%s'" (kebabcase $key) (regexReplaceAll "--log-level=[^\\s]*" $value (printf "--log-level=%s" $.Values.log.level)) }}
+            {{- else if and $.Values.log.enabled (eq $key $serverOptsKey) (not (contains "--log-level" $value)) }}
+            - {{ printf "--%s='--log-level=%s %s'" (kebabcase $key) $.Values.log.level $value }}
             {{- else }}
             - {{ printf "--%s=%s" (kebabcase $key) $value }}
             {{- end }}

--- a/charts/mlflow/unittests/deployment_test.yaml
+++ b/charts/mlflow/unittests/deployment_test.yaml
@@ -331,6 +331,23 @@ tests:
           content: --gunicorn-opts='--log-level=debug --workers=4'
         template: deployment.yaml
 
+  - it: should set log level to uvicorn when log level is set and uvicornOpts is set without log level
+    set:
+      log:
+        enabled: true
+        level: debug
+      extraArgs:
+        uvicornOpts: "--workers=4"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "mlflow")].args
+          content: --uvicorn-opts='--log-level=debug --workers=4'
+        template: deployment.yaml
+      - notContains:
+          path: spec.template.spec.containers[?(@.name == "mlflow")].args
+          content: --gunicorn-opts='--log-level=debug'
+        template: deployment.yaml
+
   - it: should set log level to gunicorn when log level is set and gunicornOpts is set with different log level
     set:
       log:

--- a/charts/mlflow/unittests/deployment_test.yaml
+++ b/charts/mlflow/unittests/deployment_test.yaml
@@ -348,7 +348,24 @@ tests:
           content: --gunicorn-opts='--log-level=debug'
         template: deployment.yaml
 
-  - it: should set log level to gunicorn when log level is set and gunicornOpts is set with different log level
+  - it: should set log level to waitress when log level is set and waitressOpts is set without log level
+    set:
+      log:
+        enabled: true
+        level: debug
+      extraArgs:
+        waitressOpts: "--workers=4"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "mlflow")].args
+          content: --waitress-opts='--log-level=debug --workers=4'
+        template: deployment.yaml
+      - notContains:
+          path: spec.template.spec.containers[?(@.name == "mlflow")].args
+          content: --gunicorn-opts='--log-level=debug'
+        template: deployment.yaml
+
+  - it: should override log level in gunicornOpts when set with different log level
     set:
       log:
         enabled: true
@@ -359,6 +376,32 @@ tests:
       - contains:
           path: spec.template.spec.containers[?(@.name == "mlflow")].args
           content: --gunicorn-opts='--log-level=debug --workers=4'
+        template: deployment.yaml
+
+  - it: should override log level in uvicornOpts when set with different log level
+    set:
+      log:
+        enabled: true
+        level: debug
+      extraArgs:
+        uvicornOpts: "--log-level=info --workers=4"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "mlflow")].args
+          content: --uvicorn-opts='--log-level=debug --workers=4'
+        template: deployment.yaml
+
+  - it: should override log level in waitressOpts when set with different log level
+    set:
+      log:
+        enabled: true
+        level: debug
+      extraArgs:
+        waitressOpts: "--log-level=info --workers=4"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "mlflow")].args
+          content: --waitress-opts='--log-level=debug --workers=4'
         template: deployment.yaml
 
   - it: should show extra arguments when we pass any


### PR DESCRIPTION
<!--
Thank you for contributing to community-charts/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in community-charts/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This PR fixes an issue in the MLFlow `deployment.yaml` template, where the "logging" feature of the chart is incompatible with alternate server options, i.e. `uvicornOpts` and `waitressOpts`. 

When the user sets `extraArgs` containing alternate server runtimes, e.g. `uvicornOpts` or `waitressOpts`, the template contains some logic that always renders `--gunicorn-opts=--log-level=info` into the container's `args`. This ends up passing both `--gunicorn-opts` and `--uvicorn-opts` to the process which causes a runtime error as only one of these should be passed.

#### Which issue this PR fixes
  - fixes https://github.com/community-charts/helm-charts/issues/407

#### Special notes for your reviewer:

@burakince: I assume you would be best to review? Thank you.

Changes:

- The PR updates the `deployment.yaml` template to make it work with `gunicornOpts`, `uvicornOpts`, and `waitressOpts`.
- The default behaviour when logging is enabled and `extraArgs` doesn't contain any of the three server options still defaults to `--gunicorn-opts='--log-level [log-level]` as before, so no backwards breaking changes for gunicorn users
- The template has been updated to make the logic dry
- Added additional unittests for the uvicorn and waitress cases


#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [ ] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [ ] `values.yaml` file fields documented
- [ ] `README.md` file updated
