### PR TITLE
[mlflow]: skip gunicorn-opts injection when uvicornOpts is set

### DIFF
--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.1
+version: 1.8.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/mlflow/templates/deployment.yaml
+++ b/charts/mlflow/templates/deployment.yaml
@@ -321,7 +321,7 @@ spec:
           {{- else if .Values.ldapAuth.enabled }}
             - --app-name=basic-auth
           {{- end }}
-          {{- if and .Values.log.enabled (not (hasKey .Values.extraArgs "gunicornOpts")) }}
+          {{- if and .Values.log.enabled (not (hasKey .Values.extraArgs "gunicornOpts")) (not (hasKey .Values.extraArgs "uvicornOpts")) }}
             - {{ printf "--gunicorn-opts='--log-level=%s'" .Values.log.level }}
           {{- end }}
           {{- range $key, $value := .Values.extraArgs }}
@@ -329,6 +329,10 @@ spec:
             - {{ printf "--gunicorn-opts='%s'" (regexReplaceAll "--log-level=[^\\s]*" $value (printf "--log-level=%s" $.Values.log.level)) }}
             {{- else if and $.Values.log.enabled (eq $key "gunicornOpts") (not (contains "--log-level" $value)) }}
             - {{ printf "--gunicorn-opts='--log-level=%s %s'" $.Values.log.level $value }}
+            {{- else if and $.Values.log.enabled (eq $key "uvicornOpts") (contains "--log-level" $value) }}
+            - {{ printf "--uvicorn-opts='%s'" (regexReplaceAll "--log-level=[^\\s]*" $value (printf "--log-level=%s" $.Values.log.level)) }}
+            {{- else if and $.Values.log.enabled (eq $key "uvicornOpts") (not (contains "--log-level" $value)) }}
+            - {{ printf "--uvicorn-opts='--log-level=%s %s'" $.Values.log.level $value }}
             {{- else }}
             - {{ printf "--%s=%s" (kebabcase $key) $value }}
             {{- end }}

--- a/charts/mlflow/unittests/deployment_test.yaml
+++ b/charts/mlflow/unittests/deployment_test.yaml
@@ -344,6 +344,40 @@ tests:
           content: --gunicorn-opts='--log-level=debug --workers=4'
         template: deployment.yaml
 
+  - it: should not set gunicorn-opts when uvicornOpts is set
+    set:
+      log:
+        enabled: true
+        level: debug
+      extraArgs:
+        uvicornOpts: "--workers=4"
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[?(@.name == "mlflow")].args
+          content: --gunicorn-opts='--log-level=debug'
+        template: deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "mlflow")].args
+          content: --uvicorn-opts='--log-level=debug --workers=4'
+        template: deployment.yaml
+
+  - it: should set log level to uvicorn when log level is set and uvicornOpts is set with different log level
+    set:
+      log:
+        enabled: true
+        level: debug
+      extraArgs:
+        uvicornOpts: "--log-level=info --workers=4"
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[?(@.name == "mlflow")].args
+          content: --gunicorn-opts='--log-level=debug'
+        template: deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "mlflow")].args
+          content: --uvicorn-opts='--log-level=debug --workers=4'
+        template: deployment.yaml
+
   - it: should show extra arguments when we pass any
     set:
       extraArgs:


### PR DESCRIPTION
When using the official MLflow image with uvicorn, the chart incorrectly injects --gunicorn-opts when log.enabled=true, even if uvicornOpts is set in extraArgs.