### PR TITLE
[outline] Update outline chart to 1.7.1

### DIFF
--- a/charts/outline/Chart.lock
+++ b/charts/outline/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 23.2.12
+  version: 25.5.3
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 18.1.9
+  version: 18.6.8
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:c4ce652e7c6195943017d87d172a8e54b627b70eca138fd1be264a2ca33cf7bb
-generated: "2025-11-17T02:44:25.382943459Z"
+digest: sha256:93c86691cecda62721004395836e36d4fda9039ea2f2c5561114f264e5347dff
+generated: "2026-05-29T21:54:03.647795+02:00"

--- a/charts/outline/Chart.yaml
+++ b/charts/outline/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.3
+version: 0.7.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.1.0"
+appVersion: "1.6.1"
 kubeVersion: ">=1.23.0-0"
 home: https://www.getoutline.com/
 maintainers:
@@ -53,23 +53,18 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update outlinewiki/outline image version to 1.1.0
+      description: Update outlinewiki/outline image version to 1.6.1
       links:
         - name: Upstream Project
           url: https://hub.docker.com/r/outlinewiki/outline
-    - kind: changed
-      description: Update dependency redis from 23.2.2 to 23.2.12
+    - kind: fixed
+      description: Fix entrypoint script to use node instead of yarn (required since v1.2.0)
       links:
-        - name: ArtifactHub
-          url: https://artifacthub.io/packages/helm/bitnami/redis
-    - kind: changed
-      description: Update dependency postgresql from 18.1.3 to 18.1.9
-      links:
-        - name: ArtifactHub
-          url: https://artifacthub.io/packages/helm/bitnami/postgresql
+        - name: Upstream Release Notes
+          url: https://github.com/outline/outline/releases/tag/v1.2.0
   artifacthub.io/images: |
     - name: outline
-      image: outlinewiki/outline:1.1.0
+      image: outlinewiki/outline:1.6.1
       platforms:
         - linux/amd64
         - linux/arm64

--- a/charts/outline/Chart.yaml
+++ b/charts/outline/Chart.yaml
@@ -62,6 +62,16 @@ annotations:
       links:
         - name: Upstream Release Notes
           url: https://github.com/outline/outline/releases/tag/v1.2.0
+    - kind: changed
+      description: Update dependency redis from 23.2.12 to 25.5.3
+      links:
+        - name: ArtifactHub
+          url: https://artifacthub.io/packages/helm/bitnami/redis
+    - kind: changed
+      description: Update dependency postgresql from 18.1.9 to 18.6.8
+      links:
+        - name: ArtifactHub
+          url: https://artifacthub.io/packages/helm/bitnami/postgresql
   artifacthub.io/images: |
     - name: outline
       image: outlinewiki/outline:1.7.1
@@ -83,11 +93,11 @@ annotations:
     url: https://keybase.io/communitycharts/pgp_keys.asc
 dependencies:
   - name: redis
-    version: 23.2.12
+    version: 25.5.3
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: postgresql
-    version: 18.1.9
+    version: 18.6.8
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: minio

--- a/charts/outline/Chart.yaml
+++ b/charts/outline/Chart.yaml
@@ -19,7 +19,7 @@ version: 0.7.4
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.6.1"
+appVersion: "1.7.1"
 kubeVersion: ">=1.23.0-0"
 home: https://www.getoutline.com/
 maintainers:
@@ -53,7 +53,7 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update outlinewiki/outline image version to 1.6.1
+      description: Update outlinewiki/outline image version to 1.7.1
       links:
         - name: Upstream Project
           url: https://hub.docker.com/r/outlinewiki/outline
@@ -64,7 +64,7 @@ annotations:
           url: https://github.com/outline/outline/releases/tag/v1.2.0
   artifacthub.io/images: |
     - name: outline
-      image: outlinewiki/outline:1.6.1
+      image: outlinewiki/outline:1.7.1
       platforms:
         - linux/amd64
         - linux/arm64

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for the fastest knowledge base for growing teams. Beautiful, realtime collaborative, feature packed, and markdown compatible.
 
-![Version: 0.7.3](https://img.shields.io/badge/Version-0.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 0.7.4](https://img.shields.io/badge/Version-0.7.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.1](https://img.shields.io/badge/AppVersion-1.6.1-informational?style=flat-square)
 
 ## Official Documentation
 

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for the fastest knowledge base for growing teams. Beautiful, realtime collaborative, feature packed, and markdown compatible.
 
-![Version: 0.7.4](https://img.shields.io/badge/Version-0.7.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.1](https://img.shields.io/badge/AppVersion-1.6.1-informational?style=flat-square)
+![Version: 0.7.4](https://img.shields.io/badge/Version-0.7.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.1](https://img.shields.io/badge/AppVersion-1.7.1-informational?style=flat-square)
 
 ## Official Documentation
 

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -516,8 +516,8 @@ Kubernetes: `>=1.23.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 18.1.9 |
-| https://charts.bitnami.com/bitnami | redis | 23.2.12 |
+| https://charts.bitnami.com/bitnami | postgresql | 18.6.8 |
+| https://charts.bitnami.com/bitnami | redis | 25.5.3 |
 | https://charts.min.io/ | minio | 5.4.0 |
 
 ## Uninstall Helm Chart

--- a/charts/outline/files/entrypoint.sh
+++ b/charts/outline/files/entrypoint.sh
@@ -10,5 +10,5 @@ BASE64_JSON=$(echo -n "$JSON" | base64)
 # Set the REDIS_URL environment variable. You can find more information about REDIS_URL [here](https://docs.getoutline.com/s/hosting/doc/redis-LGM4BFXYp4#h-advanced)
 export REDIS_URL="ioredis://$BASE64_JSON"
 
-# Execute the original command (yarn start)
-exec yarn start
+# Execute the original command
+exec node build/server/index.js

--- a/charts/outline/unittests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/outline/unittests/__snapshot__/configmap_test.yaml.snap
@@ -15,8 +15,8 @@ should match snapshot of default values:
         # Set the REDIS_URL environment variable. You can find more information about REDIS_URL [here](https://docs.getoutline.com/s/hosting/doc/redis-LGM4BFXYp4#h-advanced)
         export REDIS_URL="ioredis://$BASE64_JSON"
 
-        # Execute the original command (yarn start)
-        exec yarn start
+        # Execute the original command
+        exec node build/server/index.js
     kind: ConfigMap
     metadata:
       labels:

--- a/charts/outline/unittests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/outline/unittests/__snapshot__/deployment_test.yaml.snap
@@ -50,7 +50,7 @@ should match snapshot of default values:
       template:
         metadata:
           annotations:
-            checksum/config: 52b4c94af9c3e1eb23b0391ff13115d7b3328cc1271a67be91c19eac87d78e93
+            checksum/config: e64d33fc0d26ff94e6fbec04ebe470993b7f2b781e2f0ac8d54de1b5e23ee347
             checksum/secret: c9f56502fc6d865fa60d33519aa2d0f897bea71d2af7c35aa4b71a1fa9e70e50
           labels:
             app.kubernetes.io/instance: outline

--- a/charts/outline/unittests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/outline/unittests/__snapshot__/deployment_test.yaml.snap
@@ -15,8 +15,8 @@ should match snapshot of default values:
         # Set the REDIS_URL environment variable. You can find more information about REDIS_URL [here](https://docs.getoutline.com/s/hosting/doc/redis-LGM4BFXYp4#h-advanced)
         export REDIS_URL="ioredis://$BASE64_JSON"
 
-        # Execute the original command (yarn start)
-        exec yarn start
+        # Execute the original command
+        exec node build/server/index.js
     kind: ConfigMap
     metadata:
       labels:


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the outline chart to use the latest image version 1.6.1 from outlinewiki/outline, and fixes a broken entrypoint that has caused the chart to fail since v1.2.0.

Since v1.2.0, outline no longer uses yarn to start the server (see [release notes](https://github.com/outline/outline/releases/tag/v1.2.0)). The entrypoint script was still calling `exec yarn start`, which fails with:
> `error This project's package.json defines "packageManager": "yarn@4.x.x". However the current global version of Yarn is 1.22.x.`

This replaces it with `exec node build/server/index.js`.

This supersedes #422.

#### Which issue this PR fixes

- fixes #422 (supersedes)
- fixes #387 (supersedes)
- fixes #404 (supersedes)
- fixes  #372
- fixes #452

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[outline]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated