### PR TITLE
[cloudflared] make probes configurable

### DIFF
--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.7
+version: 2.2.8
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -57,6 +57,8 @@ annotations:
       links:
         - name: Upstream Project
           url: https://hub.docker.com/r/cloudflare/cloudflared
+    - kind: changed
+      description: Add configurable startup, readiness, and liveness probes for the cloudflared container
   artifacthub.io/images: |
     - name: cloudflared
       image: cloudflare/cloudflared:2026.2.0

--- a/charts/cloudflared/README.md
+++ b/charts/cloudflared/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for cloudflare tunnel
 
-![Version: 2.2.7](https://img.shields.io/badge/Version-2.2.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.2.0](https://img.shields.io/badge/AppVersion-2026.2.0-informational?style=flat-square)
+![Version: 2.2.8](https://img.shields.io/badge/Version-2.2.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.2.0](https://img.shields.io/badge/AppVersion-2026.2.0-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -163,11 +163,13 @@ helm upgrade [RELEASE_NAME] community-charts/cloudflared
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
 | ingress | list | `[{"hostname":"example.com","service":"http://traefik.kube-system.svc.cluster.local:80"},{"service":"http_status:404"}]` | Cloudflare ingress rules. More information can be found here: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/configure-tunnels/local-management/configuration-file/#how-traffic-is-matched |
+| livenessProbe | object | `{"enabled":true,"failureThreshold":3,"httpGet":{"path":"/ready","port":2000},"initialDelaySeconds":10,"periodSeconds":10,"timeoutSeconds":1}` | Liveness probe configuration for the cloudflared container. |
 | nameOverride | string | `""` | This is to override the chart name. |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | For more information checkout: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | podAnnotations | object | `{}` | This is for setting Kubernetes Annotations to a Pod. For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
 | podLabels | object | `{}` | This is for setting Kubernetes Labels to a Pod. For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ |
 | podSecurityContext | object | `{"fsGroup":65532,"fsGroupChangePolicy":"OnRootMismatch","sysctls":[{"name":"net.ipv4.ping_group_range","value":"0 2147483647"}]}` | This is for setting Security Context to a Pod. For more information checkout: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
+| readinessProbe | object | `{"enabled":true,"failureThreshold":3,"httpGet":{"path":"/ready","port":2000},"initialDelaySeconds":5,"periodSeconds":5,"timeoutSeconds":1}` | Readiness probe configuration for the cloudflared container. |
 | replica | object | `{"allNodes":true,"count":1}` | This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/ |
 | replica.allNodes | bool | `true` | This will use DaemonSet to deploy cloudflared to all nodes |
 | replica.count | int | `1` | If previous flag disabled, this will use Deployment to deploy cloudflared only number of following count |
@@ -178,6 +180,7 @@ helm upgrade [RELEASE_NAME] community-charts/cloudflared
 | serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials? |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| startupProbe | object | `{"enabled":true,"failureThreshold":12,"httpGet":{"path":"/ready","port":2000},"initialDelaySeconds":5,"periodSeconds":5,"timeoutSeconds":1}` | Startup probe configuration for the cloudflared container. |
 | terminationGracePeriodSeconds | int | `30` |  |
 | tolerations | list | `[{"effect":"NoSchedule","operator":"Exists"}]` | For more information checkout: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | tunnelConfig | object | `{"autoUpdateFrequency":"24h","connectTimeout":"30s","gracePeriod":"30s","logLevel":"info","metricsUpdateFrequency":"5s","name":"","noAutoUpdate":true,"protocol":"auto","retries":5,"transportLogLevel":"warn","warpRouting":false}` | Please find more configuration from https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/configuration/arguments/ |

--- a/charts/cloudflared/templates/deployment.yaml
+++ b/charts/cloudflared/templates/deployment.yaml
@@ -56,13 +56,18 @@ spec:
           env:
             - name: TUNNEL_ORIGIN_CERT
               value: {{ printf "/etc/cloudflared/creds/%s" (default "cert.pem" .Values.tunnelSecrets.existingPemFileSecret.key) | quote }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            {{- omit .Values.startupProbe "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
-            httpGet:
-              path: /ready
-              port: 2000
-            failureThreshold: 1
-            initialDelaySeconds: 10
-            periodSeconds: 10
+            {{- omit .Values.livenessProbe "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            {{- omit .Values.readinessProbe "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: /etc/cloudflared/config

--- a/charts/cloudflared/unittests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/cloudflared/unittests/__snapshot__/deployment_test.yaml.snap
@@ -45,17 +45,26 @@ should match snapshot of default values:
               image: cloudflare/cloudflared:1.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
-                failureThreshold: 1
+                failureThreshold: 3
                 httpGet:
                   path: /ready
                   port: 2000
                 initialDelaySeconds: 10
                 periodSeconds: 10
+                timeoutSeconds: 1
               name: cloudflared
               ports:
                 - containerPort: 2000
                   name: active-con-stat
                   protocol: TCP
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /ready
+                  port: 2000
+                initialDelaySeconds: 5
+                periodSeconds: 5
+                timeoutSeconds: 1
               resources: {}
               securityContext:
                 allowPrivilegeEscalation: false
@@ -68,6 +77,14 @@ should match snapshot of default values:
                 runAsGroup: 65532
                 runAsNonRoot: true
                 runAsUser: 65532
+              startupProbe:
+                failureThreshold: 12
+                httpGet:
+                  path: /ready
+                  port: 2000
+                initialDelaySeconds: 5
+                periodSeconds: 5
+                timeoutSeconds: 1
               volumeMounts:
                 - mountPath: /etc/cloudflared/config
                   name: config

--- a/charts/cloudflared/unittests/deployment_test.yaml
+++ b/charts/cloudflared/unittests/deployment_test.yaml
@@ -184,6 +184,61 @@ tests:
             value: /etc/cloudflared/creds/custom.pem
         template: deployment.yaml
 
+  - it: should set default startup, liveness, and readiness probes
+    set:
+      tunnelConfig:
+        name: unittest
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /ready
+        template: deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.port
+          value: 2000
+        template: deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 12
+        template: deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /ready
+        template: deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.failureThreshold
+          value: 3
+        template: deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /ready
+        template: deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
+          value: 3
+        template: deployment.yaml
+
+  - it: should allow disabling startup, liveness, and readiness probes
+    set:
+      tunnelConfig:
+        name: unittest
+      startupProbe:
+        enabled: false
+      livenessProbe:
+        enabled: false
+      readinessProbe:
+        enabled: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe
+        template: deployment.yaml
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe
+        template: deployment.yaml
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe
+        template: deployment.yaml
+
   - it: should match snapshot of default values
     set:
       tunnelConfig:

--- a/charts/cloudflared/values.schema.json
+++ b/charts/cloudflared/values.schema.json
@@ -62,6 +62,48 @@
       "title": "imagePullSecrets",
       "type": "array"
     },
+    "startupProbe": {
+      "additionalProperties": true,
+      "description": "Startup probe configuration for the cloudflared container.",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "title": "enabled",
+          "type": "boolean"
+        }
+      },
+      "required": ["enabled"],
+      "title": "startupProbe",
+      "type": "object"
+    },
+    "livenessProbe": {
+      "additionalProperties": true,
+      "description": "Liveness probe configuration for the cloudflared container.",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "title": "enabled",
+          "type": "boolean"
+        }
+      },
+      "required": ["enabled"],
+      "title": "livenessProbe",
+      "type": "object"
+    },
+    "readinessProbe": {
+      "additionalProperties": true,
+      "description": "Readiness probe configuration for the cloudflared container.",
+      "properties": {
+        "enabled": {
+          "default": true,
+          "title": "enabled",
+          "type": "boolean"
+        }
+      },
+      "required": ["enabled"],
+      "title": "readinessProbe",
+      "type": "object"
+    },
     "ingress": {
       "items": {
         "additionalProperties": false,

--- a/charts/cloudflared/values.yaml
+++ b/charts/cloudflared/values.yaml
@@ -126,6 +126,39 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+# -- Startup probe configuration for the cloudflared container.
+startupProbe:
+  enabled: true
+  httpGet:
+    path: /ready
+    port: 2000
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 1
+  failureThreshold: 12
+
+# -- Liveness probe configuration for the cloudflared container.
+livenessProbe:
+  enabled: true
+  httpGet:
+    path: /ready
+    port: 2000
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 1
+  failureThreshold: 3
+
+# -- Readiness probe configuration for the cloudflared container.
+readinessProbe:
+  enabled: true
+  httpGet:
+    path: /ready
+    port: 2000
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 1
+  failureThreshold: 3
+
 # -- For more information checkout: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
 nodeSelector:
   kubernetes.io/os: linux


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds configurable startup, liveness, and readiness probes to the cloudflared chart and relaxes the default liveness behavior to avoid unnecessary restarts during tunnel startup or QUIC reconnects.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

This change was motivated by cloudflared pods being restarted by kubelet after transient `/ready` 503 responses during tunnel warm-up.

Validation performed:
- `helm unittest --strict --update-snapshot --file 'unittests/**/*.yaml' charts/cloudflared`\n- `helm lint charts/cloudflared`\n\n#### Checklist\n- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed\n- [x] Chart Version bumped\n- [x] Chart `artifacthub.io/changes` field updated (if exists)\n- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)\n- [x] Unit tests written\n- [x] `values.yaml` file fields documented\n- [x] `README.md` file updated