### PR TITLE
[mlflow] fix mlflow gunicorn opts quoting

### DIFF
--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.1
+version: 1.8.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -51,6 +51,8 @@ annotations:
       url: https://github.com/burakince/mlflow
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
+    - kind: fixed
+      description: Render gunicorn options without literal shell quotes
     - kind: changed
       description: Update burakince/mlflow image version to 3.7.0
       links:

--- a/charts/mlflow/templates/deployment.yaml
+++ b/charts/mlflow/templates/deployment.yaml
@@ -322,13 +322,13 @@ spec:
             - --app-name=basic-auth
           {{- end }}
           {{- if and .Values.log.enabled (not (hasKey .Values.extraArgs "gunicornOpts")) }}
-            - {{ printf "--gunicorn-opts='--log-level=%s'" .Values.log.level }}
+            - {{ printf "--gunicorn-opts=--log-level=%s" .Values.log.level | quote }}
           {{- end }}
           {{- range $key, $value := .Values.extraArgs }}
             {{- if and $.Values.log.enabled (eq $key "gunicornOpts") (contains "--log-level" $value) }}
-            - {{ printf "--gunicorn-opts='%s'" (regexReplaceAll "--log-level=[^\\s]*" $value (printf "--log-level=%s" $.Values.log.level)) }}
+            - {{ printf "--gunicorn-opts=%s" (regexReplaceAll "--log-level=[^\\s]*" $value (printf "--log-level=%s" $.Values.log.level)) | quote }}
             {{- else if and $.Values.log.enabled (eq $key "gunicornOpts") (not (contains "--log-level" $value)) }}
-            - {{ printf "--gunicorn-opts='--log-level=%s %s'" $.Values.log.level $value }}
+            - {{ printf "--gunicorn-opts=--log-level=%s %s" $.Values.log.level $value | quote }}
             {{- else }}
             - {{ printf "--%s=%s" (kebabcase $key) $value }}
             {{- end }}

--- a/charts/mlflow/unittests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/mlflow/unittests/__snapshot__/deployment_test.yaml.snap
@@ -55,7 +55,7 @@ should match snapshot of default values:
                 - --port=5000
                 - '--backend-store-uri=sqlite:///:memory:'
                 - --default-artifact-root=./mlruns
-                - --gunicorn-opts='--log-level=info'
+                - --gunicorn-opts=--log-level=info
               command:
                 - mlflow
               env:
@@ -259,7 +259,7 @@ should match snapshot with additional values:
                 - --backend-store-uri=postgresql://
                 - --default-artifact-root=./mlruns
                 - --app-name=basic-auth
-                - --gunicorn-opts='--log-level=info'
+                - --gunicorn-opts=--log-level=info
               command:
                 - mlflow
               env:
@@ -598,7 +598,7 @@ should match snapshot with additional values when auth and auth.postgres are ena
                 - --backend-store-uri=postgresql://
                 - --default-artifact-root=./mlruns
                 - --app-name=basic-auth
-                - --gunicorn-opts='--log-level=info'
+                - --gunicorn-opts=--log-level=info
               command:
                 - mlflow
               env:
@@ -954,7 +954,7 @@ should match snapshot with additional values when bitnami mysql is enabled:
                 - --backend-store-uri=mysql+pymysql://$(MYSQL_USERNAME):$(MYSQL_PWD)@$(MYSQL_HOST):$(MYSQL_TCP_PORT)/$(MYSQL_DATABASE)
                 - --default-artifact-root=./mlruns
                 - --app-name=basic-auth
-                - --gunicorn-opts='--log-level=info'
+                - --gunicorn-opts=--log-level=info
               command:
                 - mlflow
               env:
@@ -1313,7 +1313,7 @@ should match snapshot with additional values when bitnami postgresql is enabled:
                 - --backend-store-uri=postgresql://
                 - --default-artifact-root=./mlruns
                 - --app-name=basic-auth
-                - --gunicorn-opts='--log-level=info'
+                - --gunicorn-opts=--log-level=info
               command:
                 - mlflow
               env:
@@ -1677,7 +1677,7 @@ should match snapshot with additional values when mssql is enabled:
                 - --backend-store-uri=mssql+pymssql://$(MSSQL_USERNAME):$(MSSQL_PWD)@$(MSSQL_HOST):$(MSSQL_TCP_PORT)/$(MSSQL_DATABASE)
                 - --default-artifact-root=./mlruns
                 - --app-name=basic-auth
-                - --gunicorn-opts='--log-level=info'
+                - --gunicorn-opts=--log-level=info
               command:
                 - mlflow
               env:
@@ -2021,7 +2021,7 @@ should match snapshot with additional values when mysql is enabled:
                 - --backend-store-uri=mysql+pymysql://$(MYSQL_USERNAME):$(MYSQL_PWD)@$(MYSQL_HOST):$(MYSQL_TCP_PORT)/$(MYSQL_DATABASE)
                 - --default-artifact-root=./mlruns
                 - --app-name=basic-auth
-                - --gunicorn-opts='--log-level=info'
+                - --gunicorn-opts=--log-level=info
               command:
                 - mlflow
               env:
@@ -2360,7 +2360,7 @@ should match snapshot with additional values when postgresql is enabled:
                 - --backend-store-uri=postgresql://
                 - --default-artifact-root=./mlruns
                 - --app-name=basic-auth
-                - --gunicorn-opts='--log-level=info'
+                - --gunicorn-opts=--log-level=info
               command:
                 - mlflow
               env:

--- a/charts/mlflow/unittests/deployment_test.yaml
+++ b/charts/mlflow/unittests/deployment_test.yaml
@@ -315,7 +315,7 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.containers[?(@.name == "mlflow")].args
-          content: --gunicorn-opts='--log-level=debug'
+          content: --gunicorn-opts=--log-level=debug
         template: deployment.yaml
 
   - it: should set log level to gunicorn when log level is set and gunicornOpts is set without log level
@@ -328,7 +328,7 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.containers[?(@.name == "mlflow")].args
-          content: --gunicorn-opts='--log-level=debug --workers=4'
+          content: --gunicorn-opts=--log-level=debug --workers=4
         template: deployment.yaml
 
   - it: should set log level to gunicorn when log level is set and gunicornOpts is set with different log level
@@ -341,7 +341,7 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.containers[?(@.name == "mlflow")].args
-          content: --gunicorn-opts='--log-level=debug --workers=4'
+          content: --gunicorn-opts=--log-level=debug --workers=4
         template: deployment.yaml
 
   - it: should show extra arguments when we pass any


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR fixes how the `mlflow` chart renders `extraArgs.gunicornOpts` in `charts/mlflow/templates/deployment.yaml`.

The current template wraps gunicorn options in literal single quotes, for example `--gunicorn-opts='--timeout=3600 --log-level=debug --keep-alive=600 --graceful-timeout=600'`. In Kubernetes container args those quotes are passed as literal characters instead of being interpreted by a shell. That causes `mlflow server` to pass a malformed gunicorn options string downstream, and gunicorn then fails to parse options such as `--timeout`.

This change stops rendering `gunicornOpts` with embedded literal single quotes and keeps the argument as a single YAML string, while preserving the existing `log.level` merge behavior. It also bumps the chart version, updates the Artifact Hub changelog annotation, and updates the deployment unit tests and snapshots to match the new rendering.

This PR is related to #407 and #438, but fixes a different case. Those changes address how logging interacts with alternate server options such as `uvicornOpts` and `waitressOpts`. This PR addresses the remaining `gunicornOpts` case, where quoted gunicorn arguments still break parsing even when gunicorn is the intended server.

#### Error observed
When `extraArgs.gunicornOpts` contains multiple gunicorn options, mlflow startup fails with an error like:

```text
usage: gunicorn [OPTIONS] [APP_MODULE]
gunicorn: error: argument -t/--timeout: invalid int value: '3600 --log-level=debug --keep-alive=600 --graceful-timeout=600'
```

#### Steps to reproduce
1. Use the `mlflow` chart with `log.enabled=true` and set `extraArgs.gunicornOpts` to a multi-option value such as:
   ```yaml
   extraArgs:
     gunicornOpts: "--timeout=3600 --log-level=debug --keep-alive=600 --graceful-timeout=600"
   ```
2. Render or deploy the chart and inspect the generated container args.
3. Observe that the chart renders an argument similar to:
   ```text
   --gunicorn-opts='--timeout=3600 --log-level=debug --keep-alive=600 --graceful-timeout=600'
   ```
4. Start the container with that rendered argument.
5. Observe that gunicorn fails to parse the `--timeout` value and exits.

#### Which issue this PR fixes
Related to #407 and #438.

#### Special notes for your reviewer:
I reproduced the current failure against stock mlflow images, where gunicorn exits with `argument -t/--timeout: invalid int value` when the chart-rendered quoted argument is used. With this change, the same `--gunicorn-opts=...` value is passed as a single argv element without literal single quotes, and the parsing failure no longer reproduces.

#### Checklist
- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
