### PR TITLE
[codex] fix mlflow gunicorn opts quoting

### DIFF
--- a/charts/mlflow/templates/deployment.yaml
+++ b/charts/mlflow/templates/deployment.yaml
@@ -321,17 +321,17 @@ spec:
           {{- else if .Values.ldapAuth.enabled }}
             - --app-name=basic-auth
           {{- end }}
-          {{- if and .Values.log.enabled (not (hasKey .Values.extraArgs "gunicornOpts")) }}
-            - {{ printf "--gunicorn-opts='--log-level=%s'" .Values.log.level }}
-          {{- end }}
-          {{- range $key, $value := .Values.extraArgs }}
-            {{- if and $.Values.log.enabled (eq $key "gunicornOpts") (contains "--log-level" $value) }}
-            - {{ printf "--gunicorn-opts='%s'" (regexReplaceAll "--log-level=[^\\s]*" $value (printf "--log-level=%s" $.Values.log.level)) }}
-            {{- else if and $.Values.log.enabled (eq $key "gunicornOpts") (not (contains "--log-level" $value)) }}
-            - {{ printf "--gunicorn-opts='--log-level=%s %s'" $.Values.log.level $value }}
-            {{- else }}
-            - {{ printf "--%s=%s" (kebabcase $key) $value }}
+            {{- if and .Values.log.enabled (not (hasKey .Values.extraArgs "gunicornOpts")) }}
+            - {{ printf "--gunicorn-opts=--log-level=%s" .Values.log.level }}
             {{- end }}
+            {{- range $key, $value := .Values.extraArgs }}
+              {{- if and $.Values.log.enabled (eq $key "gunicornOpts") (contains "--log-level" $value) }}
+            - {{ printf "--gunicorn-opts=%s" (regexReplaceAll "--log-level=[^\\s]*" $value (printf "--log-level=%s" $.Values.log.level)) }}
+              {{- else if and $.Values.log.enabled (eq $key "gunicornOpts") (not (contains "--log-level" $value)) }}
+            - {{ printf "--gunicorn-opts=--log-level=%s %s" $.Values.log.level $value }}
+              {{- else }}
+              - {{ printf "--%s=%s" (kebabcase $key) $value }}
+              {{- end }}
           {{- end }}
           {{- range .Values.extraFlags }}
             - --{{ kebabcase . }}


### PR DESCRIPTION
This fixes how the mlflow chart renders `extraArgs.gunicornOpts` in `charts/mlflow/templates/deployment.yaml`.

Today the template wraps the gunicorn options string in literal single quotes, for example rendering an argument like `--gunicorn-opts='--timeout=3600 --log-level=debug --keep-alive=600 --graceful-timeout=600'`. In Kubernetes container args those quotes are not interpreted by a shell; they are passed through as literal characters. That leads to `mlflow server` handing a malformed gunicorn options string to gunicorn, which then fails to parse values such as `--timeout` correctly and exits during startup.

This change removes those embedded shell quotes and keeps the existing `log.level` merge behavior intact. The chart still injects `log.level` into `gunicornOpts` when needed, but now it renders the resulting argument without quoting it as if it were being passed through a shell.

I reproduced the failure with the current rendering using a stock mlflow image, where gunicorn exits with `argument -t/--timeout: invalid int value`. I was not able to run the chart's full Helm render locally because dependency fetching for Bitnami charts was blocked from this environment, but the diff is limited to the mlflow deployment template and directly addresses the broken argument formatting.
