### PR TITLE
[n8n] Remove deprecated N8N_RUNNERS_ENABLED env var

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.16.41
+version: 1.16.42
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -50,16 +50,11 @@ annotations:
       url: https://docs.n8n.io/
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
-    - kind: changed
-      description: Update n8nio/n8n image version to 2.21.4
+    - kind: removed
+      description: Remove deprecated N8N_RUNNERS_ENABLED environment variable
       links:
-        - name: Upstream Project
-          url: https://github.com/n8n-io/n8n
-    - kind: changed
-      description: Update dependency postgresql from 18.6.4 to 18.6.7
-      links:
-        - name: ArtifactHub
-          url: https://artifacthub.io/packages/helm/bitnami/postgresql
+        - name: Upstream deprecation
+          url: https://github.com/n8n-io/n8n/blob/master/packages/cli/src/deprecation/deprecation.service.ts
   artifacthub.io/images: |
     - name: n8n
       image: n8nio/n8n:2.21.4

--- a/charts/n8n/templates/configmap.yaml
+++ b/charts/n8n/templates/configmap.yaml
@@ -191,7 +191,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  N8N_RUNNERS_ENABLED: "true"
   N8N_RUNNERS_MODE: {{ .Values.taskRunners.mode | quote }}
   N8N_RUNNERS_TASK_TIMEOUT: {{ .Values.taskRunners.taskTimeout | quote }}
   N8N_RUNNERS_HEARTBEAT_INTERVAL: {{ .Values.taskRunners.taskHeartbeatInterval | quote }}

--- a/charts/n8n/templates/deployment-mcp-webhook.yaml
+++ b/charts/n8n/templates/deployment-mcp-webhook.yaml
@@ -143,8 +143,6 @@ spec:
                   name: {{ default (include "n8n.redis.fullname" .) .Values.externalRedis.existingSecret }}
                   key: redis-password
                   optional: true
-            - name: N8N_RUNNERS_ENABLED
-              value: "true"
             - name: N8N_RUNNERS_MODE
               value: internal
             - name: N8N_RUNNERS_TASK_TIMEOUT

--- a/charts/n8n/templates/deployment-webhook.yaml
+++ b/charts/n8n/templates/deployment-webhook.yaml
@@ -156,8 +156,6 @@ spec:
                   name: {{ default (include "n8n.redis.fullname" .) .Values.externalRedis.existingSecret }}
                   key: redis-password
                   optional: true
-            - name: N8N_RUNNERS_ENABLED
-              value: "true"
             - name: N8N_RUNNERS_MODE
               value: internal
             - name: N8N_RUNNERS_TASK_TIMEOUT

--- a/charts/n8n/unittests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/n8n/unittests/__snapshot__/configmap_test.yaml.snap
@@ -85,7 +85,6 @@ should match snapshot of default values:
   7: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal
@@ -245,7 +244,6 @@ should match snapshot of external redis values:
   8: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal

--- a/charts/n8n/unittests/__snapshot__/deployment-mcp-webhook_test.yaml.snap
+++ b/charts/n8n/unittests/__snapshot__/deployment-mcp-webhook_test.yaml.snap
@@ -113,7 +113,6 @@ should match snapshot of postgres ssl certificate values:
   8: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal
@@ -190,7 +189,7 @@ should match snapshot of postgres ssl certificate values:
       template:
         metadata:
           annotations:
-            checksum/config: 9275478349b0d1960495024022e4b3e64e5681684b296cdd8cf49b9267e20bcd
+            checksum/config: 4727cd142b645f30aeffe516e758ffc38de909f8ab2a0b8ea9df8410cd049e9a
           labels:
             app.kubernetes.io/component: mcp
             app.kubernetes.io/instance: n8n
@@ -244,8 +243,6 @@ should match snapshot of postgres ssl certificate values:
                       key: redis-password
                       name: n8n-redis
                       optional: true
-                - name: N8N_RUNNERS_ENABLED
-                  value: "true"
                 - name: N8N_RUNNERS_MODE
                   value: internal
                 - name: N8N_RUNNERS_TASK_TIMEOUT

--- a/charts/n8n/unittests/__snapshot__/deployment-webhook_test.yaml.snap
+++ b/charts/n8n/unittests/__snapshot__/deployment-webhook_test.yaml.snap
@@ -113,7 +113,6 @@ should match snapshot of postgres ssl certificate values:
   8: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal
@@ -190,7 +189,7 @@ should match snapshot of postgres ssl certificate values:
       template:
         metadata:
           annotations:
-            checksum/config: 9275478349b0d1960495024022e4b3e64e5681684b296cdd8cf49b9267e20bcd
+            checksum/config: 4727cd142b645f30aeffe516e758ffc38de909f8ab2a0b8ea9df8410cd049e9a
           labels:
             app.kubernetes.io/component: webhook
             app.kubernetes.io/instance: n8n
@@ -244,8 +243,6 @@ should match snapshot of postgres ssl certificate values:
                       key: redis-password
                       name: n8n-redis
                       optional: true
-                - name: N8N_RUNNERS_ENABLED
-                  value: "true"
                 - name: N8N_RUNNERS_MODE
                   value: internal
                 - name: N8N_RUNNERS_TASK_TIMEOUT

--- a/charts/n8n/unittests/__snapshot__/deployment-worker_test.yaml.snap
+++ b/charts/n8n/unittests/__snapshot__/deployment-worker_test.yaml.snap
@@ -108,7 +108,6 @@ should match snapshot of default values:
   8: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal
@@ -185,7 +184,7 @@ should match snapshot of default values:
       template:
         metadata:
           annotations:
-            checksum/config: 8fb61eb0cf816a99cea6e26773cc00fa42056beb9d2646773c831ae2f64bec08
+            checksum/config: 1fdf11eb48bae65b75c42cf6d75185deb07be0222676c36508cd656a8beb1601
           labels:
             app.kubernetes.io/component: worker
             app.kubernetes.io/instance: n8n
@@ -461,7 +460,6 @@ should match snapshot of postgres ssl certificate values:
   8: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal
@@ -538,7 +536,7 @@ should match snapshot of postgres ssl certificate values:
       template:
         metadata:
           annotations:
-            checksum/config: 4b91f5a9264f8a417ef03702235da2bf32fdbb10f4520969f8c1381184c7d4d2
+            checksum/config: 161b5c213ae64dd2e15a005be7ffa3cb001fa4b6ac005af1c977c150a68b78a4
           labels:
             app.kubernetes.io/component: worker
             app.kubernetes.io/instance: n8n
@@ -842,7 +840,6 @@ should match snapshot of worker persistence:
   8: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal
@@ -919,7 +916,7 @@ should match snapshot of worker persistence:
       template:
         metadata:
           annotations:
-            checksum/config: 8fb61eb0cf816a99cea6e26773cc00fa42056beb9d2646773c831ae2f64bec08
+            checksum/config: 1fdf11eb48bae65b75c42cf6d75185deb07be0222676c36508cd656a8beb1601
           labels:
             app.kubernetes.io/component: worker
             app.kubernetes.io/instance: n8n

--- a/charts/n8n/unittests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/n8n/unittests/__snapshot__/deployment_test.yaml.snap
@@ -85,7 +85,6 @@ should match snapshot of default values:
   7: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal
@@ -161,7 +160,7 @@ should match snapshot of default values:
       template:
         metadata:
           annotations:
-            checksum/config: ebb640e853e11410aa426741a83e301290fcfa10987f5e8a3e7d2cb8a84eb4c8
+            checksum/config: fc9799ad2ff7266b11a1422e4886d8f41ba893b4e4f24079a667238037ee9667
           labels:
             app.kubernetes.io/component: main
             app.kubernetes.io/instance: n8n
@@ -343,7 +342,6 @@ should match snapshot of main persistence:
   7: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal
@@ -419,7 +417,7 @@ should match snapshot of main persistence:
       template:
         metadata:
           annotations:
-            checksum/config: ebb640e853e11410aa426741a83e301290fcfa10987f5e8a3e7d2cb8a84eb4c8
+            checksum/config: fc9799ad2ff7266b11a1422e4886d8f41ba893b4e4f24079a667238037ee9667
           labels:
             app.kubernetes.io/component: main
             app.kubernetes.io/instance: n8n
@@ -609,7 +607,6 @@ should match snapshot of main persistence with multiple main node and mode read 
   7: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal
@@ -685,7 +682,7 @@ should match snapshot of main persistence with multiple main node and mode read 
       template:
         metadata:
           annotations:
-            checksum/config: ebb640e853e11410aa426741a83e301290fcfa10987f5e8a3e7d2cb8a84eb4c8
+            checksum/config: fc9799ad2ff7266b11a1422e4886d8f41ba893b4e4f24079a667238037ee9667
           labels:
             app.kubernetes.io/component: main
             app.kubernetes.io/instance: n8n
@@ -887,7 +884,6 @@ should match snapshot of postgres ssl certificate values:
   7: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal
@@ -963,7 +959,7 @@ should match snapshot of postgres ssl certificate values:
       template:
         metadata:
           annotations:
-            checksum/config: b9968f93f265e5024a55c0d954ae1ab89d083de575b8bb39815245d357f8cc85
+            checksum/config: 4db2178b5cd47bd137334fb0cf833a9cc35ab8b9816f990f7b7b12fc55d0eb3a
           labels:
             app.kubernetes.io/component: main
             app.kubernetes.io/instance: n8n

--- a/charts/n8n/unittests/__snapshot__/statefulset-worker_test.yaml.snap
+++ b/charts/n8n/unittests/__snapshot__/statefulset-worker_test.yaml.snap
@@ -108,7 +108,6 @@ should match snapshot of default values:
   8: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal
@@ -226,7 +225,7 @@ should match snapshot of default values:
       template:
         metadata:
           annotations:
-            checksum/config: 8fb61eb0cf816a99cea6e26773cc00fa42056beb9d2646773c831ae2f64bec08
+            checksum/config: 1fdf11eb48bae65b75c42cf6d75185deb07be0222676c36508cd656a8beb1601
           labels:
             app.kubernetes.io/component: worker
             app.kubernetes.io/instance: n8n
@@ -472,7 +471,6 @@ should match snapshot of postgres ssl certificate values:
   8: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal
@@ -590,7 +588,7 @@ should match snapshot of postgres ssl certificate values:
       template:
         metadata:
           annotations:
-            checksum/config: 4b91f5a9264f8a417ef03702235da2bf32fdbb10f4520969f8c1381184c7d4d2
+            checksum/config: 161b5c213ae64dd2e15a005be7ffa3cb001fa4b6ac005af1c977c150a68b78a4
           labels:
             app.kubernetes.io/component: worker
             app.kubernetes.io/instance: n8n
@@ -863,7 +861,6 @@ should match snapshot of worker persistence:
   8: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal

--- a/charts/n8n/unittests/__snapshot__/statefulset_test.yaml.snap
+++ b/charts/n8n/unittests/__snapshot__/statefulset_test.yaml.snap
@@ -85,7 +85,6 @@ should match snapshot of default values:
   7: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal
@@ -175,7 +174,7 @@ should match snapshot of default values:
       template:
         metadata:
           annotations:
-            checksum/config: ebb640e853e11410aa426741a83e301290fcfa10987f5e8a3e7d2cb8a84eb4c8
+            checksum/config: fc9799ad2ff7266b11a1422e4886d8f41ba893b4e4f24079a667238037ee9667
           labels:
             app.kubernetes.io/component: main
             app.kubernetes.io/instance: n8n
@@ -366,7 +365,6 @@ should match snapshot of postgres ssl certificate values:
   7: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal
@@ -469,7 +467,7 @@ should match snapshot of postgres ssl certificate values:
       template:
         metadata:
           annotations:
-            checksum/config: b9968f93f265e5024a55c0d954ae1ab89d083de575b8bb39815245d357f8cc85
+            checksum/config: 4db2178b5cd47bd137334fb0cf833a9cc35ab8b9816f990f7b7b12fc55d0eb3a
           labels:
             app.kubernetes.io/component: main
             app.kubernetes.io/instance: n8n

--- a/charts/n8n/unittests/configmap_test.yaml
+++ b/charts/n8n/unittests/configmap_test.yaml
@@ -879,9 +879,6 @@ tests:
       value: n8n-task-broker-configmap
     asserts:
       - equal:
-          path: data.N8N_RUNNERS_ENABLED
-          value: "true"
-      - equal:
           path: data.N8N_RUNNERS_MODE
           value: internal
 

--- a/charts/n8n/unittests/deployment-mcp-webhook_test.yaml
+++ b/charts/n8n/unittests/deployment-mcp-webhook_test.yaml
@@ -772,15 +772,6 @@ tests:
             value: n8nextraenvvar
         template: deployment-mcp-webhook.yaml
 
-  - it: should set n8n runners enabled environment variable
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[?(@.name == "n8n-mcp-webhook")].env
-          content:
-            name: N8N_RUNNERS_ENABLED
-            value: "true"
-        template: deployment-mcp-webhook.yaml
-
   - it: should set n8n runners mode environment variable
     asserts:
       - contains:
@@ -1220,15 +1211,6 @@ tests:
             key: fake-key
             operator: fake-operator
             value: fake-value
-        template: deployment-mcp-webhook.yaml
-
-  - it: should set task runner enabled environment variable
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[?(@.name == "n8n-mcp-webhook")].env
-          content:
-            name: N8N_RUNNERS_ENABLED
-            value: "true"
         template: deployment-mcp-webhook.yaml
 
   - it: should set task runner mode environment variable

--- a/charts/n8n/unittests/deployment-webhook_test.yaml
+++ b/charts/n8n/unittests/deployment-webhook_test.yaml
@@ -766,15 +766,6 @@ tests:
             value: n8nextraenvvar
         template: deployment-webhook.yaml
 
-  - it: should set n8n runners enabled environment variable
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[?(@.name == "n8n-webhook")].env
-          content:
-            name: N8N_RUNNERS_ENABLED
-            value: "true"
-        template: deployment-webhook.yaml
-
   - it: should set n8n runners mode environment variable
     asserts:
       - contains:
@@ -1210,15 +1201,6 @@ tests:
             key: fake-key
             operator: fake-operator
             value: fake-value
-        template: deployment-webhook.yaml
-
-  - it: should set task runner enabled environment variable
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[?(@.name == "n8n-webhook")].env
-          content:
-            name: N8N_RUNNERS_ENABLED
-            value: "true"
         template: deployment-webhook.yaml
 
   - it: should set task runner mode environment variable


### PR DESCRIPTION
Removes the deprecated `N8N_RUNNERS_ENABLED` environment variable, which the n8n upstream marks as `SAFE_TO_REMOVE` since task runners have been default-on since n8n v1.69.0. Setting this variable produces a deprecation warning on every pod startup that chart users cannot suppress without forking.

#### What this PR does / why we need it
- Removes the unused `N8N_RUNNERS_ENABLED: "true"` from the `task-broker-configmap` (consumed by `main` and `worker`) and the inline env block of `webhook` and `mcpWebhook` deployments.
- Eliminates the startup warning: `N8N_RUNNERS_ENABLED -> Remove this environment variable; it is no longer needed.`
- Aligns the chart with the upstream n8n recommendation: https://github.com/n8n-io/n8n/blob/master/packages/cli/src/deprecation/deprecation.service.ts

#### Changes
- Remove `N8N_RUNNERS_ENABLED` from `charts/n8n/templates/configmap.yaml` (task-broker-configmap).
- Remove `N8N_RUNNERS_ENABLED` from `charts/n8n/templates/deployment-webhook.yaml`.
- Remove `N8N_RUNNERS_ENABLED` from `charts/n8n/templates/deployment-mcp-webhook.yaml`.
- Update affected unit tests in `configmap_test.yaml`, `deployment-webhook_test.yaml`, `deployment-mcp-webhook_test.yaml`.
- Regenerate snapshots for `configmap`, `deployment`, `deployment-worker`, `deployment-webhook`, `deployment-mcp-webhook`, `statefulset`, `statefulset-worker`.
- Bump chart version from `1.16.41` to `1.16.42`.
- Update `artifacthub.io/changes`.

#### Which issue this PR fixes
- fixes #474

#### Special notes for your reviewer
- Run tests with: `helm unittest --strict -f 'unittests/*_test.yaml' charts/n8n`
- All 767 unit tests pass and 219 snapshots verified.
- This is a backwards-compatible patch: the variable being unset has no effect on any n8n version supported by this chart (task runners are default-on since 1.69.0; chart `appVersion` is 2.21.4).
- The other `N8N_RUNNERS_*` variables (`MODE`, `TASK_TIMEOUT`, etc.) are left untouched — they still affect `main`/`worker` behavior. Only the redundant `_ENABLED` flag is removed.

#### Checklist
- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written/updated
- [x] `values.yaml` file fields documented (no new fields)
- [x] `README.md` file updated (no changes required — `helm-docs` regenerates from `values.yaml`)