### PR TITLE
[cloudflared] Update cloudflared chart to 2026.3.0

### DIFF
--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.7
+version: 2.2.8
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2026.2.0"
+appVersion: "2026.3.0"
 kubeVersion: ">=1.21.0-0"
 home: https://github.com/cloudflare/cloudflared
 maintainers:
@@ -53,13 +53,13 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update cloudflare/cloudflared image version to 2026.2.0
+      description: Update cloudflare/cloudflared image version to 2026.3.0
       links:
         - name: Upstream Project
           url: https://hub.docker.com/r/cloudflare/cloudflared
   artifacthub.io/images: |
     - name: cloudflared
-      image: cloudflare/cloudflared:2026.2.0
+      image: cloudflare/cloudflared:2026.3.0
       platforms:
         - linux/amd64
         - linux/arm64

--- a/charts/cloudflared/README.md
+++ b/charts/cloudflared/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for cloudflare tunnel
 
-![Version: 2.2.7](https://img.shields.io/badge/Version-2.2.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.2.0](https://img.shields.io/badge/AppVersion-2026.2.0-informational?style=flat-square)
+![Version: 2.2.8](https://img.shields.io/badge/Version-2.2.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.3.0](https://img.shields.io/badge/AppVersion-2026.3.0-informational?style=flat-square)
 
 ## Official Documentation
 


### PR DESCRIPTION
## What this PR does / why we need it

Updates the `cloudflared` image version from `2026.2.0` to `2026.3.0`, following the latest upstream release.

## Which issue this PR fixes

N/A

## Special notes for your reviewer

Bumped chart version from `2.2.7` to `2.2.8` and updated `artifacthub.io/changes` and `artifacthub.io/images` annotations accordingly.

## Checklist

- [x] DCO signed (`Signed-off-by` present in commit)
- [x] Chart `version` bumped (`2.2.7` → `2.2.8`)
- [x] `artifacthub.io/changes` field updated
- [x] PR title starts with chart name (`[cloudflared]`)
- [x] `README.md` badges updated