### PR TITLE
[outline] Update outline chart to 1.8.1

### DIFF
--- a/charts/outline/Chart.lock
+++ b/charts/outline/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 25.5.3
+  version: 27.0.4
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 18.7.0
+  version: 18.7.2
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:edb69562e55be360f3a25ca280902f68be38a5e8b1b83a213122bd8bcd07b655
-generated: "2026-06-02T02:49:32.160966444Z"
+digest: sha256:4815fff98b711c231c950f98fdfd32fd9505d8f6a8aa62be5ac8a873585fa0d4
+generated: "2026-06-07T12:19:59.285170882Z"

--- a/charts/outline/Chart.yaml
+++ b/charts/outline/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 0.8.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.8.0"
+appVersion: "1.8.1"
 kubeVersion: ">=1.23.0-0"
 home: https://www.getoutline.com/
 maintainers:
@@ -51,12 +51,25 @@ annotations:
     - name: Official Hosting Documentation
       url: https://docs.getoutline.com/s/hosting/
   artifacthub.io/containsSecurityUpdates: "false"
-  artifacthub.io/changes: |
-    - kind: added
-      description: Support setting custom labels on the local persistence pvc
+  artifacthub.io/changes: |-
+    - kind: changed
+      description: Update outlinewiki/outline image version to 1.8.1
+      links:
+        - name: Upstream Project
+          url: https://hub.docker.com/r/outlinewiki/outline
+    - kind: changed
+      description: Update dependency redis from 25.5.3 to 27.0.4
+      links:
+        - name: ArtifactHub
+          url: https://artifacthub.io/packages/helm/bitnami/redis
+    - kind: changed
+      description: Update dependency postgresql from 18.7.0 to 18.7.2
+      links:
+        - name: ArtifactHub
+          url: https://artifacthub.io/packages/helm/bitnami/postgresql
   artifacthub.io/images: |
     - name: outline
-      image: outlinewiki/outline:1.8.0
+      image: outlinewiki/outline:1.8.1
       platforms:
         - linux/amd64
         - linux/arm64
@@ -75,11 +88,11 @@ annotations:
     url: https://keybase.io/communitycharts/pgp_keys.asc
 dependencies:
   - name: redis
-    version: 25.5.3
+    version: 27.0.4
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: postgresql
-    version: 18.7.0
+    version: 18.7.2
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: minio

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for the fastest knowledge base for growing teams. Beautiful, realtime collaborative, feature packed, and markdown compatible.
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
+![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.1](https://img.shields.io/badge/AppVersion-1.8.1-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -516,8 +516,8 @@ Kubernetes: `>=1.23.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 18.7.0 |
-| https://charts.bitnami.com/bitnami | redis | 25.5.3 |
+| https://charts.bitnami.com/bitnami | postgresql | 18.7.2 |
+| https://charts.bitnami.com/bitnami | redis | 27.0.4 |
 | https://charts.min.io/ | minio | 5.4.0 |
 
 ## Uninstall Helm Chart

--- a/charts/outline/templates/deployment.yaml
+++ b/charts/outline/templates/deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "outline.fullname" . }}
+  annotations:
+    ignore-check.kube-linter.io/read-secret-from-env-var: "Outline reads secrets via environment variables; the application does not support file-based secret loading"
   labels:
     {{- include "outline.labels" . | nindent 4 }}
 spec:

--- a/charts/outline/unittests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/outline/unittests/__snapshot__/deployment_test.yaml.snap
@@ -29,6 +29,8 @@ should match snapshot of default values:
     apiVersion: apps/v1
     kind: Deployment
     metadata:
+      annotations:
+        ignore-check.kube-linter.io/read-secret-from-env-var: Outline reads secrets via environment variables; the application does not support file-based secret loading
       labels:
         app.kubernetes.io/instance: outline
         app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the outline chart to use the latest image version 1.8.1 from outlinewiki/outline. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated