### PR TITLE
[n8n] Add support for priorityClassName

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.16.32
+version: 1.16.33
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -413,6 +413,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
       {{- end }}

--- a/charts/n8n/templates/statefulset-worker.yaml
+++ b/charts/n8n/templates/statefulset-worker.yaml
@@ -401,6 +401,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
       {{- end }}

--- a/charts/n8n/templates/statefulset.yaml
+++ b/charts/n8n/templates/statefulset.yaml
@@ -391,6 +391,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
       {{- end }}

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -2094,6 +2094,11 @@
       "title": "tolerations",
       "type": "array"
     },
+    "priorityClassName": {
+      "description": "priorityClassName for the n8n pods",
+      "title": "priorityClassName",
+      "type": "string"
+    },
     "versionNotifications": {
       "additionalProperties": false,
       "properties": {
@@ -4875,6 +4880,7 @@
     "main",
     "nodeSelector",
     "tolerations",
+    "priorityClassName",
     "affinity",
     "dnsPolicy",
     "dnsConfig",

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -987,6 +987,9 @@ tolerations: []
 # -- DEPRECATED: Use main, worker, and webhook blocks volumes fields instead. This field will be removed in a future release.
 affinity: {}
 
+# -- priorityClassName for the n8n pods
+priorityClassName: ""
+
 # -- For more information checkout: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
 dnsPolicy: ""
 


### PR DESCRIPTION
## Summary

Add optional `priorityClassName` field to the n8n Deployment, StatefulSet, and worker StatefulSet pod specs.

This allows users to set a [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) on n8n pods, which is commonly required by Kyverno/OPA policies enforcing pod scheduling standards.

## Changes

- `charts/n8n/templates/deployment.yaml` — add `priorityClassName` block
- `charts/n8n/templates/statefulset.yaml` — add `priorityClassName` block
- `charts/n8n/templates/statefulset-worker.yaml` — add `priorityClassName` block
- `charts/n8n/values.yaml` — add `priorityClassName: ""` default

## Usage

```yaml
priorityClassName: "high-priority"
```