### PR TITLE
[outline] Update outline chart to 1.8.0

### DIFF
--- a/charts/outline/Chart.lock
+++ b/charts/outline/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 25.5.3
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 18.6.8
+  version: 18.7.0
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:93c86691cecda62721004395836e36d4fda9039ea2f2c5561114f264e5347dff
-generated: "2026-05-29T21:54:03.647795+02:00"
+digest: sha256:edb69562e55be360f3a25ca280902f68be38a5e8b1b83a213122bd8bcd07b655
+generated: "2026-06-02T02:49:32.160966444Z"

--- a/charts/outline/Chart.yaml
+++ b/charts/outline/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.4
+version: 0.7.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.7.1"
+appVersion: "1.8.0"
 kubeVersion: ">=1.23.0-0"
 home: https://www.getoutline.com/
 maintainers:
@@ -53,28 +53,18 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update outlinewiki/outline image version to 1.7.1
+      description: Update outlinewiki/outline image version to 1.8.0
       links:
         - name: Upstream Project
           url: https://hub.docker.com/r/outlinewiki/outline
-    - kind: fixed
-      description: Fix entrypoint script to use node instead of yarn (required since v1.2.0)
-      links:
-        - name: Upstream Release Notes
-          url: https://github.com/outline/outline/releases/tag/v1.2.0
     - kind: changed
-      description: Update dependency redis from 23.2.12 to 25.5.3
-      links:
-        - name: ArtifactHub
-          url: https://artifacthub.io/packages/helm/bitnami/redis
-    - kind: changed
-      description: Update dependency postgresql from 18.1.9 to 18.6.8
+      description: Update dependency postgresql from 18.6.8 to 18.7.0
       links:
         - name: ArtifactHub
           url: https://artifacthub.io/packages/helm/bitnami/postgresql
   artifacthub.io/images: |
     - name: outline
-      image: outlinewiki/outline:1.7.1
+      image: outlinewiki/outline:1.8.0
       platforms:
         - linux/amd64
         - linux/arm64
@@ -97,7 +87,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: postgresql
-    version: 18.6.8
+    version: 18.7.0
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: minio

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for the fastest knowledge base for growing teams. Beautiful, realtime collaborative, feature packed, and markdown compatible.
 
-![Version: 0.7.4](https://img.shields.io/badge/Version-0.7.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.1](https://img.shields.io/badge/AppVersion-1.7.1-informational?style=flat-square)
+![Version: 0.7.5](https://img.shields.io/badge/Version-0.7.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -516,7 +516,7 @@ Kubernetes: `>=1.23.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 18.6.8 |
+| https://charts.bitnami.com/bitnami | postgresql | 18.7.0 |
 | https://charts.bitnami.com/bitnami | redis | 25.5.3 |
 | https://charts.min.io/ | minio | 5.4.0 |
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the outline chart to use the latest image version 1.8.0 from outlinewiki/outline. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated