### PR TITLE
[n8n] Update n8n chart to 2.22.6

### DIFF
--- a/charts/n8n/Chart.lock
+++ b/charts/n8n/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 25.5.3
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 18.6.8
+  version: 18.7.0
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:93c86691cecda62721004395836e36d4fda9039ea2f2c5561114f264e5347dff
-generated: "2026-05-29T02:44:16.370397042Z"
+digest: sha256:edb69562e55be360f3a25ca280902f68be38a5e8b1b83a213122bd8bcd07b655
+generated: "2026-06-02T02:47:36.002771349Z"

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.16.44
+version: 1.16.45
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.22.5"
+appVersion: "2.22.6"
 kubeVersion: ">=1.23.0-0"
 home: https://n8n.io
 maintainers:
@@ -51,18 +51,18 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update n8nio/n8n image version to 2.22.5
+      description: Update n8nio/n8n image version to 2.22.6
       links:
         - name: Upstream Project
           url: https://github.com/n8n-io/n8n
     - kind: changed
-      description: Update dependency postgresql from 18.6.7 to 18.6.8
+      description: Update dependency postgresql from 18.6.8 to 18.7.0
       links:
         - name: ArtifactHub
           url: https://artifacthub.io/packages/helm/bitnami/postgresql
   artifacthub.io/images: |
     - name: n8n
-      image: n8nio/n8n:2.22.5
+      image: n8nio/n8n:2.22.6
       platforms:
         - linux/amd64
         - linux/arm64
@@ -118,7 +118,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: postgresql
-    version: 18.6.8
+    version: 18.7.0
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: minio

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.16.44](https://img.shields.io/badge/Version-1.16.44-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.22.5](https://img.shields.io/badge/AppVersion-2.22.5-informational?style=flat-square)
+![Version: 1.16.45](https://img.shields.io/badge/Version-1.16.45-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.22.6](https://img.shields.io/badge/AppVersion-2.22.6-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -891,7 +891,7 @@ Kubernetes: `>=1.23.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 18.6.8 |
+| https://charts.bitnami.com/bitnami | postgresql | 18.7.0 |
 | https://charts.bitnami.com/bitnami | redis | 25.5.3 |
 | https://charts.min.io/ | minio | 5.4.0 |
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the n8n chart to use the latest image version 2.22.6 from n8nio/n8n. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated