### PR TITLE
[n8n] Update n8n chart to 2.23.2

### DIFF
--- a/charts/n8n/Chart.lock
+++ b/charts/n8n/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 25.5.3
+  version: 27.0.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 18.7.0
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:edb69562e55be360f3a25ca280902f68be38a5e8b1b83a213122bd8bcd07b655
-generated: "2026-06-02T02:47:36.002771349Z"
+digest: sha256:3dbb185e2349753d1fc8aca2ed00c83fc74b6fc3b3ce2edbd6e7b783e6837bee
+generated: "2026-06-02T19:33:40.803904063Z"

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.16.45
+version: 1.16.46
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.22.6"
+appVersion: "2.23.2"
 kubeVersion: ">=1.23.0-0"
 home: https://n8n.io
 maintainers:
@@ -51,18 +51,18 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update n8nio/n8n image version to 2.22.6
+      description: Update n8nio/n8n image version to 2.23.2
       links:
         - name: Upstream Project
           url: https://github.com/n8n-io/n8n
     - kind: changed
-      description: Update dependency postgresql from 18.6.8 to 18.7.0
+      description: Update dependency redis from 25.5.3 to 27.0.0
       links:
         - name: ArtifactHub
-          url: https://artifacthub.io/packages/helm/bitnami/postgresql
+          url: https://artifacthub.io/packages/helm/bitnami/redis
   artifacthub.io/images: |
     - name: n8n
-      image: n8nio/n8n:2.22.6
+      image: n8nio/n8n:2.23.2
       platforms:
         - linux/amd64
         - linux/arm64
@@ -114,7 +114,7 @@ annotations:
     url: https://keybase.io/communitycharts/pgp_keys.asc
 dependencies:
   - name: redis
-    version: 25.5.3
+    version: 27.0.0
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: postgresql

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.16.45](https://img.shields.io/badge/Version-1.16.45-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.22.6](https://img.shields.io/badge/AppVersion-2.22.6-informational?style=flat-square)
+![Version: 1.16.46](https://img.shields.io/badge/Version-1.16.46-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.23.2](https://img.shields.io/badge/AppVersion-2.23.2-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -892,7 +892,7 @@ Kubernetes: `>=1.23.0-0`
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.bitnami.com/bitnami | postgresql | 18.7.0 |
-| https://charts.bitnami.com/bitnami | redis | 25.5.3 |
+| https://charts.bitnami.com/bitnami | redis | 27.0.0 |
 | https://charts.min.io/ | minio | 5.4.0 |
 
 ## Uninstall Helm Chart


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the n8n chart to use the latest image version 2.23.2 from n8nio/n8n. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated