### PR TITLE
[n8n] Fix task runner deprecation warning, wrong runner image, and queue mode sidecar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,7 @@ charts/<name>/
 - `appVersion` tracks the upstream application version.
 - Breaking changes bump MAJOR version and must document manual upgrade steps in `README.md.gotmpl` under an "Upgrading" section.
 - The `artifacthub.io/changes` annotation in `Chart.yaml` is used to auto-generate release notes — always populate it for every change.
+- **Bump `version` only once per branch/PR.** After the first bump, do not bump again for subsequent commits on the same branch — all changes in the PR are released together under the single bumped version.
 
 ### CI Pipeline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a community Helm chart repository hosting production-grade Kubernetes charts for: `actualbudget`, `cloudflared`, `drone`, `kserve`, `mlflow`, `n8n`, `outline`, and `pypiserver`. Charts are published to GitHub Pages via the `chart-releaser` action.
 
+## External Documentation
+
+### n8n
+
+When working on the `n8n` chart, use `https://docs.n8n.io/llms.txt` as the entry point for official n8n documentation. That file lists available documentation pages — fetch individual pages from it as needed for accurate, up-to-date details on configuration, environment variables, and features.
+
 ## Common Commands
 
 ### Linting

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -51,29 +51,38 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: fixed
-      description: Remove deprecated N8N_RUNNERS_ENABLED environment variable (safe to remove since n8n 1.69+)
+      description: Remove deprecated N8N_RUNNERS_ENABLED environment variable (safe since n8n 1.69+)
+      links:
+        - name: "Issue #412"
+          url: https://github.com/community-charts/helm-charts/issues/412
+        - name: "Issue #436"
+          url: https://github.com/community-charts/helm-charts/issues/436
+        - name: "Issue #474"
+          url: https://github.com/community-charts/helm-charts/issues/474
     - kind: fixed
       description: Use n8nio/runners image for external task runner sidecar instead of n8nio/n8n
+      links:
+        - name: "Issue #329"
+          url: https://github.com/community-charts/helm-charts/issues/329
+        - name: "Issue #434"
+          url: https://github.com/community-charts/helm-charts/issues/434
     - kind: fixed
       description: Skip external task runner sidecar on main pod when worker.mode is queue
-    - kind: added
-      description: Add Python runner support via taskRunners.python.enabled flag (requires n8n 1.111.0+)
+      links:
+        - name: "Issue #414"
+          url: https://github.com/community-charts/helm-charts/issues/414
     - kind: fixed
-      description: Rename runner sidecar port from http to runner-health to fix duplicate port name warning
-    - kind: changed
-      description: Add unit test coverage for external runner image tag, port name, and Python runner negative cases
+      description: Rename runner sidecar port from http to runner-health to eliminate duplicate port name warning
     - kind: fixed
-      description: Move N8N_RUNNERS_STDLIB_ALLOW and N8N_RUNNERS_EXTERNAL_ALLOW to broker configmap so n8n enforces the correct Python security policy
+      description: Move N8N_RUNNERS_STDLIB_ALLOW and N8N_RUNNERS_EXTERNAL_ALLOW to task-broker configmap so n8n enforces the correct Python security policy
     - kind: added
-      description: Add taskRunners.python.packages to install Python packages via uv before the runner starts
-    - kind: changed
-      description: Derive N8N_RUNNERS_EXTERNAL_ALLOW automatically from taskRunners.python.packages, removing the redundant externalAllow field
-    - kind: changed
-      description: Restructure taskRunners.python config to match nodes section pattern (builtin.modules array and external.packages with allowAll flag)
-    - kind: changed
-      description: Move Python Code node config from taskRunners.python to nodes.python, alongside JS config
+      description: Add Python runner support via nodes.python.enabled flag (requires n8n 1.111.0+ and taskRunners.mode=external)
     - kind: added
-      description: Add optional PVC persistence for Python installed packages via nodes.python.persistence
+      description: Add nodes.python.external.packages to install Python packages via uv before the runner starts; N8N_RUNNERS_EXTERNAL_ALLOW is derived automatically from the package list
+    - kind: added
+      description: Add optional PVC persistence for Python installed packages via nodes.python.persistence; ReadWriteMany required when HPA or multi-node Deployment is used
+    - kind: changed
+      description: Move Python Code node config (builtin.modules, external.packages, external.allowAll) from taskRunners.python to nodes.python alongside the JS node config
   artifacthub.io/images: |
     - name: n8n
       image: n8nio/n8n:2.23.4

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.22.1
+version: 1.22.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -66,6 +66,8 @@ annotations:
       description: Move N8N_RUNNERS_STDLIB_ALLOW and N8N_RUNNERS_EXTERNAL_ALLOW to broker configmap so n8n enforces the correct Python security policy
     - kind: added
       description: Add taskRunners.python.packages to install Python packages via uv before the runner starts
+    - kind: changed
+      description: Derive N8N_RUNNERS_EXTERNAL_ALLOW automatically from taskRunners.python.packages, removing the redundant externalAllow field
   artifacthub.io/images: |
     - name: n8n
       image: n8nio/n8n:2.23.4

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.22.0
+version: 1.22.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -62,6 +62,10 @@ annotations:
       description: Rename runner sidecar port from http to runner-health to fix duplicate port name warning
     - kind: changed
       description: Add unit test coverage for external runner image tag, port name, and Python runner negative cases
+    - kind: fixed
+      description: Move N8N_RUNNERS_STDLIB_ALLOW and N8N_RUNNERS_EXTERNAL_ALLOW to broker configmap so n8n enforces the correct Python security policy
+    - kind: added
+      description: Add taskRunners.python.packages to install Python packages via uv before the runner starts
   artifacthub.io/images: |
     - name: n8n
       image: n8nio/n8n:2.23.4

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -68,6 +68,8 @@ annotations:
       description: Add taskRunners.python.packages to install Python packages via uv before the runner starts
     - kind: changed
       description: Derive N8N_RUNNERS_EXTERNAL_ALLOW automatically from taskRunners.python.packages, removing the redundant externalAllow field
+    - kind: changed
+      description: Restructure taskRunners.python config to match nodes section pattern (builtin.modules array and external.packages with allowAll flag)
   artifacthub.io/images: |
     - name: n8n
       image: n8nio/n8n:2.23.4

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -56,6 +56,8 @@ annotations:
       description: Use n8nio/runners image for external task runner sidecar instead of n8nio/n8n
     - kind: fixed
       description: Skip external task runner sidecar on main pod when worker.mode is queue
+    - kind: added
+      description: Add Python runner support via taskRunners.python.enabled flag (requires n8n 1.111.0+)
   artifacthub.io/images: |
     - name: n8n
       image: n8nio/n8n:2.23.4

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -72,6 +72,8 @@ annotations:
       description: Restructure taskRunners.python config to match nodes section pattern (builtin.modules array and external.packages with allowAll flag)
     - kind: changed
       description: Move Python Code node config from taskRunners.python to nodes.python, alongside JS config
+    - kind: added
+      description: Add optional PVC persistence for Python installed packages via nodes.python.persistence
   artifacthub.io/images: |
     - name: n8n
       image: n8nio/n8n:2.23.4

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -81,8 +81,6 @@ annotations:
       description: Add nodes.python.external.packages to install Python packages via uv before the runner starts; N8N_RUNNERS_EXTERNAL_ALLOW is derived automatically from the package list
     - kind: added
       description: Add optional PVC persistence for Python installed packages via nodes.python.persistence; ReadWriteMany required when HPA or multi-node Deployment is used
-    - kind: changed
-      description: Move Python Code node config (builtin.modules, external.packages, external.allowAll) from taskRunners.python to nodes.python alongside the JS node config
   artifacthub.io/images: |
     - name: n8n
       image: n8nio/n8n:2.23.4

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -81,6 +81,8 @@ annotations:
       description: Add nodes.python.external.packages to install Python packages via uv before the runner starts; N8N_RUNNERS_EXTERNAL_ALLOW is derived automatically from the package list
     - kind: added
       description: Add optional PVC persistence for Python installed packages via nodes.python.persistence; ReadWriteMany required when HPA or multi-node Deployment is used
+    - kind: added
+      description: Add pypiRegistry support for installing Python packages from a private PyPI index (URL-only via UV_DEFAULT_INDEX or uv.toml config file via UV_CONFIG_FILE; mirrors npmRegistry pattern)
   artifacthub.io/images: |
     - name: n8n
       image: n8nio/n8n:2.23.4

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.21.0
+version: 1.22.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -50,11 +50,20 @@ annotations:
       url: https://docs.n8n.io/
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
-    - kind: added
-      description: Add support for extra manifests via extraManifests and extraTemplateManifests values
+    - kind: fixed
+      description: Remove deprecated N8N_RUNNERS_ENABLED environment variable (safe to remove since n8n 1.69+)
+    - kind: fixed
+      description: Use n8nio/runners image for external task runner sidecar instead of n8nio/n8n
+    - kind: fixed
+      description: Skip external task runner sidecar on main pod when worker.mode is queue
   artifacthub.io/images: |
     - name: n8n
       image: n8nio/n8n:2.23.4
+      platforms:
+        - linux/amd64
+        - linux/arm64
+    - name: n8n-runners
+      image: n8nio/runners:2.23.4
       platforms:
         - linux/amd64
         - linux/arm64

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -58,6 +58,10 @@ annotations:
       description: Skip external task runner sidecar on main pod when worker.mode is queue
     - kind: added
       description: Add Python runner support via taskRunners.python.enabled flag (requires n8n 1.111.0+)
+    - kind: fixed
+      description: Rename runner sidecar port from http to runner-health to fix duplicate port name warning
+    - kind: changed
+      description: Add unit test coverage for external runner image tag, port name, and Python runner negative cases
   artifacthub.io/images: |
     - name: n8n
       image: n8nio/n8n:2.23.4

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -70,6 +70,8 @@ annotations:
       description: Derive N8N_RUNNERS_EXTERNAL_ALLOW automatically from taskRunners.python.packages, removing the redundant externalAllow field
     - kind: changed
       description: Restructure taskRunners.python config to match nodes section pattern (builtin.modules array and external.packages with allowAll flag)
+    - kind: changed
+      description: Move Python Code node config from taskRunners.python to nodes.python, alongside JS config
   artifacthub.io/images: |
     - name: n8n
       image: n8nio/n8n:2.23.4

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.22.1](https://img.shields.io/badge/Version-1.22.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.23.4](https://img.shields.io/badge/AppVersion-2.23.4-informational?style=flat-square)
+![Version: 1.22.0](https://img.shields.io/badge/Version-1.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.23.4](https://img.shields.io/badge/AppVersion-2.23.4-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -351,11 +351,11 @@ taskRunners:
       - requests
 ```
 
-> **Note**: Package installation adds a few seconds to runner startup time. Packages must also be listed in `externalAllow` for n8n to permit their use in Code nodes.
+> **Note**: Package installation adds a few seconds to runner startup time. Each package listed in `packages` is automatically allowed as an external package in Code nodes — no separate allowlist entry is needed.
 
 ### Restrict Python Module Access
 
-Use `stdlibAllow` to allowlist Python standard library modules and `externalAllow` for third-party packages. Set either to `*` to allow all. These settings apply to both the n8n broker (security enforcement) and the runner sidecar.
+Use `stdlibAllow` to allowlist Python standard library modules. Set to `*` to allow all. This setting applies to both the n8n broker (security enforcement) and the runner sidecar. External packages listed in `packages` are automatically permitted.
 
 ```yaml
 taskRunners:
@@ -363,7 +363,6 @@ taskRunners:
   python:
     enabled: true
     stdlibAllow: "os,sys,json,math,datetime,re"
-    externalAllow: "numpy,pandas"
     packages:
       - numpy
       - pandas
@@ -392,7 +391,6 @@ taskRunners:
   python:
     enabled: true
     stdlibAllow: "*"
-    externalAllow: "numpy,pandas"
     packages:
       - numpy
       - pandas
@@ -1401,7 +1399,7 @@ helm upgrade [RELEASE_NAME] community-charts/n8n
 | serviceMonitor.targetLabels | list | `[]` | Set of labels to transfer on the Kubernetes Service onto the target. |
 | serviceMonitor.timeout | string | `"10s"` | Set timeout for scrape |
 | strategy | object | `{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"}` | This will set the deployment strategy more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |
-| taskRunners | object | `{"broker":{"address":"127.0.0.1","port":5679},"external":{"autoShutdownTimeout":15,"image":{"pullPolicy":"IfNotPresent","repository":"n8nio/runners","tag":""},"mainNodeAuthToken":"","nodeOptions":["--max-semi-space-size=16","--max-old-space-size=300"],"port":5680,"resources":{"limits":{"cpu":"2000m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"32Mi"}},"workerNodeAuthToken":""},"maxConcurrency":5,"mode":"internal","python":{"enabled":false,"externalAllow":"","packages":[],"stdlibAllow":""},"taskHeartbeatInterval":30,"taskTimeout":60}` | Task runners mode. Please follow the documentation for more information: https://docs.n8n.io/hosting/configuration/task-runners/ |
+| taskRunners | object | `{"broker":{"address":"127.0.0.1","port":5679},"external":{"autoShutdownTimeout":15,"image":{"pullPolicy":"IfNotPresent","repository":"n8nio/runners","tag":""},"mainNodeAuthToken":"","nodeOptions":["--max-semi-space-size=16","--max-old-space-size=300"],"port":5680,"resources":{"limits":{"cpu":"2000m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"32Mi"}},"workerNodeAuthToken":""},"maxConcurrency":5,"mode":"internal","python":{"enabled":false,"packages":[],"stdlibAllow":""},"taskHeartbeatInterval":30,"taskTimeout":60}` | Task runners mode. Please follow the documentation for more information: https://docs.n8n.io/hosting/configuration/task-runners/ |
 | taskRunners.broker | object | `{"address":"127.0.0.1","port":5679}` | The address for the broker of the external task runner |
 | taskRunners.broker.address | string | `"127.0.0.1"` | The address for the broker of the external task runner |
 | taskRunners.broker.port | int | `5679` | The port for the broker of the external task runner |
@@ -1424,10 +1422,9 @@ helm upgrade [RELEASE_NAME] community-charts/n8n
 | taskRunners.external.workerNodeAuthToken | string | `""` | The auth token for the worker node |
 | taskRunners.maxConcurrency | int | `5` | The maximum concurrency for the task |
 | taskRunners.mode | string | `"internal"` | Use `internal` to use internal task runner, or use `external` to have external sidecar task runner. For more information please follow the documentation: https://docs.n8n.io/hosting/configuration/task-runners/#task-runner-modes |
-| taskRunners.python | object | `{"enabled":false,"externalAllow":"","packages":[],"stdlibAllow":""}` | Python runner configuration. Requires n8n 1.111.0+ and external task runner mode. |
+| taskRunners.python | object | `{"enabled":false,"packages":[],"stdlibAllow":""}` | Python runner configuration. Requires n8n 1.111.0+ and external task runner mode. |
 | taskRunners.python.enabled | bool | `false` | Enable Python code execution in the Code node via external task runners. |
-| taskRunners.python.externalAllow | string | `""` | Third-party Python modules allowed in Code nodes (comma-separated). Use * to allow all. |
-| taskRunners.python.packages | list | `[]` | Python packages to install via uv before starting the runner (e.g. ["pandas", "numpy"]). |
+| taskRunners.python.packages | list | `[]` | Python packages to install via uv before starting the runner (e.g. ["pandas", "numpy"]). Each listed package is also automatically allowed as an external package in Code nodes. |
 | taskRunners.python.stdlibAllow | string | `""` | Python standard library modules allowed in Code nodes (comma-separated). Use * to allow all. |
 | taskRunners.taskHeartbeatInterval | int | `30` | The heartbeat interval for the task in seconds |
 | taskRunners.taskTimeout | int | `60` | The timeout for the task in seconds |

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -338,34 +338,52 @@ taskRunners:
 
 ### Install Python Packages
 
-The `n8nio/runners` image ships only a bare Python environment. Use `taskRunners.python.packages` to install packages via `uv pip install` before the runner starts. List any third-party packages your Code nodes need:
+The `n8nio/runners` image ships only a bare Python environment. Use `taskRunners.python.external.packages` to install packages via `uv pip install` before the runner starts. Each listed package is automatically allowed in Code nodes — no separate allowlist entry is needed.
 
 ```yaml
 taskRunners:
   mode: external
   python:
     enabled: true
-    packages:
-      - pandas
-      - numpy
-      - requests
+    external:
+      packages:
+        - pandas
+        - numpy
+        - requests
 ```
 
-> **Note**: Package installation adds a few seconds to runner startup time. Each package listed in `packages` is automatically allowed as an external package in Code nodes — no separate allowlist entry is needed.
+> **Note**: Package installation adds a few seconds to runner startup time.
+
+To allow all external packages without installing them (e.g. when packages are pre-installed in a custom image), set `allowAll: true`:
+
+```yaml
+taskRunners:
+  mode: external
+  python:
+    enabled: true
+    external:
+      allowAll: true
+```
 
 ### Restrict Python Module Access
 
-Use `stdlibAllow` to allowlist Python standard library modules. Set to `*` to allow all. This setting applies to both the n8n broker (security enforcement) and the runner sidecar. External packages listed in `packages` are automatically permitted.
+Use `builtin.modules` to allowlist Python standard library modules. Use `["*"]` to allow all. This setting applies to both the n8n broker (security enforcement) and the runner sidecar.
 
 ```yaml
 taskRunners:
   mode: external
   python:
     enabled: true
-    stdlibAllow: "os,sys,json,math,datetime,re"
-    packages:
-      - numpy
-      - pandas
+    builtin:
+      modules:
+        - os
+        - sys
+        - json
+        - math
+    external:
+      packages:
+        - numpy
+        - pandas
 ```
 
 ### Full Queue Mode + External Runner + Python Example
@@ -390,10 +408,13 @@ taskRunners:
   mode: external
   python:
     enabled: true
-    stdlibAllow: "*"
-    packages:
-      - numpy
-      - pandas
+    builtin:
+      modules:
+        - "*"
+    external:
+      packages:
+        - numpy
+        - pandas
   external:
     image:
       repository: n8nio/runners
@@ -1399,7 +1420,7 @@ helm upgrade [RELEASE_NAME] community-charts/n8n
 | serviceMonitor.targetLabels | list | `[]` | Set of labels to transfer on the Kubernetes Service onto the target. |
 | serviceMonitor.timeout | string | `"10s"` | Set timeout for scrape |
 | strategy | object | `{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"}` | This will set the deployment strategy more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |
-| taskRunners | object | `{"broker":{"address":"127.0.0.1","port":5679},"external":{"autoShutdownTimeout":15,"image":{"pullPolicy":"IfNotPresent","repository":"n8nio/runners","tag":""},"mainNodeAuthToken":"","nodeOptions":["--max-semi-space-size=16","--max-old-space-size=300"],"port":5680,"resources":{"limits":{"cpu":"2000m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"32Mi"}},"workerNodeAuthToken":""},"maxConcurrency":5,"mode":"internal","python":{"enabled":false,"packages":[],"stdlibAllow":""},"taskHeartbeatInterval":30,"taskTimeout":60}` | Task runners mode. Please follow the documentation for more information: https://docs.n8n.io/hosting/configuration/task-runners/ |
+| taskRunners | object | `{"broker":{"address":"127.0.0.1","port":5679},"external":{"autoShutdownTimeout":15,"image":{"pullPolicy":"IfNotPresent","repository":"n8nio/runners","tag":""},"mainNodeAuthToken":"","nodeOptions":["--max-semi-space-size=16","--max-old-space-size=300"],"port":5680,"resources":{"limits":{"cpu":"2000m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"32Mi"}},"workerNodeAuthToken":""},"maxConcurrency":5,"mode":"internal","python":{"builtin":{"modules":[]},"enabled":false,"external":{"allowAll":false,"packages":[]}},"taskHeartbeatInterval":30,"taskTimeout":60}` | Task runners mode. Please follow the documentation for more information: https://docs.n8n.io/hosting/configuration/task-runners/ |
 | taskRunners.broker | object | `{"address":"127.0.0.1","port":5679}` | The address for the broker of the external task runner |
 | taskRunners.broker.address | string | `"127.0.0.1"` | The address for the broker of the external task runner |
 | taskRunners.broker.port | int | `5679` | The port for the broker of the external task runner |
@@ -1422,10 +1443,13 @@ helm upgrade [RELEASE_NAME] community-charts/n8n
 | taskRunners.external.workerNodeAuthToken | string | `""` | The auth token for the worker node |
 | taskRunners.maxConcurrency | int | `5` | The maximum concurrency for the task |
 | taskRunners.mode | string | `"internal"` | Use `internal` to use internal task runner, or use `external` to have external sidecar task runner. For more information please follow the documentation: https://docs.n8n.io/hosting/configuration/task-runners/#task-runner-modes |
-| taskRunners.python | object | `{"enabled":false,"packages":[],"stdlibAllow":""}` | Python runner configuration. Requires n8n 1.111.0+ and external task runner mode. |
+| taskRunners.python | object | `{"builtin":{"modules":[]},"enabled":false,"external":{"allowAll":false,"packages":[]}}` | Python runner configuration. Requires n8n 1.111.0+ and external task runner mode. |
+| taskRunners.python.builtin | object | `{"modules":[]}` | Built-in Python module access for the Code node. |
+| taskRunners.python.builtin.modules | list | `[]` | Python standard library modules allowed in Code nodes. Use ['*'] to allow all. |
 | taskRunners.python.enabled | bool | `false` | Enable Python code execution in the Code node via external task runners. |
-| taskRunners.python.packages | list | `[]` | Python packages to install via uv before starting the runner (e.g. ["pandas", "numpy"]). Each listed package is also automatically allowed as an external package in Code nodes. |
-| taskRunners.python.stdlibAllow | string | `""` | Python standard library modules allowed in Code nodes (comma-separated). Use * to allow all. |
+| taskRunners.python.external | object | `{"allowAll":false,"packages":[]}` | External Python package access for the Code node. |
+| taskRunners.python.external.allowAll | bool | `false` | Allow all external Python packages in Code nodes. When true, sets N8N_RUNNERS_EXTERNAL_ALLOW=* regardless of packages list. |
+| taskRunners.python.external.packages | list | `[]` | Python packages to install via uv before starting the runner (e.g. ["pandas", "numpy"]). Each listed package is also automatically allowed as an external package in Code nodes. |
 | taskRunners.taskHeartbeatInterval | int | `30` | The heartbeat interval for the task in seconds |
 | taskRunners.taskTimeout | int | `60` | The timeout for the task in seconds |
 | timezone | string | `"Europe/Berlin"` | For instance, the Schedule node uses it to know at what time the workflow should start. Find you timezone from here: https://momentjs.com/timezone/ |

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -449,6 +449,10 @@ nodes:
       packages:
         - numpy
         - pandas
+    persistence:
+      enabled: true
+      size: 2Gi
+      accessMode: ReadWriteMany  # required for queue-mode workers scaled across nodes
 
 taskRunners:
   mode: external

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -398,6 +398,55 @@ taskRunners:
   mode: external
 ```
 
+### Private Python Package Registry
+
+By default, `uv pip install` resolves packages from pypi.org. Use `pypiRegistry` to point the runner sidecar at a private or self-hosted index instead (JFrog Artifactory, AWS CodeArtifact, Nexus, etc.).
+
+#### Simple — URL only (no auth or inline credentials)
+
+```yaml
+pypiRegistry:
+  enabled: true
+  url: "https://my.jfrog.io/artifactory/api/pypi/pypi-virtual/simple/"
+```
+
+This sets `UV_DEFAULT_INDEX` in the sidecar, replacing pypi.org as the default index.
+
+#### Advanced — `uv.toml` config file (authentication or multiple indexes)
+
+For authenticated registries, create a `uv.toml` with your index configuration and let the chart store it in a Kubernetes Secret:
+
+```yaml
+pypiRegistry:
+  enabled: true
+  customUvConfig: |
+    [[index]]
+    name = "private"
+    url = "https://my.jfrog.io/artifactory/api/pypi/pypi-virtual/simple/"
+    default = true
+
+    [index.credentials]
+    username = "ci-user"
+    password = "s3cr3t"
+```
+
+The chart creates a Secret from `customUvConfig`, mounts it into the runner sidecar, and sets `UV_CONFIG_FILE` to the mounted path. The entire file is base64-encoded in the Secret.
+
+> **Note**: Do not use `url` together with `customUvConfig` or `secretName` — when a config file is provided, the index URL belongs inside the `uv.toml`.
+
+#### Advanced — reference an existing Secret
+
+If you manage credentials in an existing Kubernetes Secret, reference it directly:
+
+```yaml
+pypiRegistry:
+  enabled: true
+  secretName: "my-uv-config-secret"
+  secretKey: "uv.toml"
+```
+
+The secret must contain a key matching `secretKey` (default: `uv.toml`) whose value is valid `uv.toml` content.
+
 ### Restrict Python Module Access
 
 Use `nodes.python.builtin.modules` to allowlist Python standard library modules. Use `["*"]` to allow all. This setting applies to both the n8n broker (security enforcement) and the runner sidecar.
@@ -1425,6 +1474,12 @@ helm upgrade [RELEASE_NAME] community-charts/n8n
 | postgresql.primary.service | object | `{"ports":{"postgresql":5432}}` | This is for setting up the primary service. |
 | postgresql.primary.service.ports | object | `{"postgresql":5432}` | This is for setting up the service ports. |
 | postgresql.primary.service.ports.postgresql | int | `5432` | This is for setting up the postgresql port. |
+| pypiRegistry | object | `{"customUvConfig":"","enabled":false,"secretKey":"uv.toml","secretName":"","url":""}` | Configuration for private Python package (PyPI) registry. Used by the runner sidecar when nodes.python.external.packages is set. |
+| pypiRegistry.customUvConfig | string | `""` | Inline uv.toml content. When set and secretName is empty, the chart creates a Secret from this content (mirrors customNpmrc behaviour). Mutually exclusive with url. |
+| pypiRegistry.enabled | bool | `false` | Enable private PyPI registry support for the runner sidecar. |
+| pypiRegistry.secretKey | string | `"uv.toml"` | Key within the secret that holds the uv.toml content. |
+| pypiRegistry.secretName | string | `""` | Name of an existing Kubernetes secret whose data contains a uv.toml config file. When set, the file is mounted into the runner sidecar and UV_CONFIG_FILE is set. |
+| pypiRegistry.url | string | `""` | URL of the private PyPI index (e.g. https://my.jfrog.io/artifactory/api/pypi/pypi/simple/). Used when no config file is provided; sets UV_DEFAULT_INDEX in the sidecar. For authenticated registries embed credentials inline or use customUvConfig/secretName instead. |
 | readinessProbe | object | `{}` | @deprecated Use main, worker, and webhook blocks readinessProbe field instead. This field will be removed in a future release. |
 | redis | object | `{"architecture":"standalone","auth":{"enabled":true},"enabled":false,"image":{"repository":"bitnamilegacy/redis"},"master":{"persistence":{"enabled":false},"service":{"ports":{"redis":6379}}}}` | Bitnami Redis configuration |
 | redis.architecture | string | `"standalone"` | Enable redis architecture. |

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -1271,7 +1271,7 @@ helm upgrade [RELEASE_NAME] community-charts/n8n
 | serviceMonitor.targetLabels | list | `[]` | Set of labels to transfer on the Kubernetes Service onto the target. |
 | serviceMonitor.timeout | string | `"10s"` | Set timeout for scrape |
 | strategy | object | `{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"}` | This will set the deployment strategy more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |
-| taskRunners | object | `{"broker":{"address":"127.0.0.1","port":5679},"external":{"autoShutdownTimeout":15,"image":{"pullPolicy":"IfNotPresent","repository":"n8nio/runners","tag":""},"mainNodeAuthToken":"","nodeOptions":["--max-semi-space-size=16","--max-old-space-size=300"],"port":5680,"resources":{"limits":{"cpu":"2000m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"32Mi"}},"workerNodeAuthToken":""},"maxConcurrency":5,"mode":"internal","taskHeartbeatInterval":30,"taskTimeout":60}` | Task runners mode. Please follow the documentation for more information: https://docs.n8n.io/hosting/configuration/task-runners/ |
+| taskRunners | object | `{"broker":{"address":"127.0.0.1","port":5679},"external":{"autoShutdownTimeout":15,"image":{"pullPolicy":"IfNotPresent","repository":"n8nio/runners","tag":""},"mainNodeAuthToken":"","nodeOptions":["--max-semi-space-size=16","--max-old-space-size=300"],"port":5680,"resources":{"limits":{"cpu":"2000m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"32Mi"}},"workerNodeAuthToken":""},"maxConcurrency":5,"mode":"internal","python":{"enabled":false,"externalAllow":"","stdlibAllow":""},"taskHeartbeatInterval":30,"taskTimeout":60}` | Task runners mode. Please follow the documentation for more information: https://docs.n8n.io/hosting/configuration/task-runners/ |
 | taskRunners.broker | object | `{"address":"127.0.0.1","port":5679}` | The address for the broker of the external task runner |
 | taskRunners.broker.address | string | `"127.0.0.1"` | The address for the broker of the external task runner |
 | taskRunners.broker.port | int | `5679` | The port for the broker of the external task runner |
@@ -1294,6 +1294,10 @@ helm upgrade [RELEASE_NAME] community-charts/n8n
 | taskRunners.external.workerNodeAuthToken | string | `""` | The auth token for the worker node |
 | taskRunners.maxConcurrency | int | `5` | The maximum concurrency for the task |
 | taskRunners.mode | string | `"internal"` | Use `internal` to use internal task runner, or use `external` to have external sidecar task runner. For more information please follow the documentation: https://docs.n8n.io/hosting/configuration/task-runners/#task-runner-modes |
+| taskRunners.python | object | `{"enabled":false,"externalAllow":"","stdlibAllow":""}` | Python runner configuration. Requires n8n 1.111.0+ and external task runner mode. |
+| taskRunners.python.enabled | bool | `false` | Enable Python code execution in the Code node via external task runners. |
+| taskRunners.python.externalAllow | string | `""` | Third-party Python modules allowed in Code nodes (comma-separated). Use * to allow all. |
+| taskRunners.python.stdlibAllow | string | `""` | Python standard library modules allowed in Code nodes (comma-separated). Use * to allow all. |
 | taskRunners.taskHeartbeatInterval | int | `30` | The heartbeat interval for the task in seconds |
 | taskRunners.taskTimeout | int | `60` | The timeout for the task in seconds |
 | timezone | string | `"Europe/Berlin"` | For instance, the Schedule node uses it to know at what time the workflow should start. Find you timezone from here: https://momentjs.com/timezone/ |

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -356,7 +356,32 @@ taskRunners:
   mode: external
 ```
 
-> **Note**: Package installation adds a few seconds to runner startup time.
+> **Note**: Package installation adds a few seconds to runner startup time on the first start. To avoid re-downloading packages on every pod restart, enable persistence (see below).
+
+#### Persist Python Packages
+
+Enable `nodes.python.persistence` to store installed packages on a PVC. When enabled, `uv pip install` detects existing packages on subsequent starts and skips the download.
+
+```yaml
+nodes:
+  python:
+    enabled: true
+    external:
+      packages:
+        - pandas
+        - numpy
+    persistence:
+      enabled: true
+      size: 2Gi
+      accessMode: ReadWriteOnce  # use ReadWriteMany if workers span multiple nodes
+
+taskRunners:
+  mode: external
+```
+
+Packages are stored at `/home/node/.python-packages` inside the runner sidecar. When `persistence.enabled` is `false` (the default), an `emptyDir` volume is used and packages are re-installed on every pod restart.
+
+For StatefulSet deployments (when `main.count > 1` with `ReadWriteOnce`, or `main.forceToUseStatefulset: true`), each pod receives its own PVC via `volumeClaimTemplates`, so `ReadWriteOnce` works regardless of pod count. For Deployment-mode workers scaled by HPA across multiple nodes, use `accessMode: ReadWriteMany` with a compatible storage class (NFS, CephFS, etc.).
 
 To allow all external packages without installing them (e.g. when packages are pre-installed in a custom image), set `allowAll: true`:
 
@@ -1342,7 +1367,7 @@ helm upgrade [RELEASE_NAME] community-charts/n8n
 | minio.users[0].secretKey | string | `"Change_Me"` | n8n user secret key |
 | nameOverride | string | `""` | This is to override the chart name. |
 | nodeSelector | object | `{}` | For more information checkout: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
-| nodes | object | `{"builtin":{"enabled":false,"modules":[]},"external":{"allowAll":false,"packages":[],"reinstallMissingPackages":false},"initContainer":{"image":{"pullPolicy":"IfNotPresent","repository":"node","tag":"20-alpine"},"resources":{}},"python":{"builtin":{"modules":[]},"enabled":false,"external":{"allowAll":false,"packages":[]}}}` | Node configurations for built-in and external npm packages |
+| nodes | object | `{"builtin":{"enabled":false,"modules":[]},"external":{"allowAll":false,"packages":[],"reinstallMissingPackages":false},"initContainer":{"image":{"pullPolicy":"IfNotPresent","repository":"node","tag":"20-alpine"},"resources":{}},"python":{"builtin":{"modules":[]},"enabled":false,"external":{"allowAll":false,"packages":[]},"persistence":{"accessMode":"ReadWriteOnce","annotations":{},"enabled":false,"existingClaim":"","size":"1Gi","storageClass":""}}}` | Node configurations for built-in and external npm packages |
 | nodes.builtin | object | `{"enabled":false,"modules":[]}` | Enable built-in node functions (e.g., HTTP Request, Code Node, etc.) |
 | nodes.builtin.enabled | bool | `false` | Enable built-in modules for the Code node |
 | nodes.builtin.modules | list | `[]` | List of built-in Node.js modules to allow in the Code node (e.g., crypto, fs). Use '*' to allow all. |
@@ -1356,13 +1381,20 @@ helm upgrade [RELEASE_NAME] community-charts/n8n
 | nodes.initContainer.image.repository | string | `"node"` | Repository for the init container to install npm packages |
 | nodes.initContainer.image.tag | string | `"20-alpine"` | Tag for the init container to install npm packages |
 | nodes.initContainer.resources | object | `{}` | Resources for the init container |
-| nodes.python | object | `{"builtin":{"modules":[]},"enabled":false,"external":{"allowAll":false,"packages":[]}}` | Python Code node configuration. Requires n8n 1.111.0+ and taskRunners.mode: external. |
+| nodes.python | object | `{"builtin":{"modules":[]},"enabled":false,"external":{"allowAll":false,"packages":[]},"persistence":{"accessMode":"ReadWriteOnce","annotations":{},"enabled":false,"existingClaim":"","size":"1Gi","storageClass":""}}` | Python Code node configuration. Requires n8n 1.111.0+ and taskRunners.mode: external. |
 | nodes.python.builtin | object | `{"modules":[]}` | Built-in Python module access for the Code node. |
 | nodes.python.builtin.modules | list | `[]` | Python standard library modules allowed in Code nodes. Use ['*'] to allow all. |
 | nodes.python.enabled | bool | `false` | Enable Python code execution in the Code node via external task runners. |
 | nodes.python.external | object | `{"allowAll":false,"packages":[]}` | External Python package access for the Code node. |
 | nodes.python.external.allowAll | bool | `false` | Allow all external Python packages in Code nodes. When true, sets N8N_RUNNERS_EXTERNAL_ALLOW=* regardless of packages list. |
 | nodes.python.external.packages | list | `[]` | Python packages to install via uv before starting the runner (e.g. ["pandas", "numpy"]). Each listed package is also automatically allowed as an external package in Code nodes. |
+| nodes.python.persistence | object | `{"accessMode":"ReadWriteOnce","annotations":{},"enabled":false,"existingClaim":"","size":"1Gi","storageClass":""}` | Persistence for Python packages installed by uv. Optional PVC so packages survive pod restarts without re-downloading. |
+| nodes.python.persistence.accessMode | string | `"ReadWriteOnce"` | Access mode. Use ReadWriteMany when worker pods may be scheduled on different nodes. |
+| nodes.python.persistence.annotations | object | `{}` | Additional annotations for the PVC. |
+| nodes.python.persistence.enabled | bool | `false` | Enable persistence. When false, packages are installed into an emptyDir and lost on pod restart. |
+| nodes.python.persistence.existingClaim | string | `""` | Use an existing PVC instead of creating one. When set, no PVC is created by this chart. |
+| nodes.python.persistence.size | string | `"1Gi"` | Size of the PVC. |
+| nodes.python.persistence.storageClass | string | `""` | Storage class for the PVC. Empty string uses the cluster default. |
 | npmRegistry | object | `{"customNpmrc":"","enabled":false,"secretKey":"npmrc","secretName":"","url":""}` | Configuration for private npm registry |
 | npmRegistry.customNpmrc | string | `""` | Custom .npmrc content (optional, overrides secret if provided) |
 | npmRegistry.enabled | bool | `false` | Enable private npm registry |

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -275,9 +275,115 @@ webhook:
 
 Please find more detail about external task runners from [here](https://docs.n8n.io/hosting/securing/hardening-task-runners/).
 
+The external task runner runs as a sidecar container using the dedicated `n8nio/runners` image alongside each worker pod. In queue mode the main pod does **not** receive the sidecar because it does not execute workflows.
+
+### Basic External Task Runner
+
 ```yaml
 taskRunners:
   mode: external
+```
+
+### Pinning the Runner Image Tag
+
+By default the runner image tag matches the chart `appVersion`. Pin an explicit version with `taskRunners.external.image.tag`:
+
+```yaml
+taskRunners:
+  mode: external
+  external:
+    image:
+      repository: n8nio/runners
+      pullPolicy: IfNotPresent
+      tag: "2.23.4"
+```
+
+### External Task Runner with Queue Mode
+
+In queue mode the sidecar is attached to worker pods only — the main pod is excluded automatically because it offloads all workflow execution to workers.
+
+```yaml
+db:
+  type: postgresdb
+
+worker:
+  mode: queue
+
+taskRunners:
+  mode: external
+  external:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 64Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
+```
+
+## Python Runner Support
+
+The `n8nio/runners` image ships a Python runner alongside the JavaScript runner. Enable it with `taskRunners.python.enabled: true` (requires n8n 1.111.0+). This activates the Python Code node on the main container and starts the Python launcher inside the sidecar.
+
+> **Tip**: Python runner requires `taskRunners.mode: external`.
+
+### Enable Python Runner
+
+```yaml
+taskRunners:
+  mode: external
+  python:
+    enabled: true
+```
+
+### Restrict Python Module Access
+
+Use `stdlibAllow` to allowlist Python standard library modules and `externalAllow` for third-party packages. Set either to `*` to allow all.
+
+```yaml
+taskRunners:
+  mode: external
+  python:
+    enabled: true
+    stdlibAllow: "os,sys,json,math,datetime,re"
+    externalAllow: "numpy,pandas"
+```
+
+### Full Queue Mode + External Runner + Python Example
+
+```yaml
+db:
+  type: postgresdb
+
+worker:
+  mode: queue
+  count: 2
+
+  waitMainNodeReady:
+    enabled: true
+
+externalRedis:
+  host: "redis-instance1.ab012cdefghi.eu-central-1.rds.amazonaws.com"
+  username: "default"
+  password: "Pa33w0rd!"
+
+taskRunners:
+  mode: external
+  python:
+    enabled: true
+    stdlibAllow: "*"
+  external:
+    image:
+      repository: n8nio/runners
+      pullPolicy: IfNotPresent
+      tag: ""
+    resources:
+      requests:
+        cpu: 100m
+        memory: 64Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
 ```
 
 ## Autoscaling Configuration

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -383,6 +383,8 @@ Packages are stored at `/home/node/.python-packages` inside the runner sidecar. 
 
 For StatefulSet deployments (when `main.count > 1` with `ReadWriteOnce`, or `main.forceToUseStatefulset: true`), each pod receives its own PVC via `volumeClaimTemplates`, so `ReadWriteOnce` works regardless of pod count. For Deployment-mode workers scaled by HPA across multiple nodes, use `accessMode: ReadWriteMany` with a compatible storage class (NFS, CephFS, etc.).
 
+> **Warning**: When `worker.autoscaling.enabled: true`, you **must** set `nodes.python.persistence.accessMode: ReadWriteMany` (or leave persistence disabled). The HPA will not render if python packages persistence is enabled with `ReadWriteOnce`, because scaling workers across nodes would cause PVC mount failures.
+
 To allow all external packages without installing them (e.g. when packages are pre-installed in a custom image), set `allowAll: true`:
 
 ```yaml

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -323,26 +323,27 @@ taskRunners:
 
 ## Python Runner Support
 
-The `n8nio/runners` image ships a Python runner alongside the JavaScript runner. Enable it with `taskRunners.python.enabled: true` (requires n8n 1.111.0+). This activates the Python Code node on the main container and starts the Python launcher inside the sidecar.
+The `n8nio/runners` image ships a Python runner alongside the JavaScript runner. Enable it with `nodes.python.enabled: true` (requires n8n 1.111.0+). This activates the Python Code node on the main container and starts the Python launcher inside the sidecar.
 
 > **Tip**: Python runner requires `taskRunners.mode: external`.
 
 ### Enable Python Runner
 
 ```yaml
-taskRunners:
-  mode: external
+nodes:
   python:
     enabled: true
+
+taskRunners:
+  mode: external
 ```
 
 ### Install Python Packages
 
-The `n8nio/runners` image ships only a bare Python environment. Use `taskRunners.python.external.packages` to install packages via `uv pip install` before the runner starts. Each listed package is automatically allowed in Code nodes — no separate allowlist entry is needed.
+The `n8nio/runners` image ships only a bare Python environment. Use `nodes.python.external.packages` to install packages via `uv pip install` before the runner starts. Each listed package is automatically allowed in Code nodes — no separate allowlist entry is needed.
 
 ```yaml
-taskRunners:
-  mode: external
+nodes:
   python:
     enabled: true
     external:
@@ -350,6 +351,9 @@ taskRunners:
         - pandas
         - numpy
         - requests
+
+taskRunners:
+  mode: external
 ```
 
 > **Note**: Package installation adds a few seconds to runner startup time.
@@ -357,21 +361,22 @@ taskRunners:
 To allow all external packages without installing them (e.g. when packages are pre-installed in a custom image), set `allowAll: true`:
 
 ```yaml
-taskRunners:
-  mode: external
+nodes:
   python:
     enabled: true
     external:
       allowAll: true
+
+taskRunners:
+  mode: external
 ```
 
 ### Restrict Python Module Access
 
-Use `builtin.modules` to allowlist Python standard library modules. Use `["*"]` to allow all. This setting applies to both the n8n broker (security enforcement) and the runner sidecar.
+Use `nodes.python.builtin.modules` to allowlist Python standard library modules. Use `["*"]` to allow all. This setting applies to both the n8n broker (security enforcement) and the runner sidecar.
 
 ```yaml
-taskRunners:
-  mode: external
+nodes:
   python:
     enabled: true
     builtin:
@@ -384,6 +389,9 @@ taskRunners:
       packages:
         - numpy
         - pandas
+
+taskRunners:
+  mode: external
 ```
 
 ### Full Queue Mode + External Runner + Python Example
@@ -404,8 +412,7 @@ externalRedis:
   username: "default"
   password: "Pa33w0rd!"
 
-taskRunners:
-  mode: external
+nodes:
   python:
     enabled: true
     builtin:
@@ -415,6 +422,9 @@ taskRunners:
       packages:
         - numpy
         - pandas
+
+taskRunners:
+  mode: external
   external:
     image:
       repository: n8nio/runners
@@ -1332,7 +1342,7 @@ helm upgrade [RELEASE_NAME] community-charts/n8n
 | minio.users[0].secretKey | string | `"Change_Me"` | n8n user secret key |
 | nameOverride | string | `""` | This is to override the chart name. |
 | nodeSelector | object | `{}` | For more information checkout: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
-| nodes | object | `{"builtin":{"enabled":false,"modules":[]},"external":{"allowAll":false,"packages":[],"reinstallMissingPackages":false},"initContainer":{"image":{"pullPolicy":"IfNotPresent","repository":"node","tag":"20-alpine"},"resources":{}}}` | Node configurations for built-in and external npm packages |
+| nodes | object | `{"builtin":{"enabled":false,"modules":[]},"external":{"allowAll":false,"packages":[],"reinstallMissingPackages":false},"initContainer":{"image":{"pullPolicy":"IfNotPresent","repository":"node","tag":"20-alpine"},"resources":{}},"python":{"builtin":{"modules":[]},"enabled":false,"external":{"allowAll":false,"packages":[]}}}` | Node configurations for built-in and external npm packages |
 | nodes.builtin | object | `{"enabled":false,"modules":[]}` | Enable built-in node functions (e.g., HTTP Request, Code Node, etc.) |
 | nodes.builtin.enabled | bool | `false` | Enable built-in modules for the Code node |
 | nodes.builtin.modules | list | `[]` | List of built-in Node.js modules to allow in the Code node (e.g., crypto, fs). Use '*' to allow all. |
@@ -1346,6 +1356,13 @@ helm upgrade [RELEASE_NAME] community-charts/n8n
 | nodes.initContainer.image.repository | string | `"node"` | Repository for the init container to install npm packages |
 | nodes.initContainer.image.tag | string | `"20-alpine"` | Tag for the init container to install npm packages |
 | nodes.initContainer.resources | object | `{}` | Resources for the init container |
+| nodes.python | object | `{"builtin":{"modules":[]},"enabled":false,"external":{"allowAll":false,"packages":[]}}` | Python Code node configuration. Requires n8n 1.111.0+ and taskRunners.mode: external. |
+| nodes.python.builtin | object | `{"modules":[]}` | Built-in Python module access for the Code node. |
+| nodes.python.builtin.modules | list | `[]` | Python standard library modules allowed in Code nodes. Use ['*'] to allow all. |
+| nodes.python.enabled | bool | `false` | Enable Python code execution in the Code node via external task runners. |
+| nodes.python.external | object | `{"allowAll":false,"packages":[]}` | External Python package access for the Code node. |
+| nodes.python.external.allowAll | bool | `false` | Allow all external Python packages in Code nodes. When true, sets N8N_RUNNERS_EXTERNAL_ALLOW=* regardless of packages list. |
+| nodes.python.external.packages | list | `[]` | Python packages to install via uv before starting the runner (e.g. ["pandas", "numpy"]). Each listed package is also automatically allowed as an external package in Code nodes. |
 | npmRegistry | object | `{"customNpmrc":"","enabled":false,"secretKey":"npmrc","secretName":"","url":""}` | Configuration for private npm registry |
 | npmRegistry.customNpmrc | string | `""` | Custom .npmrc content (optional, overrides secret if provided) |
 | npmRegistry.enabled | bool | `false` | Enable private npm registry |
@@ -1420,7 +1437,7 @@ helm upgrade [RELEASE_NAME] community-charts/n8n
 | serviceMonitor.targetLabels | list | `[]` | Set of labels to transfer on the Kubernetes Service onto the target. |
 | serviceMonitor.timeout | string | `"10s"` | Set timeout for scrape |
 | strategy | object | `{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"}` | This will set the deployment strategy more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |
-| taskRunners | object | `{"broker":{"address":"127.0.0.1","port":5679},"external":{"autoShutdownTimeout":15,"image":{"pullPolicy":"IfNotPresent","repository":"n8nio/runners","tag":""},"mainNodeAuthToken":"","nodeOptions":["--max-semi-space-size=16","--max-old-space-size=300"],"port":5680,"resources":{"limits":{"cpu":"2000m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"32Mi"}},"workerNodeAuthToken":""},"maxConcurrency":5,"mode":"internal","python":{"builtin":{"modules":[]},"enabled":false,"external":{"allowAll":false,"packages":[]}},"taskHeartbeatInterval":30,"taskTimeout":60}` | Task runners mode. Please follow the documentation for more information: https://docs.n8n.io/hosting/configuration/task-runners/ |
+| taskRunners | object | `{"broker":{"address":"127.0.0.1","port":5679},"external":{"autoShutdownTimeout":15,"image":{"pullPolicy":"IfNotPresent","repository":"n8nio/runners","tag":""},"mainNodeAuthToken":"","nodeOptions":["--max-semi-space-size=16","--max-old-space-size=300"],"port":5680,"resources":{"limits":{"cpu":"2000m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"32Mi"}},"workerNodeAuthToken":""},"maxConcurrency":5,"mode":"internal","taskHeartbeatInterval":30,"taskTimeout":60}` | Task runners mode. Please follow the documentation for more information: https://docs.n8n.io/hosting/configuration/task-runners/ |
 | taskRunners.broker | object | `{"address":"127.0.0.1","port":5679}` | The address for the broker of the external task runner |
 | taskRunners.broker.address | string | `"127.0.0.1"` | The address for the broker of the external task runner |
 | taskRunners.broker.port | int | `5679` | The port for the broker of the external task runner |
@@ -1443,13 +1460,6 @@ helm upgrade [RELEASE_NAME] community-charts/n8n
 | taskRunners.external.workerNodeAuthToken | string | `""` | The auth token for the worker node |
 | taskRunners.maxConcurrency | int | `5` | The maximum concurrency for the task |
 | taskRunners.mode | string | `"internal"` | Use `internal` to use internal task runner, or use `external` to have external sidecar task runner. For more information please follow the documentation: https://docs.n8n.io/hosting/configuration/task-runners/#task-runner-modes |
-| taskRunners.python | object | `{"builtin":{"modules":[]},"enabled":false,"external":{"allowAll":false,"packages":[]}}` | Python runner configuration. Requires n8n 1.111.0+ and external task runner mode. |
-| taskRunners.python.builtin | object | `{"modules":[]}` | Built-in Python module access for the Code node. |
-| taskRunners.python.builtin.modules | list | `[]` | Python standard library modules allowed in Code nodes. Use ['*'] to allow all. |
-| taskRunners.python.enabled | bool | `false` | Enable Python code execution in the Code node via external task runners. |
-| taskRunners.python.external | object | `{"allowAll":false,"packages":[]}` | External Python package access for the Code node. |
-| taskRunners.python.external.allowAll | bool | `false` | Allow all external Python packages in Code nodes. When true, sets N8N_RUNNERS_EXTERNAL_ALLOW=* regardless of packages list. |
-| taskRunners.python.external.packages | list | `[]` | Python packages to install via uv before starting the runner (e.g. ["pandas", "numpy"]). Each listed package is also automatically allowed as an external package in Code nodes. |
 | taskRunners.taskHeartbeatInterval | int | `30` | The heartbeat interval for the task in seconds |
 | taskRunners.taskTimeout | int | `60` | The timeout for the task in seconds |
 | timezone | string | `"Europe/Berlin"` | For instance, the Schedule node uses it to know at what time the workflow should start. Find you timezone from here: https://momentjs.com/timezone/ |

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.22.0](https://img.shields.io/badge/Version-1.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.23.4](https://img.shields.io/badge/AppVersion-2.23.4-informational?style=flat-square)
+![Version: 1.22.1](https://img.shields.io/badge/Version-1.22.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.23.4](https://img.shields.io/badge/AppVersion-2.23.4-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -336,9 +336,26 @@ taskRunners:
     enabled: true
 ```
 
+### Install Python Packages
+
+The `n8nio/runners` image ships only a bare Python environment. Use `taskRunners.python.packages` to install packages via `uv pip install` before the runner starts. List any third-party packages your Code nodes need:
+
+```yaml
+taskRunners:
+  mode: external
+  python:
+    enabled: true
+    packages:
+      - pandas
+      - numpy
+      - requests
+```
+
+> **Note**: Package installation adds a few seconds to runner startup time. Packages must also be listed in `externalAllow` for n8n to permit their use in Code nodes.
+
 ### Restrict Python Module Access
 
-Use `stdlibAllow` to allowlist Python standard library modules and `externalAllow` for third-party packages. Set either to `*` to allow all.
+Use `stdlibAllow` to allowlist Python standard library modules and `externalAllow` for third-party packages. Set either to `*` to allow all. These settings apply to both the n8n broker (security enforcement) and the runner sidecar.
 
 ```yaml
 taskRunners:
@@ -347,6 +364,9 @@ taskRunners:
     enabled: true
     stdlibAllow: "os,sys,json,math,datetime,re"
     externalAllow: "numpy,pandas"
+    packages:
+      - numpy
+      - pandas
 ```
 
 ### Full Queue Mode + External Runner + Python Example
@@ -372,6 +392,10 @@ taskRunners:
   python:
     enabled: true
     stdlibAllow: "*"
+    externalAllow: "numpy,pandas"
+    packages:
+      - numpy
+      - pandas
   external:
     image:
       repository: n8nio/runners
@@ -1377,7 +1401,7 @@ helm upgrade [RELEASE_NAME] community-charts/n8n
 | serviceMonitor.targetLabels | list | `[]` | Set of labels to transfer on the Kubernetes Service onto the target. |
 | serviceMonitor.timeout | string | `"10s"` | Set timeout for scrape |
 | strategy | object | `{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"}` | This will set the deployment strategy more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |
-| taskRunners | object | `{"broker":{"address":"127.0.0.1","port":5679},"external":{"autoShutdownTimeout":15,"image":{"pullPolicy":"IfNotPresent","repository":"n8nio/runners","tag":""},"mainNodeAuthToken":"","nodeOptions":["--max-semi-space-size=16","--max-old-space-size=300"],"port":5680,"resources":{"limits":{"cpu":"2000m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"32Mi"}},"workerNodeAuthToken":""},"maxConcurrency":5,"mode":"internal","python":{"enabled":false,"externalAllow":"","stdlibAllow":""},"taskHeartbeatInterval":30,"taskTimeout":60}` | Task runners mode. Please follow the documentation for more information: https://docs.n8n.io/hosting/configuration/task-runners/ |
+| taskRunners | object | `{"broker":{"address":"127.0.0.1","port":5679},"external":{"autoShutdownTimeout":15,"image":{"pullPolicy":"IfNotPresent","repository":"n8nio/runners","tag":""},"mainNodeAuthToken":"","nodeOptions":["--max-semi-space-size=16","--max-old-space-size=300"],"port":5680,"resources":{"limits":{"cpu":"2000m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"32Mi"}},"workerNodeAuthToken":""},"maxConcurrency":5,"mode":"internal","python":{"enabled":false,"externalAllow":"","packages":[],"stdlibAllow":""},"taskHeartbeatInterval":30,"taskTimeout":60}` | Task runners mode. Please follow the documentation for more information: https://docs.n8n.io/hosting/configuration/task-runners/ |
 | taskRunners.broker | object | `{"address":"127.0.0.1","port":5679}` | The address for the broker of the external task runner |
 | taskRunners.broker.address | string | `"127.0.0.1"` | The address for the broker of the external task runner |
 | taskRunners.broker.port | int | `5679` | The port for the broker of the external task runner |
@@ -1400,9 +1424,10 @@ helm upgrade [RELEASE_NAME] community-charts/n8n
 | taskRunners.external.workerNodeAuthToken | string | `""` | The auth token for the worker node |
 | taskRunners.maxConcurrency | int | `5` | The maximum concurrency for the task |
 | taskRunners.mode | string | `"internal"` | Use `internal` to use internal task runner, or use `external` to have external sidecar task runner. For more information please follow the documentation: https://docs.n8n.io/hosting/configuration/task-runners/#task-runner-modes |
-| taskRunners.python | object | `{"enabled":false,"externalAllow":"","stdlibAllow":""}` | Python runner configuration. Requires n8n 1.111.0+ and external task runner mode. |
+| taskRunners.python | object | `{"enabled":false,"externalAllow":"","packages":[],"stdlibAllow":""}` | Python runner configuration. Requires n8n 1.111.0+ and external task runner mode. |
 | taskRunners.python.enabled | bool | `false` | Enable Python code execution in the Code node via external task runners. |
 | taskRunners.python.externalAllow | string | `""` | Third-party Python modules allowed in Code nodes (comma-separated). Use * to allow all. |
+| taskRunners.python.packages | list | `[]` | Python packages to install via uv before starting the runner (e.g. ["pandas", "numpy"]). |
 | taskRunners.python.stdlibAllow | string | `""` | Python standard library modules allowed in Code nodes (comma-separated). Use * to allow all. |
 | taskRunners.taskHeartbeatInterval | int | `30` | The heartbeat interval for the task in seconds |
 | taskRunners.taskTimeout | int | `60` | The timeout for the task in seconds |

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.21.0](https://img.shields.io/badge/Version-1.21.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.23.4](https://img.shields.io/badge/AppVersion-2.23.4-informational?style=flat-square)
+![Version: 1.22.0](https://img.shields.io/badge/Version-1.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.23.4](https://img.shields.io/badge/AppVersion-2.23.4-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -1271,12 +1271,16 @@ helm upgrade [RELEASE_NAME] community-charts/n8n
 | serviceMonitor.targetLabels | list | `[]` | Set of labels to transfer on the Kubernetes Service onto the target. |
 | serviceMonitor.timeout | string | `"10s"` | Set timeout for scrape |
 | strategy | object | `{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"}` | This will set the deployment strategy more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |
-| taskRunners | object | `{"broker":{"address":"127.0.0.1","port":5679},"external":{"autoShutdownTimeout":15,"mainNodeAuthToken":"","nodeOptions":["--max-semi-space-size=16","--max-old-space-size=300"],"port":5680,"resources":{"limits":{"cpu":"2000m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"32Mi"}},"workerNodeAuthToken":""},"maxConcurrency":5,"mode":"internal","taskHeartbeatInterval":30,"taskTimeout":60}` | Task runners mode. Please follow the documentation for more information: https://docs.n8n.io/hosting/configuration/task-runners/ |
+| taskRunners | object | `{"broker":{"address":"127.0.0.1","port":5679},"external":{"autoShutdownTimeout":15,"image":{"pullPolicy":"IfNotPresent","repository":"n8nio/runners","tag":""},"mainNodeAuthToken":"","nodeOptions":["--max-semi-space-size=16","--max-old-space-size=300"],"port":5680,"resources":{"limits":{"cpu":"2000m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"32Mi"}},"workerNodeAuthToken":""},"maxConcurrency":5,"mode":"internal","taskHeartbeatInterval":30,"taskTimeout":60}` | Task runners mode. Please follow the documentation for more information: https://docs.n8n.io/hosting/configuration/task-runners/ |
 | taskRunners.broker | object | `{"address":"127.0.0.1","port":5679}` | The address for the broker of the external task runner |
 | taskRunners.broker.address | string | `"127.0.0.1"` | The address for the broker of the external task runner |
 | taskRunners.broker.port | int | `5679` | The port for the broker of the external task runner |
-| taskRunners.external | object | `{"autoShutdownTimeout":15,"mainNodeAuthToken":"","nodeOptions":["--max-semi-space-size=16","--max-old-space-size=300"],"port":5680,"resources":{"limits":{"cpu":"2000m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"32Mi"}},"workerNodeAuthToken":""}` | The configuration for the external task runner |
+| taskRunners.external | object | `{"autoShutdownTimeout":15,"image":{"pullPolicy":"IfNotPresent","repository":"n8nio/runners","tag":""},"mainNodeAuthToken":"","nodeOptions":["--max-semi-space-size=16","--max-old-space-size=300"],"port":5680,"resources":{"limits":{"cpu":"2000m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"32Mi"}},"workerNodeAuthToken":""}` | The configuration for the external task runner |
 | taskRunners.external.autoShutdownTimeout | int | `15` | The auto shutdown timeout for the external task runner in seconds |
+| taskRunners.external.image | object | `{"pullPolicy":"IfNotPresent","repository":"n8nio/runners","tag":""}` | The image for the external task runner sidecar. Tag must match the n8n appVersion. |
+| taskRunners.external.image.pullPolicy | string | `"IfNotPresent"` | This sets the pull policy for images. |
+| taskRunners.external.image.repository | string | `"n8nio/runners"` | The repository for the external task runner image |
+| taskRunners.external.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | taskRunners.external.mainNodeAuthToken | string | `""` | The auth token for the main node |
 | taskRunners.external.nodeOptions | list | `["--max-semi-space-size=16","--max-old-space-size=300"]` | The node options for the external task runner |
 | taskRunners.external.port | int | `5680` | The port for the external task runner |

--- a/charts/n8n/README.md.gotmpl
+++ b/charts/n8n/README.md.gotmpl
@@ -351,11 +351,11 @@ taskRunners:
       - requests
 ```
 
-> **Note**: Package installation adds a few seconds to runner startup time. Packages must also be listed in `externalAllow` for n8n to permit their use in Code nodes.
+> **Note**: Package installation adds a few seconds to runner startup time. Each package listed in `packages` is automatically allowed as an external package in Code nodes — no separate allowlist entry is needed.
 
 ### Restrict Python Module Access
 
-Use `stdlibAllow` to allowlist Python standard library modules and `externalAllow` for third-party packages. Set either to `*` to allow all. These settings apply to both the n8n broker (security enforcement) and the runner sidecar.
+Use `stdlibAllow` to allowlist Python standard library modules. Set to `*` to allow all. This setting applies to both the n8n broker (security enforcement) and the runner sidecar. External packages listed in `packages` are automatically permitted.
 
 ```yaml
 taskRunners:
@@ -363,7 +363,6 @@ taskRunners:
   python:
     enabled: true
     stdlibAllow: "os,sys,json,math,datetime,re"
-    externalAllow: "numpy,pandas"
     packages:
       - numpy
       - pandas
@@ -392,7 +391,6 @@ taskRunners:
   python:
     enabled: true
     stdlibAllow: "*"
-    externalAllow: "numpy,pandas"
     packages:
       - numpy
       - pandas

--- a/charts/n8n/README.md.gotmpl
+++ b/charts/n8n/README.md.gotmpl
@@ -338,34 +338,52 @@ taskRunners:
 
 ### Install Python Packages
 
-The `n8nio/runners` image ships only a bare Python environment. Use `taskRunners.python.packages` to install packages via `uv pip install` before the runner starts. List any third-party packages your Code nodes need:
+The `n8nio/runners` image ships only a bare Python environment. Use `taskRunners.python.external.packages` to install packages via `uv pip install` before the runner starts. Each listed package is automatically allowed in Code nodes — no separate allowlist entry is needed.
 
 ```yaml
 taskRunners:
   mode: external
   python:
     enabled: true
-    packages:
-      - pandas
-      - numpy
-      - requests
+    external:
+      packages:
+        - pandas
+        - numpy
+        - requests
 ```
 
-> **Note**: Package installation adds a few seconds to runner startup time. Each package listed in `packages` is automatically allowed as an external package in Code nodes — no separate allowlist entry is needed.
+> **Note**: Package installation adds a few seconds to runner startup time.
+
+To allow all external packages without installing them (e.g. when packages are pre-installed in a custom image), set `allowAll: true`:
+
+```yaml
+taskRunners:
+  mode: external
+  python:
+    enabled: true
+    external:
+      allowAll: true
+```
 
 ### Restrict Python Module Access
 
-Use `stdlibAllow` to allowlist Python standard library modules. Set to `*` to allow all. This setting applies to both the n8n broker (security enforcement) and the runner sidecar. External packages listed in `packages` are automatically permitted.
+Use `builtin.modules` to allowlist Python standard library modules. Use `["*"]` to allow all. This setting applies to both the n8n broker (security enforcement) and the runner sidecar.
 
 ```yaml
 taskRunners:
   mode: external
   python:
     enabled: true
-    stdlibAllow: "os,sys,json,math,datetime,re"
-    packages:
-      - numpy
-      - pandas
+    builtin:
+      modules:
+        - os
+        - sys
+        - json
+        - math
+    external:
+      packages:
+        - numpy
+        - pandas
 ```
 
 ### Full Queue Mode + External Runner + Python Example
@@ -390,10 +408,13 @@ taskRunners:
   mode: external
   python:
     enabled: true
-    stdlibAllow: "*"
-    packages:
-      - numpy
-      - pandas
+    builtin:
+      modules:
+        - "*"
+    external:
+      packages:
+        - numpy
+        - pandas
   external:
     image:
       repository: n8nio/runners

--- a/charts/n8n/README.md.gotmpl
+++ b/charts/n8n/README.md.gotmpl
@@ -449,6 +449,10 @@ nodes:
       packages:
         - numpy
         - pandas
+    persistence:
+      enabled: true
+      size: 2Gi
+      accessMode: ReadWriteMany  # required for queue-mode workers scaled across nodes
 
 taskRunners:
   mode: external

--- a/charts/n8n/README.md.gotmpl
+++ b/charts/n8n/README.md.gotmpl
@@ -323,26 +323,27 @@ taskRunners:
 
 ## Python Runner Support
 
-The `n8nio/runners` image ships a Python runner alongside the JavaScript runner. Enable it with `taskRunners.python.enabled: true` (requires n8n 1.111.0+). This activates the Python Code node on the main container and starts the Python launcher inside the sidecar.
+The `n8nio/runners` image ships a Python runner alongside the JavaScript runner. Enable it with `nodes.python.enabled: true` (requires n8n 1.111.0+). This activates the Python Code node on the main container and starts the Python launcher inside the sidecar.
 
 > **Tip**: Python runner requires `taskRunners.mode: external`.
 
 ### Enable Python Runner
 
 ```yaml
-taskRunners:
-  mode: external
+nodes:
   python:
     enabled: true
+
+taskRunners:
+  mode: external
 ```
 
 ### Install Python Packages
 
-The `n8nio/runners` image ships only a bare Python environment. Use `taskRunners.python.external.packages` to install packages via `uv pip install` before the runner starts. Each listed package is automatically allowed in Code nodes — no separate allowlist entry is needed.
+The `n8nio/runners` image ships only a bare Python environment. Use `nodes.python.external.packages` to install packages via `uv pip install` before the runner starts. Each listed package is automatically allowed in Code nodes — no separate allowlist entry is needed.
 
 ```yaml
-taskRunners:
-  mode: external
+nodes:
   python:
     enabled: true
     external:
@@ -350,6 +351,9 @@ taskRunners:
         - pandas
         - numpy
         - requests
+
+taskRunners:
+  mode: external
 ```
 
 > **Note**: Package installation adds a few seconds to runner startup time.
@@ -357,21 +361,22 @@ taskRunners:
 To allow all external packages without installing them (e.g. when packages are pre-installed in a custom image), set `allowAll: true`:
 
 ```yaml
-taskRunners:
-  mode: external
+nodes:
   python:
     enabled: true
     external:
       allowAll: true
+
+taskRunners:
+  mode: external
 ```
 
 ### Restrict Python Module Access
 
-Use `builtin.modules` to allowlist Python standard library modules. Use `["*"]` to allow all. This setting applies to both the n8n broker (security enforcement) and the runner sidecar.
+Use `nodes.python.builtin.modules` to allowlist Python standard library modules. Use `["*"]` to allow all. This setting applies to both the n8n broker (security enforcement) and the runner sidecar.
 
 ```yaml
-taskRunners:
-  mode: external
+nodes:
   python:
     enabled: true
     builtin:
@@ -384,6 +389,9 @@ taskRunners:
       packages:
         - numpy
         - pandas
+
+taskRunners:
+  mode: external
 ```
 
 ### Full Queue Mode + External Runner + Python Example
@@ -404,8 +412,7 @@ externalRedis:
   username: "default"
   password: "Pa33w0rd!"
 
-taskRunners:
-  mode: external
+nodes:
   python:
     enabled: true
     builtin:
@@ -415,6 +422,9 @@ taskRunners:
       packages:
         - numpy
         - pandas
+
+taskRunners:
+  mode: external
   external:
     image:
       repository: n8nio/runners

--- a/charts/n8n/README.md.gotmpl
+++ b/charts/n8n/README.md.gotmpl
@@ -275,9 +275,115 @@ webhook:
 
 Please find more detail about external task runners from [here](https://docs.n8n.io/hosting/securing/hardening-task-runners/).
 
+The external task runner runs as a sidecar container using the dedicated `n8nio/runners` image alongside each worker pod. In queue mode the main pod does **not** receive the sidecar because it does not execute workflows.
+
+### Basic External Task Runner
+
 ```yaml
 taskRunners:
   mode: external
+```
+
+### Pinning the Runner Image Tag
+
+By default the runner image tag matches the chart `appVersion`. Pin an explicit version with `taskRunners.external.image.tag`:
+
+```yaml
+taskRunners:
+  mode: external
+  external:
+    image:
+      repository: n8nio/runners
+      pullPolicy: IfNotPresent
+      tag: "2.23.4"
+```
+
+### External Task Runner with Queue Mode
+
+In queue mode the sidecar is attached to worker pods only — the main pod is excluded automatically because it offloads all workflow execution to workers.
+
+```yaml
+db:
+  type: postgresdb
+
+worker:
+  mode: queue
+
+taskRunners:
+  mode: external
+  external:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 64Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
+```
+
+## Python Runner Support
+
+The `n8nio/runners` image ships a Python runner alongside the JavaScript runner. Enable it with `taskRunners.python.enabled: true` (requires n8n 1.111.0+). This activates the Python Code node on the main container and starts the Python launcher inside the sidecar.
+
+> **Tip**: Python runner requires `taskRunners.mode: external`.
+
+### Enable Python Runner
+
+```yaml
+taskRunners:
+  mode: external
+  python:
+    enabled: true
+```
+
+### Restrict Python Module Access
+
+Use `stdlibAllow` to allowlist Python standard library modules and `externalAllow` for third-party packages. Set either to `*` to allow all.
+
+```yaml
+taskRunners:
+  mode: external
+  python:
+    enabled: true
+    stdlibAllow: "os,sys,json,math,datetime,re"
+    externalAllow: "numpy,pandas"
+```
+
+### Full Queue Mode + External Runner + Python Example
+
+```yaml
+db:
+  type: postgresdb
+
+worker:
+  mode: queue
+  count: 2
+
+  waitMainNodeReady:
+    enabled: true
+
+externalRedis:
+  host: "redis-instance1.ab012cdefghi.eu-central-1.rds.amazonaws.com"
+  username: "default"
+  password: "Pa33w0rd!"
+
+taskRunners:
+  mode: external
+  python:
+    enabled: true
+    stdlibAllow: "*"
+  external:
+    image:
+      repository: n8nio/runners
+      pullPolicy: IfNotPresent
+      tag: ""
+    resources:
+      requests:
+        cpu: 100m
+        memory: 64Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
 ```
 
 ## Autoscaling Configuration

--- a/charts/n8n/README.md.gotmpl
+++ b/charts/n8n/README.md.gotmpl
@@ -336,9 +336,26 @@ taskRunners:
     enabled: true
 ```
 
+### Install Python Packages
+
+The `n8nio/runners` image ships only a bare Python environment. Use `taskRunners.python.packages` to install packages via `uv pip install` before the runner starts. List any third-party packages your Code nodes need:
+
+```yaml
+taskRunners:
+  mode: external
+  python:
+    enabled: true
+    packages:
+      - pandas
+      - numpy
+      - requests
+```
+
+> **Note**: Package installation adds a few seconds to runner startup time. Packages must also be listed in `externalAllow` for n8n to permit their use in Code nodes.
+
 ### Restrict Python Module Access
 
-Use `stdlibAllow` to allowlist Python standard library modules and `externalAllow` for third-party packages. Set either to `*` to allow all.
+Use `stdlibAllow` to allowlist Python standard library modules and `externalAllow` for third-party packages. Set either to `*` to allow all. These settings apply to both the n8n broker (security enforcement) and the runner sidecar.
 
 ```yaml
 taskRunners:
@@ -347,6 +364,9 @@ taskRunners:
     enabled: true
     stdlibAllow: "os,sys,json,math,datetime,re"
     externalAllow: "numpy,pandas"
+    packages:
+      - numpy
+      - pandas
 ```
 
 ### Full Queue Mode + External Runner + Python Example
@@ -372,6 +392,10 @@ taskRunners:
   python:
     enabled: true
     stdlibAllow: "*"
+    externalAllow: "numpy,pandas"
+    packages:
+      - numpy
+      - pandas
   external:
     image:
       repository: n8nio/runners

--- a/charts/n8n/README.md.gotmpl
+++ b/charts/n8n/README.md.gotmpl
@@ -383,6 +383,8 @@ Packages are stored at `/home/node/.python-packages` inside the runner sidecar. 
 
 For StatefulSet deployments (when `main.count > 1` with `ReadWriteOnce`, or `main.forceToUseStatefulset: true`), each pod receives its own PVC via `volumeClaimTemplates`, so `ReadWriteOnce` works regardless of pod count. For Deployment-mode workers scaled by HPA across multiple nodes, use `accessMode: ReadWriteMany` with a compatible storage class (NFS, CephFS, etc.).
 
+> **Warning**: When `worker.autoscaling.enabled: true`, you **must** set `nodes.python.persistence.accessMode: ReadWriteMany` (or leave persistence disabled). The HPA will not render if python packages persistence is enabled with `ReadWriteOnce`, because scaling workers across nodes would cause PVC mount failures.
+
 To allow all external packages without installing them (e.g. when packages are pre-installed in a custom image), set `allowAll: true`:
 
 ```yaml

--- a/charts/n8n/README.md.gotmpl
+++ b/charts/n8n/README.md.gotmpl
@@ -356,7 +356,32 @@ taskRunners:
   mode: external
 ```
 
-> **Note**: Package installation adds a few seconds to runner startup time.
+> **Note**: Package installation adds a few seconds to runner startup time on the first start. To avoid re-downloading packages on every pod restart, enable persistence (see below).
+
+#### Persist Python Packages
+
+Enable `nodes.python.persistence` to store installed packages on a PVC. When enabled, `uv pip install` detects existing packages on subsequent starts and skips the download.
+
+```yaml
+nodes:
+  python:
+    enabled: true
+    external:
+      packages:
+        - pandas
+        - numpy
+    persistence:
+      enabled: true
+      size: 2Gi
+      accessMode: ReadWriteOnce  # use ReadWriteMany if workers span multiple nodes
+
+taskRunners:
+  mode: external
+```
+
+Packages are stored at `/home/node/.python-packages` inside the runner sidecar. When `persistence.enabled` is `false` (the default), an `emptyDir` volume is used and packages are re-installed on every pod restart.
+
+For StatefulSet deployments (when `main.count > 1` with `ReadWriteOnce`, or `main.forceToUseStatefulset: true`), each pod receives its own PVC via `volumeClaimTemplates`, so `ReadWriteOnce` works regardless of pod count. For Deployment-mode workers scaled by HPA across multiple nodes, use `accessMode: ReadWriteMany` with a compatible storage class (NFS, CephFS, etc.).
 
 To allow all external packages without installing them (e.g. when packages are pre-installed in a custom image), set `allowAll: true`:
 

--- a/charts/n8n/README.md.gotmpl
+++ b/charts/n8n/README.md.gotmpl
@@ -398,6 +398,55 @@ taskRunners:
   mode: external
 ```
 
+### Private Python Package Registry
+
+By default, `uv pip install` resolves packages from pypi.org. Use `pypiRegistry` to point the runner sidecar at a private or self-hosted index instead (JFrog Artifactory, AWS CodeArtifact, Nexus, etc.).
+
+#### Simple — URL only (no auth or inline credentials)
+
+```yaml
+pypiRegistry:
+  enabled: true
+  url: "https://my.jfrog.io/artifactory/api/pypi/pypi-virtual/simple/"
+```
+
+This sets `UV_DEFAULT_INDEX` in the sidecar, replacing pypi.org as the default index.
+
+#### Advanced — `uv.toml` config file (authentication or multiple indexes)
+
+For authenticated registries, create a `uv.toml` with your index configuration and let the chart store it in a Kubernetes Secret:
+
+```yaml
+pypiRegistry:
+  enabled: true
+  customUvConfig: |
+    [[index]]
+    name = "private"
+    url = "https://my.jfrog.io/artifactory/api/pypi/pypi-virtual/simple/"
+    default = true
+
+    [index.credentials]
+    username = "ci-user"
+    password = "s3cr3t"
+```
+
+The chart creates a Secret from `customUvConfig`, mounts it into the runner sidecar, and sets `UV_CONFIG_FILE` to the mounted path. The entire file is base64-encoded in the Secret.
+
+> **Note**: Do not use `url` together with `customUvConfig` or `secretName` — when a config file is provided, the index URL belongs inside the `uv.toml`.
+
+#### Advanced — reference an existing Secret
+
+If you manage credentials in an existing Kubernetes Secret, reference it directly:
+
+```yaml
+pypiRegistry:
+  enabled: true
+  secretName: "my-uv-config-secret"
+  secretKey: "uv.toml"
+```
+
+The secret must contain a key matching `secretKey` (default: `uv.toml`) whose value is valid `uv.toml` content.
+
 ### Restrict Python Module Access
 
 Use `nodes.python.builtin.modules` to allowlist Python standard library modules. Use `["*"]` to allow all. This setting applies to both the n8n broker (security enforcement) and the runner sidecar.

--- a/charts/n8n/templates/_helpers.tpl
+++ b/charts/n8n/templates/_helpers.tpl
@@ -404,6 +404,20 @@ app.kubernetes.io/component: persistence
 {{- end }}
 
 {{/*
+n8n python packages PVC name
+*/}}
+{{- define "n8n-python.packages.name" -}}
+{{- printf "%s-python-packages" (include "n8n.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+n8n python packages PVC full name (respects existingClaim)
+*/}}
+{{- define "n8n-python.packages.fullname" -}}
+{{- default (include "n8n-python.packages.name" .) .Values.nodes.python.persistence.existingClaim -}}
+{{- end -}}
+
+{{/*
 n8n npm install script logic
 */}}
 {{- define "n8n.npmInstallScript" -}}

--- a/charts/n8n/templates/_helpers.tpl
+++ b/charts/n8n/templates/_helpers.tpl
@@ -421,7 +421,7 @@ n8n python packages PVC full name (respects existingClaim)
 n8n task runner uv install shell command string (unquoted)
 */}}
 {{- define "n8n.taskRunners.uvInstallCommand" -}}
-UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /home/node/.python-packages {{ .Values.nodes.python.external.packages | join " " }} && export PYTHONPATH=/home/node/.python-packages && exec /usr/local/bin/task-runner-launcher javascript{{ ternary " python" "" .Values.nodes.python.enabled }}
+UV_CACHE_DIR=/tmp/.uv-cache UV_LINK_MODE=copy uv pip install --target /home/node/.python-packages {{ .Values.nodes.python.external.packages | join " " }} && export PYTHONPATH=/home/node/.python-packages && exec /usr/local/bin/task-runner-launcher javascript{{ ternary " python" "" .Values.nodes.python.enabled }}
 {{- end -}}
 
 {{/*

--- a/charts/n8n/templates/_helpers.tpl
+++ b/charts/n8n/templates/_helpers.tpl
@@ -418,6 +418,13 @@ n8n python packages PVC full name (respects existingClaim)
 {{- end -}}
 
 {{/*
+n8n task runner uv install shell command string (unquoted)
+*/}}
+{{- define "n8n.taskRunners.uvInstallCommand" -}}
+UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /home/node/.python-packages {{ .Values.nodes.python.external.packages | join " " }} && export PYTHONPATH=/home/node/.python-packages && exec /usr/local/bin/task-runner-launcher javascript{{ ternary " python" "" .Values.nodes.python.enabled }}
+{{- end -}}
+
+{{/*
 n8n npm install script logic
 */}}
 {{- define "n8n.npmInstallScript" -}}

--- a/charts/n8n/templates/configmap.yaml
+++ b/charts/n8n/templates/configmap.yaml
@@ -191,7 +191,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  N8N_RUNNERS_ENABLED: "true"
   N8N_RUNNERS_MODE: {{ .Values.taskRunners.mode | quote }}
   N8N_RUNNERS_TASK_TIMEOUT: {{ .Values.taskRunners.taskTimeout | quote }}
   N8N_RUNNERS_HEARTBEAT_INTERVAL: {{ .Values.taskRunners.taskHeartbeatInterval | quote }}

--- a/charts/n8n/templates/configmap.yaml
+++ b/charts/n8n/templates/configmap.yaml
@@ -202,11 +202,13 @@ data:
 {{- end }}
 {{- if .Values.taskRunners.python.enabled }}
   N8N_NATIVE_PYTHON_RUNNER: "true"
-{{- if .Values.taskRunners.python.stdlibAllow }}
-  N8N_RUNNERS_STDLIB_ALLOW: {{ .Values.taskRunners.python.stdlibAllow | quote }}
+{{- if .Values.taskRunners.python.builtin.modules }}
+  N8N_RUNNERS_STDLIB_ALLOW: {{ .Values.taskRunners.python.builtin.modules | join "," | quote }}
 {{- end }}
-{{- if .Values.taskRunners.python.packages }}
-  N8N_RUNNERS_EXTERNAL_ALLOW: {{ .Values.taskRunners.python.packages | join "," | quote }}
+{{- if .Values.taskRunners.python.external.allowAll }}
+  N8N_RUNNERS_EXTERNAL_ALLOW: "*"
+{{- else if .Values.taskRunners.python.external.packages }}
+  N8N_RUNNERS_EXTERNAL_ALLOW: {{ .Values.taskRunners.python.external.packages | join "," | quote }}
 {{- end }}
 {{- end }}
 ---
@@ -262,11 +264,13 @@ data:
   SENTRY_DSN: ""
 {{- end }}
 {{- if .Values.taskRunners.python.enabled }}
-{{- if .Values.taskRunners.python.stdlibAllow }}
-  N8N_RUNNERS_STDLIB_ALLOW: {{ .Values.taskRunners.python.stdlibAllow | quote }}
+{{- if .Values.taskRunners.python.builtin.modules }}
+  N8N_RUNNERS_STDLIB_ALLOW: {{ .Values.taskRunners.python.builtin.modules | join "," | quote }}
 {{- end }}
-{{- if .Values.taskRunners.python.packages }}
-  N8N_RUNNERS_EXTERNAL_ALLOW: {{ .Values.taskRunners.python.packages | join "," | quote }}
+{{- if .Values.taskRunners.python.external.allowAll }}
+  N8N_RUNNERS_EXTERNAL_ALLOW: "*"
+{{- else if .Values.taskRunners.python.external.packages }}
+  N8N_RUNNERS_EXTERNAL_ALLOW: {{ .Values.taskRunners.python.external.packages | join "," | quote }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/n8n/templates/configmap.yaml
+++ b/charts/n8n/templates/configmap.yaml
@@ -200,15 +200,15 @@ data:
 {{- else }}
   N8N_RUNNERS_MAX_CONCURRENCY: {{ .Values.taskRunners.maxConcurrency | quote }}
 {{- end }}
-{{- if .Values.taskRunners.python.enabled }}
+{{- if .Values.nodes.python.enabled }}
   N8N_NATIVE_PYTHON_RUNNER: "true"
-{{- if .Values.taskRunners.python.builtin.modules }}
-  N8N_RUNNERS_STDLIB_ALLOW: {{ .Values.taskRunners.python.builtin.modules | join "," | quote }}
+{{- if .Values.nodes.python.builtin.modules }}
+  N8N_RUNNERS_STDLIB_ALLOW: {{ .Values.nodes.python.builtin.modules | join "," | quote }}
 {{- end }}
-{{- if .Values.taskRunners.python.external.allowAll }}
+{{- if .Values.nodes.python.external.allowAll }}
   N8N_RUNNERS_EXTERNAL_ALLOW: "*"
-{{- else if .Values.taskRunners.python.external.packages }}
-  N8N_RUNNERS_EXTERNAL_ALLOW: {{ .Values.taskRunners.python.external.packages | join "," | quote }}
+{{- else if .Values.nodes.python.external.packages }}
+  N8N_RUNNERS_EXTERNAL_ALLOW: {{ .Values.nodes.python.external.packages | join "," | quote }}
 {{- end }}
 {{- end }}
 ---
@@ -263,14 +263,14 @@ data:
 {{- else }}
   SENTRY_DSN: ""
 {{- end }}
-{{- if .Values.taskRunners.python.enabled }}
-{{- if .Values.taskRunners.python.builtin.modules }}
-  N8N_RUNNERS_STDLIB_ALLOW: {{ .Values.taskRunners.python.builtin.modules | join "," | quote }}
+{{- if .Values.nodes.python.enabled }}
+{{- if .Values.nodes.python.builtin.modules }}
+  N8N_RUNNERS_STDLIB_ALLOW: {{ .Values.nodes.python.builtin.modules | join "," | quote }}
 {{- end }}
-{{- if .Values.taskRunners.python.external.allowAll }}
+{{- if .Values.nodes.python.external.allowAll }}
   N8N_RUNNERS_EXTERNAL_ALLOW: "*"
-{{- else if .Values.taskRunners.python.external.packages }}
-  N8N_RUNNERS_EXTERNAL_ALLOW: {{ .Values.taskRunners.python.external.packages | join "," | quote }}
+{{- else if .Values.nodes.python.external.packages }}
+  N8N_RUNNERS_EXTERNAL_ALLOW: {{ .Values.nodes.python.external.packages | join "," | quote }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/n8n/templates/configmap.yaml
+++ b/charts/n8n/templates/configmap.yaml
@@ -202,6 +202,12 @@ data:
 {{- end }}
 {{- if .Values.taskRunners.python.enabled }}
   N8N_NATIVE_PYTHON_RUNNER: "true"
+{{- if .Values.taskRunners.python.stdlibAllow }}
+  N8N_RUNNERS_STDLIB_ALLOW: {{ .Values.taskRunners.python.stdlibAllow | quote }}
+{{- end }}
+{{- if .Values.taskRunners.python.externalAllow }}
+  N8N_RUNNERS_EXTERNAL_ALLOW: {{ .Values.taskRunners.python.externalAllow | quote }}
+{{- end }}
 {{- end }}
 ---
 apiVersion: v1

--- a/charts/n8n/templates/configmap.yaml
+++ b/charts/n8n/templates/configmap.yaml
@@ -205,8 +205,8 @@ data:
 {{- if .Values.taskRunners.python.stdlibAllow }}
   N8N_RUNNERS_STDLIB_ALLOW: {{ .Values.taskRunners.python.stdlibAllow | quote }}
 {{- end }}
-{{- if .Values.taskRunners.python.externalAllow }}
-  N8N_RUNNERS_EXTERNAL_ALLOW: {{ .Values.taskRunners.python.externalAllow | quote }}
+{{- if .Values.taskRunners.python.packages }}
+  N8N_RUNNERS_EXTERNAL_ALLOW: {{ .Values.taskRunners.python.packages | join "," | quote }}
 {{- end }}
 {{- end }}
 ---
@@ -265,8 +265,8 @@ data:
 {{- if .Values.taskRunners.python.stdlibAllow }}
   N8N_RUNNERS_STDLIB_ALLOW: {{ .Values.taskRunners.python.stdlibAllow | quote }}
 {{- end }}
-{{- if .Values.taskRunners.python.externalAllow }}
-  N8N_RUNNERS_EXTERNAL_ALLOW: {{ .Values.taskRunners.python.externalAllow | quote }}
+{{- if .Values.taskRunners.python.packages }}
+  N8N_RUNNERS_EXTERNAL_ALLOW: {{ .Values.taskRunners.python.packages | join "," | quote }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/n8n/templates/configmap.yaml
+++ b/charts/n8n/templates/configmap.yaml
@@ -200,6 +200,9 @@ data:
 {{- else }}
   N8N_RUNNERS_MAX_CONCURRENCY: {{ .Values.taskRunners.maxConcurrency | quote }}
 {{- end }}
+{{- if .Values.taskRunners.python.enabled }}
+  N8N_NATIVE_PYTHON_RUNNER: "true"
+{{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -251,6 +254,14 @@ data:
   DEPLOYMENT_NAME: {{ .Release.Name | quote }}
 {{- else }}
   SENTRY_DSN: ""
+{{- end }}
+{{- if .Values.taskRunners.python.enabled }}
+{{- if .Values.taskRunners.python.stdlibAllow }}
+  N8N_RUNNERS_STDLIB_ALLOW: {{ .Values.taskRunners.python.stdlibAllow | quote }}
+{{- end }}
+{{- if .Values.taskRunners.python.externalAllow }}
+  N8N_RUNNERS_EXTERNAL_ALLOW: {{ .Values.taskRunners.python.externalAllow | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- if .Values.license.enabled }}

--- a/charts/n8n/templates/deployment-mcp-webhook.yaml
+++ b/charts/n8n/templates/deployment-mcp-webhook.yaml
@@ -148,8 +148,6 @@ spec:
                   name: {{ default (include "n8n.redis.fullname" .) .Values.externalRedis.existingSecret }}
                   key: {{ default "redis-password" .Values.externalRedis.existingPasswordKey }}
                   optional: true
-            - name: N8N_RUNNERS_ENABLED
-              value: "true"
             - name: N8N_RUNNERS_MODE
               value: internal
             - name: N8N_RUNNERS_TASK_TIMEOUT

--- a/charts/n8n/templates/deployment-webhook.yaml
+++ b/charts/n8n/templates/deployment-webhook.yaml
@@ -161,8 +161,6 @@ spec:
                   name: {{ default (include "n8n.redis.fullname" .) .Values.externalRedis.existingSecret }}
                   key: {{ default "redis-password" .Values.externalRedis.existingPasswordKey }}
                   optional: true
-            - name: N8N_RUNNERS_ENABLED
-              value: "true"
             - name: N8N_RUNNERS_MODE
               value: internal
             - name: N8N_RUNNERS_TASK_TIMEOUT

--- a/charts/n8n/templates/deployment-worker.yaml
+++ b/charts/n8n/templates/deployment-worker.yaml
@@ -325,11 +325,11 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.taskRunners.external.image.repository }}:{{ .Values.taskRunners.external.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.taskRunners.external.image.pullPolicy }}
-          {{- if .Values.taskRunners.python.packages }}
+          {{- if .Values.taskRunners.python.external.packages }}
           command:
             - /bin/sh
             - -c
-            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages %s && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.taskRunners.python.packages | join " ") (ternary " python" "" .Values.taskRunners.python.enabled) | quote }}
+            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages %s && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.taskRunners.python.external.packages | join " ") (ternary " python" "" .Values.taskRunners.python.enabled) | quote }}
           {{- else }}
           command:
             - /usr/local/bin/task-runner-launcher

--- a/charts/n8n/templates/deployment-worker.yaml
+++ b/charts/n8n/templates/deployment-worker.yaml
@@ -325,17 +325,17 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.taskRunners.external.image.repository }}:{{ .Values.taskRunners.external.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.taskRunners.external.image.pullPolicy }}
-          {{- if .Values.taskRunners.python.external.packages }}
+          {{- if .Values.nodes.python.external.packages }}
           command:
             - /bin/sh
             - -c
-            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages %s && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.taskRunners.python.external.packages | join " ") (ternary " python" "" .Values.taskRunners.python.enabled) | quote }}
+            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages %s && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.nodes.python.external.packages | join " ") (ternary " python" "" .Values.nodes.python.enabled) | quote }}
           {{- else }}
           command:
             - /usr/local/bin/task-runner-launcher
           args:
             - javascript
-          {{- if .Values.taskRunners.python.enabled }}
+          {{- if .Values.nodes.python.enabled }}
             - python
           {{- end }}
           {{- end }}

--- a/charts/n8n/templates/deployment-worker.yaml
+++ b/charts/n8n/templates/deployment-worker.yaml
@@ -332,17 +332,17 @@ spec:
             - python
           {{- end }}
           ports:
-            - name: http
+            - name: runner-health
               containerPort: {{ .Values.taskRunners.external.port }}
               protocol: TCP
           livenessProbe:
             httpGet:
               path: /healthz
-              port: http
+              port: runner-health
           readinessProbe:
             httpGet:
               path: /healthz
-              port: http
+              port: runner-health
           resources:
             {{- toYaml .Values.taskRunners.external.resources | nindent 12 }}
           env:

--- a/charts/n8n/templates/deployment-worker.yaml
+++ b/charts/n8n/templates/deployment-worker.yaml
@@ -329,7 +329,7 @@ spec:
           command:
             - /bin/sh
             - -c
-            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages %s && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.nodes.python.external.packages | join " ") (ternary " python" "" .Values.nodes.python.enabled) | quote }}
+            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /home/node/.python-packages %s && export PYTHONPATH=/home/node/.python-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.nodes.python.external.packages | join " ") (ternary " python" "" .Values.nodes.python.enabled) | quote }}
           {{- else }}
           command:
             - /usr/local/bin/task-runner-launcher
@@ -388,6 +388,8 @@ spec:
               mountPath: /tmp
             - name: cache
               mountPath: /home/node/.cache
+            - name: python-packages
+              mountPath: /home/node/.python-packages
             - name: {{ default "node-modules" .Values.worker.persistence.volumeName }}
               mountPath: {{ .Values.worker.persistence.mountPath }}
               {{- if .Values.worker.persistence.subPath }}
@@ -408,6 +410,15 @@ spec:
           emptyDir: {}
         - name: cache
           emptyDir: {}
+      {{- if eq .Values.taskRunners.mode "external" }}
+        - name: python-packages
+          {{- if .Values.nodes.python.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "n8n-python.packages.fullname" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+      {{- end }}
       {{- if .Values.worker.persistence.enabled }}
         - name: {{ default "node-modules" .Values.worker.persistence.volumeName }}
           persistentVolumeClaim:

--- a/charts/n8n/templates/deployment-worker.yaml
+++ b/charts/n8n/templates/deployment-worker.yaml
@@ -380,6 +380,15 @@ spec:
             - name: N8N_REINSTALL_MISSING_PACKAGES
               value: "true"
           {{- end }}
+          {{- if .Values.pypiRegistry.enabled }}
+          {{- if or .Values.pypiRegistry.secretName .Values.pypiRegistry.customUvConfig }}
+            - name: UV_CONFIG_FILE
+              value: {{ printf "/home/node/.uv-config/%s" (default "uv.toml" .Values.pypiRegistry.secretKey) | quote }}
+          {{- else if .Values.pypiRegistry.url }}
+            - name: UV_DEFAULT_INDEX
+              value: {{ .Values.pypiRegistry.url | quote }}
+          {{- end }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ template "n8n.taskRunners.fullname" . }}-configmap
@@ -390,6 +399,11 @@ spec:
               mountPath: /home/node/.cache
             - name: python-packages
               mountPath: /home/node/.python-packages
+          {{- if and .Values.pypiRegistry.enabled (or .Values.pypiRegistry.secretName .Values.pypiRegistry.customUvConfig) }}
+            - name: uv-config
+              mountPath: /home/node/.uv-config
+              readOnly: true
+          {{- end }}
             - name: {{ default "node-modules" .Values.worker.persistence.volumeName }}
               mountPath: {{ .Values.worker.persistence.mountPath }}
               {{- if .Values.worker.persistence.subPath }}
@@ -430,6 +444,12 @@ spec:
       {{- if .Values.nodes.external.packages }}
         - name: community-node-modules
           emptyDir: {}
+      {{- end }}
+      {{- if and (eq .Values.taskRunners.mode "external") .Values.pypiRegistry.enabled (or .Values.pypiRegistry.secretName .Values.pypiRegistry.customUvConfig) }}
+        - name: uv-config
+          secret:
+            secretName: {{ default (printf "%s-pypi-registry-secret" (include "n8n.fullname" .)) .Values.pypiRegistry.secretName | quote }}
+            optional: true
       {{- end }}
       {{- if .Values.npmRegistry.enabled }}
         - name: npmrc

--- a/charts/n8n/templates/deployment-worker.yaml
+++ b/charts/n8n/templates/deployment-worker.yaml
@@ -325,16 +325,30 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.taskRunners.external.image.repository }}:{{ .Values.taskRunners.external.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.taskRunners.external.image.pullPolicy }}
-          command: ["/usr/local/bin/task-runner-launcher"]
+          {{- if .Values.taskRunners.python.packages }}
+          command:
+            - /bin/sh
+            - -c
+            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages %s && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.taskRunners.python.packages | join " ") (ternary " python" "" .Values.taskRunners.python.enabled) | quote }}
+          {{- else }}
+          command:
+            - /usr/local/bin/task-runner-launcher
           args:
             - javascript
           {{- if .Values.taskRunners.python.enabled }}
             - python
           {{- end }}
+          {{- end }}
           ports:
             - name: runner-health
               containerPort: {{ .Values.taskRunners.external.port }}
               protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: runner-health
+            failureThreshold: 30
+            periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/n8n/templates/deployment-worker.yaml
+++ b/charts/n8n/templates/deployment-worker.yaml
@@ -323,8 +323,8 @@ spec:
         - name: {{ template "n8n.taskRunners.name" . }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.taskRunners.external.image.repository }}:{{ .Values.taskRunners.external.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.taskRunners.external.image.pullPolicy }}
           command: ["/usr/local/bin/task-runner-launcher"]
           args: ["javascript"]
           ports:

--- a/charts/n8n/templates/deployment-worker.yaml
+++ b/charts/n8n/templates/deployment-worker.yaml
@@ -329,7 +329,7 @@ spec:
           command:
             - /bin/sh
             - -c
-            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /home/node/.python-packages %s && export PYTHONPATH=/home/node/.python-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.nodes.python.external.packages | join " ") (ternary " python" "" .Values.nodes.python.enabled) | quote }}
+            - {{ include "n8n.taskRunners.uvInstallCommand" . | quote }}
           {{- else }}
           command:
             - /usr/local/bin/task-runner-launcher

--- a/charts/n8n/templates/deployment-worker.yaml
+++ b/charts/n8n/templates/deployment-worker.yaml
@@ -326,7 +326,11 @@ spec:
           image: "{{ .Values.taskRunners.external.image.repository }}:{{ .Values.taskRunners.external.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.taskRunners.external.image.pullPolicy }}
           command: ["/usr/local/bin/task-runner-launcher"]
-          args: ["javascript"]
+          args:
+            - javascript
+          {{- if .Values.taskRunners.python.enabled }}
+            - python
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.taskRunners.external.port }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -305,17 +305,17 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.taskRunners.external.image.repository }}:{{ .Values.taskRunners.external.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.taskRunners.external.image.pullPolicy }}
-          {{- if .Values.taskRunners.python.external.packages }}
+          {{- if .Values.nodes.python.external.packages }}
           command:
             - /bin/sh
             - -c
-            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages %s && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.taskRunners.python.external.packages | join " ") (ternary " python" "" .Values.taskRunners.python.enabled) | quote }}
+            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages %s && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.nodes.python.external.packages | join " ") (ternary " python" "" .Values.nodes.python.enabled) | quote }}
           {{- else }}
           command:
             - /usr/local/bin/task-runner-launcher
           args:
             - javascript
-          {{- if .Values.taskRunners.python.enabled }}
+          {{- if .Values.nodes.python.enabled }}
             - python
           {{- end }}
           {{- end }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -299,12 +299,12 @@ spec:
           {{- with (default .Values.volumeMounts .Values.main.volumeMounts) }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- if eq .Values.taskRunners.mode "external" }}
+      {{- if and (eq .Values.taskRunners.mode "external") (ne .Values.worker.mode "queue") }}
         - name: {{ template "n8n.taskRunners.name" . }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.taskRunners.external.image.repository }}:{{ .Values.taskRunners.external.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.taskRunners.external.image.pullPolicy }}
           command: ["/usr/local/bin/task-runner-launcher"]
           args: ["javascript"]
           ports:

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -390,7 +390,7 @@ spec:
           emptyDir: {}
         - name: cache
           emptyDir: {}
-      {{- if eq .Values.taskRunners.mode "external" }}
+      {{- if and (eq .Values.taskRunners.mode "external") (ne .Values.worker.mode "queue") }}
         - name: python-packages
           {{- if .Values.nodes.python.persistence.enabled }}
           persistentVolumeClaim:

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -305,11 +305,11 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.taskRunners.external.image.repository }}:{{ .Values.taskRunners.external.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.taskRunners.external.image.pullPolicy }}
-          {{- if .Values.taskRunners.python.packages }}
+          {{- if .Values.taskRunners.python.external.packages }}
           command:
             - /bin/sh
             - -c
-            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages %s && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.taskRunners.python.packages | join " ") (ternary " python" "" .Values.taskRunners.python.enabled) | quote }}
+            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages %s && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.taskRunners.python.external.packages | join " ") (ternary " python" "" .Values.taskRunners.python.enabled) | quote }}
           {{- else }}
           command:
             - /usr/local/bin/task-runner-launcher

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -305,16 +305,30 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.taskRunners.external.image.repository }}:{{ .Values.taskRunners.external.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.taskRunners.external.image.pullPolicy }}
-          command: ["/usr/local/bin/task-runner-launcher"]
+          {{- if .Values.taskRunners.python.packages }}
+          command:
+            - /bin/sh
+            - -c
+            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages %s && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.taskRunners.python.packages | join " ") (ternary " python" "" .Values.taskRunners.python.enabled) | quote }}
+          {{- else }}
+          command:
+            - /usr/local/bin/task-runner-launcher
           args:
             - javascript
           {{- if .Values.taskRunners.python.enabled }}
             - python
           {{- end }}
+          {{- end }}
           ports:
             - name: runner-health
               containerPort: {{ .Values.taskRunners.external.port }}
               protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: runner-health
+            failureThreshold: 30
+            periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -360,6 +360,15 @@ spec:
             - name: N8N_REINSTALL_MISSING_PACKAGES
               value: "true"
           {{- end }}
+          {{- if .Values.pypiRegistry.enabled }}
+          {{- if or .Values.pypiRegistry.secretName .Values.pypiRegistry.customUvConfig }}
+            - name: UV_CONFIG_FILE
+              value: {{ printf "/home/node/.uv-config/%s" (default "uv.toml" .Values.pypiRegistry.secretKey) | quote }}
+          {{- else if .Values.pypiRegistry.url }}
+            - name: UV_DEFAULT_INDEX
+              value: {{ .Values.pypiRegistry.url | quote }}
+          {{- end }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ template "n8n.taskRunners.fullname" . }}-configmap
@@ -370,6 +379,11 @@ spec:
               mountPath: /home/node/.cache
             - name: python-packages
               mountPath: /home/node/.python-packages
+          {{- if and .Values.pypiRegistry.enabled (or .Values.pypiRegistry.secretName .Values.pypiRegistry.customUvConfig) }}
+            - name: uv-config
+              mountPath: /home/node/.uv-config
+              readOnly: true
+          {{- end }}
             - name: {{ default "node-modules" .Values.main.persistence.volumeName }}
               mountPath: {{ .Values.main.persistence.mountPath }}
               {{- if .Values.main.persistence.subPath }}
@@ -410,6 +424,12 @@ spec:
       {{- if .Values.nodes.external.packages }}
         - name: community-node-modules
           emptyDir: {}
+      {{- end }}
+      {{- if and (eq .Values.taskRunners.mode "external") (ne .Values.worker.mode "queue") .Values.pypiRegistry.enabled (or .Values.pypiRegistry.secretName .Values.pypiRegistry.customUvConfig) }}
+        - name: uv-config
+          secret:
+            secretName: {{ default (printf "%s-pypi-registry-secret" (include "n8n.fullname" .)) .Values.pypiRegistry.secretName | quote }}
+            optional: true
       {{- end }}
       {{- if .Values.npmRegistry.enabled }}
         - name: npmrc

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -306,7 +306,11 @@ spec:
           image: "{{ .Values.taskRunners.external.image.repository }}:{{ .Values.taskRunners.external.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.taskRunners.external.image.pullPolicy }}
           command: ["/usr/local/bin/task-runner-launcher"]
-          args: ["javascript"]
+          args:
+            - javascript
+          {{- if .Values.taskRunners.python.enabled }}
+            - python
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.taskRunners.external.port }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -309,7 +309,7 @@ spec:
           command:
             - /bin/sh
             - -c
-            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages %s && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.nodes.python.external.packages | join " ") (ternary " python" "" .Values.nodes.python.enabled) | quote }}
+            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /home/node/.python-packages %s && export PYTHONPATH=/home/node/.python-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.nodes.python.external.packages | join " ") (ternary " python" "" .Values.nodes.python.enabled) | quote }}
           {{- else }}
           command:
             - /usr/local/bin/task-runner-launcher
@@ -368,6 +368,8 @@ spec:
               mountPath: /tmp
             - name: cache
               mountPath: /home/node/.cache
+            - name: python-packages
+              mountPath: /home/node/.python-packages
             - name: {{ default "node-modules" .Values.main.persistence.volumeName }}
               mountPath: {{ .Values.main.persistence.mountPath }}
               {{- if .Values.main.persistence.subPath }}
@@ -388,6 +390,15 @@ spec:
           emptyDir: {}
         - name: cache
           emptyDir: {}
+      {{- if eq .Values.taskRunners.mode "external" }}
+        - name: python-packages
+          {{- if .Values.nodes.python.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "n8n-python.packages.fullname" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+      {{- end }}
       {{- if .Values.main.persistence.enabled }}
         - name: {{ default "node-modules" .Values.main.persistence.volumeName }}
           persistentVolumeClaim:

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -312,17 +312,17 @@ spec:
             - python
           {{- end }}
           ports:
-            - name: http
+            - name: runner-health
               containerPort: {{ .Values.taskRunners.external.port }}
               protocol: TCP
           livenessProbe:
             httpGet:
               path: /healthz
-              port: http
+              port: runner-health
           readinessProbe:
             httpGet:
               path: /healthz
-              port: http
+              port: runner-health
           resources:
             {{- toYaml .Values.taskRunners.external.resources | nindent 12 }}
           env:

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -309,7 +309,7 @@ spec:
           command:
             - /bin/sh
             - -c
-            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /home/node/.python-packages %s && export PYTHONPATH=/home/node/.python-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.nodes.python.external.packages | join " ") (ternary " python" "" .Values.nodes.python.enabled) | quote }}
+            - {{ include "n8n.taskRunners.uvInstallCommand" . | quote }}
           {{- else }}
           command:
             - /usr/local/bin/task-runner-launcher

--- a/charts/n8n/templates/hpa.yaml
+++ b/charts/n8n/templates/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.worker.autoscaling.enabled (not .Values.worker.forceToUseStatefulset) (or (not .Values.worker.persistence.enabled) (and .Values.worker.persistence.enabled (eq .Values.worker.persistence.accessMode "ReadWriteMany") )) (eq .Values.db.type "postgresdb") (eq .Values.worker.mode "queue") (not .Values.worker.allNodes) }}
+{{- if and .Values.worker.autoscaling.enabled (not .Values.worker.forceToUseStatefulset) (or (not .Values.worker.persistence.enabled) (and .Values.worker.persistence.enabled (eq .Values.worker.persistence.accessMode "ReadWriteMany") )) (or (not .Values.nodes.python.persistence.enabled) (eq .Values.nodes.python.persistence.accessMode "ReadWriteMany")) (eq .Values.db.type "postgresdb") (eq .Values.worker.mode "queue") (not .Values.worker.allNodes) }}
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler

--- a/charts/n8n/templates/pvc.yaml
+++ b/charts/n8n/templates/pvc.yaml
@@ -56,3 +56,27 @@ spec:
     {{- end }}
   {{- end }}
 {{- end }}
+{{- if and .Values.nodes.python.persistence.enabled (not .Values.nodes.python.persistence.existingClaim) (eq .Values.taskRunners.mode "external") }}
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "n8n-python.packages.fullname" . }}
+  {{- with .Values.nodes.python.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.nodes.python.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.nodes.python.persistence.size }}
+  {{- if .Values.nodes.python.persistence.storageClass }}
+    {{- if (eq "-" .Values.nodes.python.persistence.storageClass) }}
+  storageClassName: ""
+    {{- else }}
+  storageClassName: {{ .Values.nodes.python.persistence.storageClass | quote }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/n8n/templates/secret.yaml
+++ b/charts/n8n/templates/secret.yaml
@@ -117,6 +117,22 @@ data:
   {{- end }}
 {{- end }}
 {{- end }}
+{{- if and .Values.pypiRegistry.enabled .Values.pypiRegistry.customUvConfig (not .Values.pypiRegistry.secretName) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "n8n.fullname" . }}-pypi-registry-secret
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "n8n.name" . }}
+    chart: {{ include "n8n.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  uv.toml: {{ .Values.pypiRegistry.customUvConfig | b64enc | quote }}
+{{- end }}
 {{- if and .Values.npmRegistry.enabled .Values.npmRegistry.customNpmrc (not .Values.npmRegistry.secretName) }}
 ---
 apiVersion: v1

--- a/charts/n8n/templates/statefulset-worker.yaml
+++ b/charts/n8n/templates/statefulset-worker.yaml
@@ -307,8 +307,8 @@ spec:
         - name: {{ template "n8n.taskRunners.name" . }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.taskRunners.external.image.repository }}:{{ .Values.taskRunners.external.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.taskRunners.external.image.pullPolicy }}
           command: ["/usr/local/bin/task-runner-launcher"]
           args: ["javascript"]
           ports:

--- a/charts/n8n/templates/statefulset-worker.yaml
+++ b/charts/n8n/templates/statefulset-worker.yaml
@@ -309,16 +309,30 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.taskRunners.external.image.repository }}:{{ .Values.taskRunners.external.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.taskRunners.external.image.pullPolicy }}
-          command: ["/usr/local/bin/task-runner-launcher"]
+          {{- if .Values.taskRunners.python.packages }}
+          command:
+            - /bin/sh
+            - -c
+            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages %s && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.taskRunners.python.packages | join " ") (ternary " python" "" .Values.taskRunners.python.enabled) | quote }}
+          {{- else }}
+          command:
+            - /usr/local/bin/task-runner-launcher
           args:
             - javascript
           {{- if .Values.taskRunners.python.enabled }}
             - python
           {{- end }}
+          {{- end }}
           ports:
             - name: runner-health
               containerPort: {{ .Values.taskRunners.external.port }}
               protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: runner-health
+            failureThreshold: 30
+            periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/n8n/templates/statefulset-worker.yaml
+++ b/charts/n8n/templates/statefulset-worker.yaml
@@ -316,17 +316,17 @@ spec:
             - python
           {{- end }}
           ports:
-            - name: http
+            - name: runner-health
               containerPort: {{ .Values.taskRunners.external.port }}
               protocol: TCP
           livenessProbe:
             httpGet:
               path: /healthz
-              port: http
+              port: runner-health
           readinessProbe:
             httpGet:
               path: /healthz
-              port: http
+              port: runner-health
           resources:
             {{- toYaml .Values.taskRunners.external.resources | nindent 12 }}
           env:

--- a/charts/n8n/templates/statefulset-worker.yaml
+++ b/charts/n8n/templates/statefulset-worker.yaml
@@ -309,17 +309,17 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.taskRunners.external.image.repository }}:{{ .Values.taskRunners.external.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.taskRunners.external.image.pullPolicy }}
-          {{- if .Values.taskRunners.python.external.packages }}
+          {{- if .Values.nodes.python.external.packages }}
           command:
             - /bin/sh
             - -c
-            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages %s && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.taskRunners.python.external.packages | join " ") (ternary " python" "" .Values.taskRunners.python.enabled) | quote }}
+            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages %s && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.nodes.python.external.packages | join " ") (ternary " python" "" .Values.nodes.python.enabled) | quote }}
           {{- else }}
           command:
             - /usr/local/bin/task-runner-launcher
           args:
             - javascript
-          {{- if .Values.taskRunners.python.enabled }}
+          {{- if .Values.nodes.python.enabled }}
             - python
           {{- end }}
           {{- end }}

--- a/charts/n8n/templates/statefulset-worker.yaml
+++ b/charts/n8n/templates/statefulset-worker.yaml
@@ -310,7 +310,11 @@ spec:
           image: "{{ .Values.taskRunners.external.image.repository }}:{{ .Values.taskRunners.external.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.taskRunners.external.image.pullPolicy }}
           command: ["/usr/local/bin/task-runner-launcher"]
-          args: ["javascript"]
+          args:
+            - javascript
+          {{- if .Values.taskRunners.python.enabled }}
+            - python
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.taskRunners.external.port }}

--- a/charts/n8n/templates/statefulset-worker.yaml
+++ b/charts/n8n/templates/statefulset-worker.yaml
@@ -364,6 +364,15 @@ spec:
             - name: N8N_REINSTALL_MISSING_PACKAGES
               value: "true"
           {{- end }}
+          {{- if .Values.pypiRegistry.enabled }}
+          {{- if or .Values.pypiRegistry.secretName .Values.pypiRegistry.customUvConfig }}
+            - name: UV_CONFIG_FILE
+              value: {{ printf "/home/node/.uv-config/%s" (default "uv.toml" .Values.pypiRegistry.secretKey) | quote }}
+          {{- else if .Values.pypiRegistry.url }}
+            - name: UV_DEFAULT_INDEX
+              value: {{ .Values.pypiRegistry.url | quote }}
+          {{- end }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ template "n8n.taskRunners.fullname" . }}-configmap
@@ -374,6 +383,11 @@ spec:
               mountPath: /home/node/.cache
             - name: python-packages
               mountPath: /home/node/.python-packages
+          {{- if and .Values.pypiRegistry.enabled (or .Values.pypiRegistry.secretName .Values.pypiRegistry.customUvConfig) }}
+            - name: uv-config
+              mountPath: /home/node/.uv-config
+              readOnly: true
+          {{- end }}
             - name: {{ default "node-modules" .Values.worker.persistence.volumeName }}
               mountPath: {{ .Values.worker.persistence.mountPath }}
               {{- if .Values.worker.persistence.subPath }}
@@ -407,6 +421,12 @@ spec:
       {{- if .Values.nodes.external.packages }}
         - name: community-node-modules
           emptyDir: {}
+      {{- end }}
+      {{- if and (eq .Values.taskRunners.mode "external") .Values.pypiRegistry.enabled (or .Values.pypiRegistry.secretName .Values.pypiRegistry.customUvConfig) }}
+        - name: uv-config
+          secret:
+            secretName: {{ default (printf "%s-pypi-registry-secret" (include "n8n.fullname" .)) .Values.pypiRegistry.secretName | quote }}
+            optional: true
       {{- end }}
       {{- if .Values.npmRegistry.enabled }}
         - name: npmrc

--- a/charts/n8n/templates/statefulset-worker.yaml
+++ b/charts/n8n/templates/statefulset-worker.yaml
@@ -313,7 +313,7 @@ spec:
           command:
             - /bin/sh
             - -c
-            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages %s && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.nodes.python.external.packages | join " ") (ternary " python" "" .Values.nodes.python.enabled) | quote }}
+            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /home/node/.python-packages %s && export PYTHONPATH=/home/node/.python-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.nodes.python.external.packages | join " ") (ternary " python" "" .Values.nodes.python.enabled) | quote }}
           {{- else }}
           command:
             - /usr/local/bin/task-runner-launcher
@@ -372,6 +372,8 @@ spec:
               mountPath: /tmp
             - name: cache
               mountPath: /home/node/.cache
+            - name: python-packages
+              mountPath: /home/node/.python-packages
             - name: {{ default "node-modules" .Values.worker.persistence.volumeName }}
               mountPath: {{ .Values.worker.persistence.mountPath }}
               {{- if .Values.worker.persistence.subPath }}
@@ -392,6 +394,16 @@ spec:
           emptyDir: {}
         - name: cache
           emptyDir: {}
+      {{- if eq .Values.taskRunners.mode "external" }}
+        {{- if not .Values.nodes.python.persistence.enabled }}
+        - name: python-packages
+          emptyDir: {}
+        {{- else if .Values.nodes.python.persistence.existingClaim }}
+        - name: python-packages
+          persistentVolumeClaim:
+            claimName: {{ include "n8n-python.packages.fullname" . }}
+        {{- end }}
+      {{- end }}
       {{- if .Values.nodes.external.packages }}
         - name: community-node-modules
           emptyDir: {}
@@ -464,4 +476,21 @@ spec:
         storageClassName: {{ .Values.worker.persistence.storageClass | quote }}
           {{- end }}
         {{- end }}
+    {{- if and (eq .Values.taskRunners.mode "external") .Values.nodes.python.persistence.enabled (not .Values.nodes.python.persistence.existingClaim) }}
+    - metadata:
+        name: python-packages
+      spec:
+        accessModes:
+          - {{ .Values.nodes.python.persistence.accessMode }}
+        resources:
+          requests:
+            storage: {{ .Values.nodes.python.persistence.size }}
+        {{- if .Values.nodes.python.persistence.storageClass }}
+          {{- if (eq "-" .Values.nodes.python.persistence.storageClass) }}
+        storageClassName: ""
+          {{- else }}
+        storageClassName: {{ .Values.nodes.python.persistence.storageClass | quote }}
+          {{- end }}
+        {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/n8n/templates/statefulset-worker.yaml
+++ b/charts/n8n/templates/statefulset-worker.yaml
@@ -313,7 +313,7 @@ spec:
           command:
             - /bin/sh
             - -c
-            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /home/node/.python-packages %s && export PYTHONPATH=/home/node/.python-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.nodes.python.external.packages | join " ") (ternary " python" "" .Values.nodes.python.enabled) | quote }}
+            - {{ include "n8n.taskRunners.uvInstallCommand" . | quote }}
           {{- else }}
           command:
             - /usr/local/bin/task-runner-launcher

--- a/charts/n8n/templates/statefulset-worker.yaml
+++ b/charts/n8n/templates/statefulset-worker.yaml
@@ -309,11 +309,11 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.taskRunners.external.image.repository }}:{{ .Values.taskRunners.external.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.taskRunners.external.image.pullPolicy }}
-          {{- if .Values.taskRunners.python.packages }}
+          {{- if .Values.taskRunners.python.external.packages }}
           command:
             - /bin/sh
             - -c
-            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages %s && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.taskRunners.python.packages | join " ") (ternary " python" "" .Values.taskRunners.python.enabled) | quote }}
+            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages %s && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.taskRunners.python.external.packages | join " ") (ternary " python" "" .Values.taskRunners.python.enabled) | quote }}
           {{- else }}
           command:
             - /usr/local/bin/task-runner-launcher

--- a/charts/n8n/templates/statefulset.yaml
+++ b/charts/n8n/templates/statefulset.yaml
@@ -348,6 +348,15 @@ spec:
             - name: N8N_REINSTALL_MISSING_PACKAGES
               value: "true"
           {{- end }}
+          {{- if .Values.pypiRegistry.enabled }}
+          {{- if or .Values.pypiRegistry.secretName .Values.pypiRegistry.customUvConfig }}
+            - name: UV_CONFIG_FILE
+              value: {{ printf "/home/node/.uv-config/%s" (default "uv.toml" .Values.pypiRegistry.secretKey) | quote }}
+          {{- else if .Values.pypiRegistry.url }}
+            - name: UV_DEFAULT_INDEX
+              value: {{ .Values.pypiRegistry.url | quote }}
+          {{- end }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ template "n8n.taskRunners.fullname" . }}-configmap
@@ -358,6 +367,11 @@ spec:
               mountPath: /home/node/.cache
             - name: python-packages
               mountPath: /home/node/.python-packages
+          {{- if and .Values.pypiRegistry.enabled (or .Values.pypiRegistry.secretName .Values.pypiRegistry.customUvConfig) }}
+            - name: uv-config
+              mountPath: /home/node/.uv-config
+              readOnly: true
+          {{- end }}
             - name: {{ default "node-modules" .Values.main.persistence.volumeName }}
               mountPath: {{ .Values.main.persistence.mountPath }}
               {{- if .Values.main.persistence.subPath }}
@@ -391,6 +405,12 @@ spec:
       {{- if .Values.nodes.external.packages }}
         - name: community-node-modules
           emptyDir: {}
+      {{- end }}
+      {{- if and (eq .Values.taskRunners.mode "external") (ne .Values.worker.mode "queue") .Values.pypiRegistry.enabled (or .Values.pypiRegistry.secretName .Values.pypiRegistry.customUvConfig) }}
+        - name: uv-config
+          secret:
+            secretName: {{ default (printf "%s-pypi-registry-secret" (include "n8n.fullname" .)) .Values.pypiRegistry.secretName | quote }}
+            optional: true
       {{- end }}
       {{- if .Values.npmRegistry.enabled }}
         - name: npmrc

--- a/charts/n8n/templates/statefulset.yaml
+++ b/charts/n8n/templates/statefulset.yaml
@@ -293,11 +293,11 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.taskRunners.external.image.repository }}:{{ .Values.taskRunners.external.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.taskRunners.external.image.pullPolicy }}
-          {{- if .Values.taskRunners.python.packages }}
+          {{- if .Values.taskRunners.python.external.packages }}
           command:
             - /bin/sh
             - -c
-            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages %s && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.taskRunners.python.packages | join " ") (ternary " python" "" .Values.taskRunners.python.enabled) | quote }}
+            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages %s && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.taskRunners.python.external.packages | join " ") (ternary " python" "" .Values.taskRunners.python.enabled) | quote }}
           {{- else }}
           command:
             - /usr/local/bin/task-runner-launcher

--- a/charts/n8n/templates/statefulset.yaml
+++ b/charts/n8n/templates/statefulset.yaml
@@ -294,7 +294,11 @@ spec:
           image: "{{ .Values.taskRunners.external.image.repository }}:{{ .Values.taskRunners.external.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.taskRunners.external.image.pullPolicy }}
           command: ["/usr/local/bin/task-runner-launcher"]
-          args: ["javascript"]
+          args:
+            - javascript
+          {{- if .Values.taskRunners.python.enabled }}
+            - python
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.taskRunners.external.port }}

--- a/charts/n8n/templates/statefulset.yaml
+++ b/charts/n8n/templates/statefulset.yaml
@@ -293,16 +293,30 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.taskRunners.external.image.repository }}:{{ .Values.taskRunners.external.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.taskRunners.external.image.pullPolicy }}
-          command: ["/usr/local/bin/task-runner-launcher"]
+          {{- if .Values.taskRunners.python.packages }}
+          command:
+            - /bin/sh
+            - -c
+            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages %s && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.taskRunners.python.packages | join " ") (ternary " python" "" .Values.taskRunners.python.enabled) | quote }}
+          {{- else }}
+          command:
+            - /usr/local/bin/task-runner-launcher
           args:
             - javascript
           {{- if .Values.taskRunners.python.enabled }}
             - python
           {{- end }}
+          {{- end }}
           ports:
             - name: runner-health
               containerPort: {{ .Values.taskRunners.external.port }}
               protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: runner-health
+            failureThreshold: 30
+            periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/n8n/templates/statefulset.yaml
+++ b/charts/n8n/templates/statefulset.yaml
@@ -293,17 +293,17 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.taskRunners.external.image.repository }}:{{ .Values.taskRunners.external.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.taskRunners.external.image.pullPolicy }}
-          {{- if .Values.taskRunners.python.external.packages }}
+          {{- if .Values.nodes.python.external.packages }}
           command:
             - /bin/sh
             - -c
-            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages %s && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.taskRunners.python.external.packages | join " ") (ternary " python" "" .Values.taskRunners.python.enabled) | quote }}
+            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages %s && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.nodes.python.external.packages | join " ") (ternary " python" "" .Values.nodes.python.enabled) | quote }}
           {{- else }}
           command:
             - /usr/local/bin/task-runner-launcher
           args:
             - javascript
-          {{- if .Values.taskRunners.python.enabled }}
+          {{- if .Values.nodes.python.enabled }}
             - python
           {{- end }}
           {{- end }}

--- a/charts/n8n/templates/statefulset.yaml
+++ b/charts/n8n/templates/statefulset.yaml
@@ -287,12 +287,12 @@ spec:
           {{- with (default .Values.volumeMounts .Values.main.volumeMounts) }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- if eq .Values.taskRunners.mode "external" }}
+      {{- if and (eq .Values.taskRunners.mode "external") (ne .Values.worker.mode "queue") }}
         - name: {{ template "n8n.taskRunners.name" . }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.taskRunners.external.image.repository }}:{{ .Values.taskRunners.external.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.taskRunners.external.image.pullPolicy }}
           command: ["/usr/local/bin/task-runner-launcher"]
           args: ["javascript"]
           ports:

--- a/charts/n8n/templates/statefulset.yaml
+++ b/charts/n8n/templates/statefulset.yaml
@@ -300,17 +300,17 @@ spec:
             - python
           {{- end }}
           ports:
-            - name: http
+            - name: runner-health
               containerPort: {{ .Values.taskRunners.external.port }}
               protocol: TCP
           livenessProbe:
             httpGet:
               path: /healthz
-              port: http
+              port: runner-health
           readinessProbe:
             httpGet:
               path: /healthz
-              port: http
+              port: runner-health
           resources:
             {{- toYaml .Values.taskRunners.external.resources | nindent 12 }}
           env:

--- a/charts/n8n/templates/statefulset.yaml
+++ b/charts/n8n/templates/statefulset.yaml
@@ -378,7 +378,7 @@ spec:
           emptyDir: {}
         - name: cache
           emptyDir: {}
-      {{- if eq .Values.taskRunners.mode "external" }}
+      {{- if and (eq .Values.taskRunners.mode "external") (ne .Values.worker.mode "queue") }}
         {{- if not .Values.nodes.python.persistence.enabled }}
         - name: python-packages
           emptyDir: {}
@@ -460,7 +460,7 @@ spec:
         storageClassName: {{ .Values.main.persistence.storageClass | quote }}
           {{- end }}
         {{- end }}
-    {{- if and (eq .Values.taskRunners.mode "external") .Values.nodes.python.persistence.enabled (not .Values.nodes.python.persistence.existingClaim) }}
+    {{- if and (eq .Values.taskRunners.mode "external") (ne .Values.worker.mode "queue") .Values.nodes.python.persistence.enabled (not .Values.nodes.python.persistence.existingClaim) }}
     - metadata:
         name: python-packages
       spec:

--- a/charts/n8n/templates/statefulset.yaml
+++ b/charts/n8n/templates/statefulset.yaml
@@ -297,7 +297,7 @@ spec:
           command:
             - /bin/sh
             - -c
-            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages %s && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.nodes.python.external.packages | join " ") (ternary " python" "" .Values.nodes.python.enabled) | quote }}
+            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /home/node/.python-packages %s && export PYTHONPATH=/home/node/.python-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.nodes.python.external.packages | join " ") (ternary " python" "" .Values.nodes.python.enabled) | quote }}
           {{- else }}
           command:
             - /usr/local/bin/task-runner-launcher
@@ -356,6 +356,8 @@ spec:
               mountPath: /tmp
             - name: cache
               mountPath: /home/node/.cache
+            - name: python-packages
+              mountPath: /home/node/.python-packages
             - name: {{ default "node-modules" .Values.main.persistence.volumeName }}
               mountPath: {{ .Values.main.persistence.mountPath }}
               {{- if .Values.main.persistence.subPath }}
@@ -376,6 +378,16 @@ spec:
           emptyDir: {}
         - name: cache
           emptyDir: {}
+      {{- if eq .Values.taskRunners.mode "external" }}
+        {{- if not .Values.nodes.python.persistence.enabled }}
+        - name: python-packages
+          emptyDir: {}
+        {{- else if .Values.nodes.python.persistence.existingClaim }}
+        - name: python-packages
+          persistentVolumeClaim:
+            claimName: {{ include "n8n-python.packages.fullname" . }}
+        {{- end }}
+      {{- end }}
       {{- if .Values.nodes.external.packages }}
         - name: community-node-modules
           emptyDir: {}
@@ -448,4 +460,21 @@ spec:
         storageClassName: {{ .Values.main.persistence.storageClass | quote }}
           {{- end }}
         {{- end }}
+    {{- if and (eq .Values.taskRunners.mode "external") .Values.nodes.python.persistence.enabled (not .Values.nodes.python.persistence.existingClaim) }}
+    - metadata:
+        name: python-packages
+      spec:
+        accessModes:
+          - {{ .Values.nodes.python.persistence.accessMode }}
+        resources:
+          requests:
+            storage: {{ .Values.nodes.python.persistence.size }}
+        {{- if .Values.nodes.python.persistence.storageClass }}
+          {{- if (eq "-" .Values.nodes.python.persistence.storageClass) }}
+        storageClassName: ""
+          {{- else }}
+        storageClassName: {{ .Values.nodes.python.persistence.storageClass | quote }}
+          {{- end }}
+        {{- end }}
+    {{- end }}
 {{- end }}

--- a/charts/n8n/templates/statefulset.yaml
+++ b/charts/n8n/templates/statefulset.yaml
@@ -297,7 +297,7 @@ spec:
           command:
             - /bin/sh
             - -c
-            - {{ printf "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /home/node/.python-packages %s && export PYTHONPATH=/home/node/.python-packages && exec /usr/local/bin/task-runner-launcher javascript%s" (.Values.nodes.python.external.packages | join " ") (ternary " python" "" .Values.nodes.python.enabled) | quote }}
+            - {{ include "n8n.taskRunners.uvInstallCommand" . | quote }}
           {{- else }}
           command:
             - /usr/local/bin/task-runner-launcher

--- a/charts/n8n/unittests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/n8n/unittests/__snapshot__/configmap_test.yaml.snap
@@ -85,7 +85,6 @@ should match snapshot of default values:
   7: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal
@@ -245,7 +244,6 @@ should match snapshot of external redis values:
   8: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal

--- a/charts/n8n/unittests/__snapshot__/deployment-mcp-webhook_test.yaml.snap
+++ b/charts/n8n/unittests/__snapshot__/deployment-mcp-webhook_test.yaml.snap
@@ -113,7 +113,6 @@ should match snapshot of postgres ssl certificate values:
   8: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal
@@ -190,7 +189,7 @@ should match snapshot of postgres ssl certificate values:
       template:
         metadata:
           annotations:
-            checksum/config: 9275478349b0d1960495024022e4b3e64e5681684b296cdd8cf49b9267e20bcd
+            checksum/config: 4727cd142b645f30aeffe516e758ffc38de909f8ab2a0b8ea9df8410cd049e9a
           labels:
             app.kubernetes.io/component: mcp
             app.kubernetes.io/instance: n8n
@@ -244,8 +243,6 @@ should match snapshot of postgres ssl certificate values:
                       key: redis-password
                       name: n8n-redis
                       optional: true
-                - name: N8N_RUNNERS_ENABLED
-                  value: "true"
                 - name: N8N_RUNNERS_MODE
                   value: internal
                 - name: N8N_RUNNERS_TASK_TIMEOUT

--- a/charts/n8n/unittests/__snapshot__/deployment-webhook_test.yaml.snap
+++ b/charts/n8n/unittests/__snapshot__/deployment-webhook_test.yaml.snap
@@ -113,7 +113,6 @@ should match snapshot of postgres ssl certificate values:
   8: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal
@@ -190,7 +189,7 @@ should match snapshot of postgres ssl certificate values:
       template:
         metadata:
           annotations:
-            checksum/config: 9275478349b0d1960495024022e4b3e64e5681684b296cdd8cf49b9267e20bcd
+            checksum/config: 4727cd142b645f30aeffe516e758ffc38de909f8ab2a0b8ea9df8410cd049e9a
           labels:
             app.kubernetes.io/component: webhook
             app.kubernetes.io/instance: n8n
@@ -244,8 +243,6 @@ should match snapshot of postgres ssl certificate values:
                       key: redis-password
                       name: n8n-redis
                       optional: true
-                - name: N8N_RUNNERS_ENABLED
-                  value: "true"
                 - name: N8N_RUNNERS_MODE
                   value: internal
                 - name: N8N_RUNNERS_TASK_TIMEOUT

--- a/charts/n8n/unittests/__snapshot__/deployment-worker_test.yaml.snap
+++ b/charts/n8n/unittests/__snapshot__/deployment-worker_test.yaml.snap
@@ -108,7 +108,6 @@ should match snapshot of default values:
   8: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal
@@ -185,7 +184,7 @@ should match snapshot of default values:
       template:
         metadata:
           annotations:
-            checksum/config: 8fb61eb0cf816a99cea6e26773cc00fa42056beb9d2646773c831ae2f64bec08
+            checksum/config: 1fdf11eb48bae65b75c42cf6d75185deb07be0222676c36508cd656a8beb1601
           labels:
             app.kubernetes.io/component: worker
             app.kubernetes.io/instance: n8n
@@ -478,7 +477,6 @@ should match snapshot of postgres ssl certificate values:
   8: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal
@@ -555,7 +553,7 @@ should match snapshot of postgres ssl certificate values:
       template:
         metadata:
           annotations:
-            checksum/config: 4b91f5a9264f8a417ef03702235da2bf32fdbb10f4520969f8c1381184c7d4d2
+            checksum/config: 161b5c213ae64dd2e15a005be7ffa3cb001fa4b6ac005af1c977c150a68b78a4
           labels:
             app.kubernetes.io/component: worker
             app.kubernetes.io/instance: n8n
@@ -874,7 +872,6 @@ should match snapshot of worker persistence:
   8: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal
@@ -951,7 +948,7 @@ should match snapshot of worker persistence:
       template:
         metadata:
           annotations:
-            checksum/config: 8fb61eb0cf816a99cea6e26773cc00fa42056beb9d2646773c831ae2f64bec08
+            checksum/config: 1fdf11eb48bae65b75c42cf6d75185deb07be0222676c36508cd656a8beb1601
           labels:
             app.kubernetes.io/component: worker
             app.kubernetes.io/instance: n8n

--- a/charts/n8n/unittests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/n8n/unittests/__snapshot__/deployment_test.yaml.snap
@@ -85,7 +85,6 @@ should match snapshot of default values:
   7: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal
@@ -161,7 +160,7 @@ should match snapshot of default values:
       template:
         metadata:
           annotations:
-            checksum/config: ebb640e853e11410aa426741a83e301290fcfa10987f5e8a3e7d2cb8a84eb4c8
+            checksum/config: fc9799ad2ff7266b11a1422e4886d8f41ba893b4e4f24079a667238037ee9667
           labels:
             app.kubernetes.io/component: main
             app.kubernetes.io/instance: n8n
@@ -360,7 +359,6 @@ should match snapshot of main persistence:
   7: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal
@@ -436,7 +434,7 @@ should match snapshot of main persistence:
       template:
         metadata:
           annotations:
-            checksum/config: ebb640e853e11410aa426741a83e301290fcfa10987f5e8a3e7d2cb8a84eb4c8
+            checksum/config: fc9799ad2ff7266b11a1422e4886d8f41ba893b4e4f24079a667238037ee9667
           labels:
             app.kubernetes.io/component: main
             app.kubernetes.io/instance: n8n
@@ -636,7 +634,6 @@ should match snapshot of main persistence with multiple main node and mode read 
   7: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal
@@ -712,7 +709,7 @@ should match snapshot of main persistence with multiple main node and mode read 
       template:
         metadata:
           annotations:
-            checksum/config: ebb640e853e11410aa426741a83e301290fcfa10987f5e8a3e7d2cb8a84eb4c8
+            checksum/config: fc9799ad2ff7266b11a1422e4886d8f41ba893b4e4f24079a667238037ee9667
           labels:
             app.kubernetes.io/component: main
             app.kubernetes.io/instance: n8n
@@ -924,7 +921,6 @@ should match snapshot of postgres ssl certificate values:
   7: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal
@@ -1000,7 +996,7 @@ should match snapshot of postgres ssl certificate values:
       template:
         metadata:
           annotations:
-            checksum/config: b9968f93f265e5024a55c0d954ae1ab89d083de575b8bb39815245d357f8cc85
+            checksum/config: 4db2178b5cd47bd137334fb0cf833a9cc35ab8b9816f990f7b7b12fc55d0eb3a
           labels:
             app.kubernetes.io/component: main
             app.kubernetes.io/instance: n8n

--- a/charts/n8n/unittests/__snapshot__/statefulset-worker_test.yaml.snap
+++ b/charts/n8n/unittests/__snapshot__/statefulset-worker_test.yaml.snap
@@ -108,7 +108,6 @@ should match snapshot of default values:
   8: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal
@@ -226,7 +225,7 @@ should match snapshot of default values:
       template:
         metadata:
           annotations:
-            checksum/config: 8fb61eb0cf816a99cea6e26773cc00fa42056beb9d2646773c831ae2f64bec08
+            checksum/config: 1fdf11eb48bae65b75c42cf6d75185deb07be0222676c36508cd656a8beb1601
           labels:
             app.kubernetes.io/component: worker
             app.kubernetes.io/instance: n8n
@@ -483,7 +482,6 @@ should match snapshot of postgres ssl certificate values:
   8: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal
@@ -601,7 +599,7 @@ should match snapshot of postgres ssl certificate values:
       template:
         metadata:
           annotations:
-            checksum/config: 4b91f5a9264f8a417ef03702235da2bf32fdbb10f4520969f8c1381184c7d4d2
+            checksum/config: 161b5c213ae64dd2e15a005be7ffa3cb001fa4b6ac005af1c977c150a68b78a4
           labels:
             app.kubernetes.io/component: worker
             app.kubernetes.io/instance: n8n
@@ -884,7 +882,6 @@ should match snapshot of worker persistence:
   8: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal

--- a/charts/n8n/unittests/__snapshot__/statefulset_test.yaml.snap
+++ b/charts/n8n/unittests/__snapshot__/statefulset_test.yaml.snap
@@ -85,7 +85,6 @@ should match snapshot of default values:
   7: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal
@@ -175,7 +174,7 @@ should match snapshot of default values:
       template:
         metadata:
           annotations:
-            checksum/config: ebb640e853e11410aa426741a83e301290fcfa10987f5e8a3e7d2cb8a84eb4c8
+            checksum/config: fc9799ad2ff7266b11a1422e4886d8f41ba893b4e4f24079a667238037ee9667
           labels:
             app.kubernetes.io/component: main
             app.kubernetes.io/instance: n8n
@@ -377,7 +376,6 @@ should match snapshot of postgres ssl certificate values:
   7: |
     apiVersion: v1
     data:
-      N8N_RUNNERS_ENABLED: "true"
       N8N_RUNNERS_HEARTBEAT_INTERVAL: "30"
       N8N_RUNNERS_MAX_CONCURRENCY: "5"
       N8N_RUNNERS_MODE: internal
@@ -480,7 +478,7 @@ should match snapshot of postgres ssl certificate values:
       template:
         metadata:
           annotations:
-            checksum/config: b9968f93f265e5024a55c0d954ae1ab89d083de575b8bb39815245d357f8cc85
+            checksum/config: 4db2178b5cd47bd137334fb0cf833a9cc35ab8b9816f990f7b7b12fc55d0eb3a
           labels:
             app.kubernetes.io/component: main
             app.kubernetes.io/instance: n8n

--- a/charts/n8n/unittests/configmap_test.yaml
+++ b/charts/n8n/unittests/configmap_test.yaml
@@ -1100,13 +1100,16 @@ tests:
       - notExists:
           path: data.N8N_NATIVE_PYTHON_RUNNER
 
-  - it: should set N8N_RUNNERS_STDLIB_ALLOW when python.enabled and stdlibAllow is set
+  - it: should set N8N_RUNNERS_STDLIB_ALLOW when python.enabled and builtin.modules is set
     set:
       taskRunners:
         mode: external
         python:
           enabled: true
-          stdlibAllow: "os,sys"
+          builtin:
+            modules:
+              - os
+              - sys
     documentSelector:
       path: metadata.name
       value: n8n-task-runners-configmap
@@ -1115,15 +1118,16 @@ tests:
           path: data.N8N_RUNNERS_STDLIB_ALLOW
           value: "os,sys"
 
-  - it: should set N8N_RUNNERS_EXTERNAL_ALLOW from packages list when python.enabled and packages are set
+  - it: should set N8N_RUNNERS_EXTERNAL_ALLOW from external.packages when python.enabled and packages are set
     set:
       taskRunners:
         mode: external
         python:
           enabled: true
-          packages:
-            - numpy
-            - pandas
+          external:
+            packages:
+              - numpy
+              - pandas
     documentSelector:
       path: metadata.name
       value: n8n-task-runners-configmap
@@ -1143,12 +1147,15 @@ tests:
       - notExists:
           path: data.N8N_RUNNERS_ENABLED
 
-  - it: should set N8N_RUNNERS_STDLIB_ALLOW in task-broker-configmap when python.enabled and stdlibAllow is set
+  - it: should set N8N_RUNNERS_STDLIB_ALLOW in task-broker-configmap when python.enabled and builtin.modules is set
     set:
       taskRunners:
         python:
           enabled: true
-          stdlibAllow: "os,sys"
+          builtin:
+            modules:
+              - os
+              - sys
     documentSelector:
       path: metadata.name
       value: n8n-task-broker-configmap
@@ -1157,14 +1164,15 @@ tests:
           path: data.N8N_RUNNERS_STDLIB_ALLOW
           value: "os,sys"
 
-  - it: should set N8N_RUNNERS_EXTERNAL_ALLOW in task-broker-configmap from packages list when python.enabled and packages are set
+  - it: should set N8N_RUNNERS_EXTERNAL_ALLOW in task-broker-configmap from external.packages when python.enabled and packages are set
     set:
       taskRunners:
         python:
           enabled: true
-          packages:
-            - numpy
-            - pandas
+          external:
+            packages:
+              - numpy
+              - pandas
     documentSelector:
       path: metadata.name
       value: n8n-task-broker-configmap
@@ -1223,19 +1231,51 @@ tests:
       - notExists:
           path: data.N8N_RUNNERS_EXTERNAL_ALLOW
 
-  - it: should not set N8N_RUNNERS_EXTERNAL_ALLOW when python.enabled and packages is empty
+  - it: should not set N8N_RUNNERS_EXTERNAL_ALLOW when python.enabled and external.packages is empty
     set:
       taskRunners:
         mode: external
         python:
           enabled: true
-          packages: []
+          external:
+            packages: []
     documentSelector:
       path: metadata.name
       value: n8n-task-runners-configmap
     asserts:
       - notExists:
           path: data.N8N_RUNNERS_EXTERNAL_ALLOW
+
+  - it: should set N8N_RUNNERS_EXTERNAL_ALLOW to * when python.external.allowAll is true
+    set:
+      taskRunners:
+        mode: external
+        python:
+          enabled: true
+          external:
+            allowAll: true
+    documentSelector:
+      path: metadata.name
+      value: n8n-task-runners-configmap
+    asserts:
+      - equal:
+          path: data.N8N_RUNNERS_EXTERNAL_ALLOW
+          value: "*"
+
+  - it: should set N8N_RUNNERS_EXTERNAL_ALLOW to * in task-broker-configmap when python.external.allowAll is true
+    set:
+      taskRunners:
+        python:
+          enabled: true
+          external:
+            allowAll: true
+    documentSelector:
+      path: metadata.name
+      value: n8n-task-broker-configmap
+    asserts:
+      - equal:
+          path: data.N8N_RUNNERS_EXTERNAL_ALLOW
+          value: "*"
 
   - it: should set license environment variables when license.enabled is true
     set:

--- a/charts/n8n/unittests/configmap_test.yaml
+++ b/charts/n8n/unittests/configmap_test.yaml
@@ -1141,6 +1141,58 @@ tests:
       - notExists:
           path: data.N8N_RUNNERS_ENABLED
 
+  - it: should set N8N_RUNNERS_STDLIB_ALLOW in task-broker-configmap when python.enabled and stdlibAllow is set
+    set:
+      taskRunners:
+        python:
+          enabled: true
+          stdlibAllow: "os,sys"
+    documentSelector:
+      path: metadata.name
+      value: n8n-task-broker-configmap
+    asserts:
+      - equal:
+          path: data.N8N_RUNNERS_STDLIB_ALLOW
+          value: "os,sys"
+
+  - it: should set N8N_RUNNERS_EXTERNAL_ALLOW in task-broker-configmap when python.enabled and externalAllow is set
+    set:
+      taskRunners:
+        python:
+          enabled: true
+          externalAllow: "numpy,pandas"
+    documentSelector:
+      path: metadata.name
+      value: n8n-task-broker-configmap
+    asserts:
+      - equal:
+          path: data.N8N_RUNNERS_EXTERNAL_ALLOW
+          value: "numpy,pandas"
+
+  - it: should not set N8N_RUNNERS_STDLIB_ALLOW in task-broker-configmap when python.enabled is false
+    set:
+      taskRunners:
+        python:
+          enabled: false
+    documentSelector:
+      path: metadata.name
+      value: n8n-task-broker-configmap
+    asserts:
+      - notExists:
+          path: data.N8N_RUNNERS_STDLIB_ALLOW
+
+  - it: should not set N8N_RUNNERS_EXTERNAL_ALLOW in task-broker-configmap when python.enabled is false
+    set:
+      taskRunners:
+        python:
+          enabled: false
+    documentSelector:
+      path: metadata.name
+      value: n8n-task-broker-configmap
+    asserts:
+      - notExists:
+          path: data.N8N_RUNNERS_EXTERNAL_ALLOW
+
   - it: should not set N8N_RUNNERS_STDLIB_ALLOW when python.enabled is false
     set:
       taskRunners:

--- a/charts/n8n/unittests/configmap_test.yaml
+++ b/charts/n8n/unittests/configmap_test.yaml
@@ -1075,9 +1075,9 @@ tests:
           path: data.SENTRY_DSN
           value: ""
 
-  - it: should set N8N_NATIVE_PYTHON_RUNNER when taskRunners.python.enabled is true
+  - it: should set N8N_NATIVE_PYTHON_RUNNER when nodes.python.enabled is true
     set:
-      taskRunners:
+      nodes:
         python:
           enabled: true
     documentSelector:
@@ -1088,9 +1088,9 @@ tests:
           path: data.N8N_NATIVE_PYTHON_RUNNER
           value: "true"
 
-  - it: should not set N8N_NATIVE_PYTHON_RUNNER when taskRunners.python.enabled is false
+  - it: should not set N8N_NATIVE_PYTHON_RUNNER when nodes.python.enabled is false
     set:
-      taskRunners:
+      nodes:
         python:
           enabled: false
     documentSelector:
@@ -1104,6 +1104,7 @@ tests:
     set:
       taskRunners:
         mode: external
+      nodes:
         python:
           enabled: true
           builtin:
@@ -1122,6 +1123,7 @@ tests:
     set:
       taskRunners:
         mode: external
+      nodes:
         python:
           enabled: true
           external:
@@ -1149,7 +1151,7 @@ tests:
 
   - it: should set N8N_RUNNERS_STDLIB_ALLOW in task-broker-configmap when python.enabled and builtin.modules is set
     set:
-      taskRunners:
+      nodes:
         python:
           enabled: true
           builtin:
@@ -1166,7 +1168,7 @@ tests:
 
   - it: should set N8N_RUNNERS_EXTERNAL_ALLOW in task-broker-configmap from external.packages when python.enabled and packages are set
     set:
-      taskRunners:
+      nodes:
         python:
           enabled: true
           external:
@@ -1183,7 +1185,7 @@ tests:
 
   - it: should not set N8N_RUNNERS_STDLIB_ALLOW in task-broker-configmap when python.enabled is false
     set:
-      taskRunners:
+      nodes:
         python:
           enabled: false
     documentSelector:
@@ -1195,7 +1197,7 @@ tests:
 
   - it: should not set N8N_RUNNERS_EXTERNAL_ALLOW in task-broker-configmap when python.enabled is false
     set:
-      taskRunners:
+      nodes:
         python:
           enabled: false
     documentSelector:
@@ -1209,6 +1211,7 @@ tests:
     set:
       taskRunners:
         mode: external
+      nodes:
         python:
           enabled: false
     documentSelector:
@@ -1222,6 +1225,7 @@ tests:
     set:
       taskRunners:
         mode: external
+      nodes:
         python:
           enabled: false
     documentSelector:
@@ -1235,6 +1239,7 @@ tests:
     set:
       taskRunners:
         mode: external
+      nodes:
         python:
           enabled: true
           external:
@@ -1250,6 +1255,7 @@ tests:
     set:
       taskRunners:
         mode: external
+      nodes:
         python:
           enabled: true
           external:
@@ -1264,7 +1270,7 @@ tests:
 
   - it: should set N8N_RUNNERS_EXTERNAL_ALLOW to * in task-broker-configmap when python.external.allowAll is true
     set:
-      taskRunners:
+      nodes:
         python:
           enabled: true
           external:

--- a/charts/n8n/unittests/configmap_test.yaml
+++ b/charts/n8n/unittests/configmap_test.yaml
@@ -878,9 +878,8 @@ tests:
       path: metadata.name
       value: n8n-task-broker-configmap
     asserts:
-      - equal:
+      - notExists:
           path: data.N8N_RUNNERS_ENABLED
-          value: "true"
       - equal:
           path: data.N8N_RUNNERS_MODE
           value: internal

--- a/charts/n8n/unittests/configmap_test.yaml
+++ b/charts/n8n/unittests/configmap_test.yaml
@@ -1075,6 +1075,61 @@ tests:
           path: data.SENTRY_DSN
           value: ""
 
+  - it: should set N8N_NATIVE_PYTHON_RUNNER when taskRunners.python.enabled is true
+    set:
+      taskRunners:
+        python:
+          enabled: true
+    documentSelector:
+      path: metadata.name
+      value: n8n-task-broker-configmap
+    asserts:
+      - equal:
+          path: data.N8N_NATIVE_PYTHON_RUNNER
+          value: "true"
+
+  - it: should not set N8N_NATIVE_PYTHON_RUNNER when taskRunners.python.enabled is false
+    set:
+      taskRunners:
+        python:
+          enabled: false
+    documentSelector:
+      path: metadata.name
+      value: n8n-task-broker-configmap
+    asserts:
+      - notExists:
+          path: data.N8N_NATIVE_PYTHON_RUNNER
+
+  - it: should set N8N_RUNNERS_STDLIB_ALLOW when python.enabled and stdlibAllow is set
+    set:
+      taskRunners:
+        mode: external
+        python:
+          enabled: true
+          stdlibAllow: "os,sys"
+    documentSelector:
+      path: metadata.name
+      value: n8n-task-runners-configmap
+    asserts:
+      - equal:
+          path: data.N8N_RUNNERS_STDLIB_ALLOW
+          value: "os,sys"
+
+  - it: should set N8N_RUNNERS_EXTERNAL_ALLOW when python.enabled and externalAllow is set
+    set:
+      taskRunners:
+        mode: external
+        python:
+          enabled: true
+          externalAllow: "numpy,pandas"
+    documentSelector:
+      path: metadata.name
+      value: n8n-task-runners-configmap
+    asserts:
+      - equal:
+          path: data.N8N_RUNNERS_EXTERNAL_ALLOW
+          value: "numpy,pandas"
+
   - it: should set license environment variables when license.enabled is true
     set:
       license:

--- a/charts/n8n/unittests/configmap_test.yaml
+++ b/charts/n8n/unittests/configmap_test.yaml
@@ -1115,13 +1115,15 @@ tests:
           path: data.N8N_RUNNERS_STDLIB_ALLOW
           value: "os,sys"
 
-  - it: should set N8N_RUNNERS_EXTERNAL_ALLOW when python.enabled and externalAllow is set
+  - it: should set N8N_RUNNERS_EXTERNAL_ALLOW from packages list when python.enabled and packages are set
     set:
       taskRunners:
         mode: external
         python:
           enabled: true
-          externalAllow: "numpy,pandas"
+          packages:
+            - numpy
+            - pandas
     documentSelector:
       path: metadata.name
       value: n8n-task-runners-configmap
@@ -1155,12 +1157,14 @@ tests:
           path: data.N8N_RUNNERS_STDLIB_ALLOW
           value: "os,sys"
 
-  - it: should set N8N_RUNNERS_EXTERNAL_ALLOW in task-broker-configmap when python.enabled and externalAllow is set
+  - it: should set N8N_RUNNERS_EXTERNAL_ALLOW in task-broker-configmap from packages list when python.enabled and packages are set
     set:
       taskRunners:
         python:
           enabled: true
-          externalAllow: "numpy,pandas"
+          packages:
+            - numpy
+            - pandas
     documentSelector:
       path: metadata.name
       value: n8n-task-broker-configmap
@@ -1212,6 +1216,20 @@ tests:
         mode: external
         python:
           enabled: false
+    documentSelector:
+      path: metadata.name
+      value: n8n-task-runners-configmap
+    asserts:
+      - notExists:
+          path: data.N8N_RUNNERS_EXTERNAL_ALLOW
+
+  - it: should not set N8N_RUNNERS_EXTERNAL_ALLOW when python.enabled and packages is empty
+    set:
+      taskRunners:
+        mode: external
+        python:
+          enabled: true
+          packages: []
     documentSelector:
       path: metadata.name
       value: n8n-task-runners-configmap

--- a/charts/n8n/unittests/configmap_test.yaml
+++ b/charts/n8n/unittests/configmap_test.yaml
@@ -1130,6 +1130,43 @@ tests:
           path: data.N8N_RUNNERS_EXTERNAL_ALLOW
           value: "numpy,pandas"
 
+  - it: should not set N8N_RUNNERS_ENABLED when taskRunners.mode is external
+    set:
+      taskRunners:
+        mode: external
+    documentSelector:
+      path: metadata.name
+      value: n8n-task-broker-configmap
+    asserts:
+      - notExists:
+          path: data.N8N_RUNNERS_ENABLED
+
+  - it: should not set N8N_RUNNERS_STDLIB_ALLOW when python.enabled is false
+    set:
+      taskRunners:
+        mode: external
+        python:
+          enabled: false
+    documentSelector:
+      path: metadata.name
+      value: n8n-task-runners-configmap
+    asserts:
+      - notExists:
+          path: data.N8N_RUNNERS_STDLIB_ALLOW
+
+  - it: should not set N8N_RUNNERS_EXTERNAL_ALLOW when python.enabled is false
+    set:
+      taskRunners:
+        mode: external
+        python:
+          enabled: false
+    documentSelector:
+      path: metadata.name
+      value: n8n-task-runners-configmap
+    asserts:
+      - notExists:
+          path: data.N8N_RUNNERS_EXTERNAL_ALLOW
+
   - it: should set license environment variables when license.enabled is true
     set:
       license:

--- a/charts/n8n/unittests/deployment-mcp-webhook_test.yaml
+++ b/charts/n8n/unittests/deployment-mcp-webhook_test.yaml
@@ -842,9 +842,9 @@ tests:
             value: n8nextraenvvar
         template: deployment-mcp-webhook.yaml
 
-  - it: should set n8n runners enabled environment variable
+  - it: should not set deprecated N8N_RUNNERS_ENABLED environment variable
     asserts:
-      - contains:
+      - notContains:
           path: spec.template.spec.containers[?(@.name == "n8n-mcp-webhook")].env
           content:
             name: N8N_RUNNERS_ENABLED
@@ -1292,9 +1292,9 @@ tests:
             value: fake-value
         template: deployment-mcp-webhook.yaml
 
-  - it: should set task runner enabled environment variable
+  - it: should not set deprecated N8N_RUNNERS_ENABLED environment variable in task runner section
     asserts:
-      - contains:
+      - notContains:
           path: spec.template.spec.containers[?(@.name == "n8n-mcp-webhook")].env
           content:
             name: N8N_RUNNERS_ENABLED

--- a/charts/n8n/unittests/deployment-webhook_test.yaml
+++ b/charts/n8n/unittests/deployment-webhook_test.yaml
@@ -836,9 +836,9 @@ tests:
             value: n8nextraenvvar
         template: deployment-webhook.yaml
 
-  - it: should set n8n runners enabled environment variable
+  - it: should not set deprecated N8N_RUNNERS_ENABLED environment variable
     asserts:
-      - contains:
+      - notContains:
           path: spec.template.spec.containers[?(@.name == "n8n-webhook")].env
           content:
             name: N8N_RUNNERS_ENABLED
@@ -1282,9 +1282,9 @@ tests:
             value: fake-value
         template: deployment-webhook.yaml
 
-  - it: should set task runner enabled environment variable
+  - it: should not set deprecated N8N_RUNNERS_ENABLED environment variable in task runner section
     asserts:
-      - contains:
+      - notContains:
           path: spec.template.spec.containers[?(@.name == "n8n-webhook")].env
           content:
             name: N8N_RUNNERS_ENABLED

--- a/charts/n8n/unittests/deployment-worker_test.yaml
+++ b/charts/n8n/unittests/deployment-worker_test.yaml
@@ -1437,10 +1437,11 @@ tests:
               name: n8n-task-runners-configmap
         template: deployment-worker.yaml
 
-  - it: should add python arg to task runner container when taskRunners.python.enabled is true
+  - it: should add python arg to task runner container when nodes.python.enabled is true
     set:
       taskRunners:
         mode: external
+      nodes:
         python:
           enabled: true
     asserts:
@@ -1449,10 +1450,11 @@ tests:
           content: python
         template: deployment-worker.yaml
 
-  - it: should not add python arg when taskRunners.python.enabled is false
+  - it: should not add python arg when nodes.python.enabled is false
     set:
       taskRunners:
         mode: external
+      nodes:
         python:
           enabled: false
     asserts:
@@ -2525,10 +2527,11 @@ tests:
           value: n8nio/runners:2.0.0
         template: deployment-worker.yaml
 
-  - it: should use uv install command when taskRunners.python.external.packages is set
+  - it: should use uv install command when nodes.python.external.packages is set
     set:
       taskRunners:
         mode: external
+      nodes:
         python:
           enabled: true
           external:
@@ -2541,10 +2544,11 @@ tests:
           value: ["/bin/sh", "-c", "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages pandas numpy && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript python"]
         template: deployment-worker.yaml
 
-  - it: should use direct launcher command when taskRunners.python.external.packages is empty
+  - it: should use direct launcher command when nodes.python.external.packages is empty
     set:
       taskRunners:
         mode: external
+      nodes:
         python:
           enabled: true
           external:

--- a/charts/n8n/unittests/deployment-worker_test.yaml
+++ b/charts/n8n/unittests/deployment-worker_test.yaml
@@ -2541,7 +2541,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].command
-          value: ["/bin/sh", "-c", "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /home/node/.python-packages pandas numpy && export PYTHONPATH=/home/node/.python-packages && exec /usr/local/bin/task-runner-launcher javascript python"]
+          value: ["/bin/sh", "-c", "UV_CACHE_DIR=/tmp/.uv-cache UV_LINK_MODE=copy uv pip install --target /home/node/.python-packages pandas numpy && export PYTHONPATH=/home/node/.python-packages && exec /usr/local/bin/task-runner-launcher javascript python"]
         template: deployment-worker.yaml
 
   - it: should use direct launcher command when nodes.python.external.packages is empty

--- a/charts/n8n/unittests/deployment-worker_test.yaml
+++ b/charts/n8n/unittests/deployment-worker_test.yaml
@@ -1389,7 +1389,7 @@ tests:
         template: deployment-worker.yaml
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].livenessProbe.httpGet.port
-          value: http
+          value: runner-health
         template: deployment-worker.yaml
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].readinessProbe.httpGet.path
@@ -1397,7 +1397,7 @@ tests:
         template: deployment-worker.yaml
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].readinessProbe.httpGet.port
-          value: http
+          value: runner-health
         template: deployment-worker.yaml
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].resources

--- a/charts/n8n/unittests/deployment-worker_test.yaml
+++ b/charts/n8n/unittests/deployment-worker_test.yaml
@@ -2633,3 +2633,129 @@ tests:
             name: python-packages
             emptyDir: {}
         template: deployment-worker.yaml
+
+  - it: should set UV_DEFAULT_INDEX in worker when pypiRegistry.enabled and url is set without config file
+    set:
+      taskRunners:
+        mode: external
+      pypiRegistry:
+        enabled: true
+        url: "https://my.registry.com/simple/"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].env
+          content:
+            name: UV_DEFAULT_INDEX
+            value: "https://my.registry.com/simple/"
+          any: true
+        template: deployment-worker.yaml
+
+  - it: should set UV_CONFIG_FILE in worker when pypiRegistry.enabled and customUvConfig is set
+    set:
+      taskRunners:
+        mode: external
+      pypiRegistry:
+        enabled: true
+        customUvConfig: "[index]\nurl = \"https://my.registry.com/simple/\""
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].env
+          content:
+            name: UV_CONFIG_FILE
+            value: "/home/node/.uv-config/uv.toml"
+          any: true
+        template: deployment-worker.yaml
+
+  - it: should set UV_CONFIG_FILE in worker when pypiRegistry.enabled and secretName is set
+    set:
+      taskRunners:
+        mode: external
+      pypiRegistry:
+        enabled: true
+        secretName: "my-uv-secret"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].env
+          content:
+            name: UV_CONFIG_FILE
+            value: "/home/node/.uv-config/uv.toml"
+          any: true
+        template: deployment-worker.yaml
+
+  - it: should mount uv-config volume in worker when pypiRegistry.enabled and customUvConfig is set
+    set:
+      taskRunners:
+        mode: external
+      pypiRegistry:
+        enabled: true
+        customUvConfig: "[index]\nurl = \"https://my.registry.com/simple/\""
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].volumeMounts
+          content:
+            name: uv-config
+            mountPath: /home/node/.uv-config
+            readOnly: true
+          any: true
+        template: deployment-worker.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: uv-config
+            secret:
+              secretName: "n8n-pypi-registry-secret"
+              optional: true
+          any: true
+        template: deployment-worker.yaml
+
+  - it: should use existing secret name for uv-config volume in worker when pypiRegistry.secretName is set
+    set:
+      taskRunners:
+        mode: external
+      pypiRegistry:
+        enabled: true
+        secretName: "my-existing-uv-secret"
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: uv-config
+            secret:
+              secretName: "my-existing-uv-secret"
+              optional: true
+          any: true
+        template: deployment-worker.yaml
+
+  - it: should not add pypiRegistry env vars in worker when pypiRegistry is disabled
+    set:
+      taskRunners:
+        mode: external
+      pypiRegistry:
+        enabled: false
+        url: "https://my.registry.com/simple/"
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].env
+          content:
+            name: UV_DEFAULT_INDEX
+            value: "https://my.registry.com/simple/"
+          any: true
+        template: deployment-worker.yaml
+
+  - it: should not add uv-config volume in worker when pypiRegistry is disabled
+    set:
+      taskRunners:
+        mode: external
+      pypiRegistry:
+        enabled: false
+        customUvConfig: "[index]\nurl = \"https://my.registry.com/simple/\""
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: uv-config
+            secret:
+              secretName: "n8n-pypi-registry-secret"
+              optional: true
+          any: true
+        template: deployment-worker.yaml

--- a/charts/n8n/unittests/deployment-worker_test.yaml
+++ b/charts/n8n/unittests/deployment-worker_test.yaml
@@ -1400,6 +1400,18 @@ tests:
           value: runner-health
         template: deployment-worker.yaml
       - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].startupProbe.httpGet.path
+          value: /healthz
+        template: deployment-worker.yaml
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].startupProbe.httpGet.port
+          value: runner-health
+        template: deployment-worker.yaml
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].startupProbe.failureThreshold
+          value: 30
+        template: deployment-worker.yaml
+      - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].resources
           value:
             requests:
@@ -2511,4 +2523,32 @@ tests:
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].image
           value: n8nio/runners:2.0.0
+        template: deployment-worker.yaml
+
+  - it: should use uv install command when taskRunners.python.packages is set
+    set:
+      taskRunners:
+        mode: external
+        python:
+          enabled: true
+          packages:
+            - pandas
+            - numpy
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].command
+          value: ["/bin/sh", "-c", "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages pandas numpy && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript python"]
+        template: deployment-worker.yaml
+
+  - it: should use direct launcher command when taskRunners.python.packages is empty
+    set:
+      taskRunners:
+        mode: external
+        python:
+          enabled: true
+          packages: []
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].command
+          value: ["/usr/local/bin/task-runner-launcher"]
         template: deployment-worker.yaml

--- a/charts/n8n/unittests/deployment-worker_test.yaml
+++ b/charts/n8n/unittests/deployment-worker_test.yaml
@@ -2489,3 +2489,26 @@ tests:
           path: spec.revisionHistoryLimit
           value: 0
         template: deployment-worker.yaml
+
+  - it: should set runner-health port name on task runner sidecar container
+    set:
+      taskRunners:
+        mode: external
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].ports[0].name
+          value: runner-health
+        template: deployment-worker.yaml
+
+  - it: should use explicit tag when taskRunners.external.image.tag is set
+    set:
+      taskRunners:
+        mode: external
+        external:
+          image:
+            tag: "2.0.0"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].image
+          value: n8nio/runners:2.0.0
+        template: deployment-worker.yaml

--- a/charts/n8n/unittests/deployment-worker_test.yaml
+++ b/charts/n8n/unittests/deployment-worker_test.yaml
@@ -2541,7 +2541,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].command
-          value: ["/bin/sh", "-c", "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages pandas numpy && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript python"]
+          value: ["/bin/sh", "-c", "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /home/node/.python-packages pandas numpy && export PYTHONPATH=/home/node/.python-packages && exec /usr/local/bin/task-runner-launcher javascript python"]
         template: deployment-worker.yaml
 
   - it: should use direct launcher command when nodes.python.external.packages is empty
@@ -2557,4 +2557,67 @@ tests:
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].command
           value: ["/usr/local/bin/task-runner-launcher"]
+        template: deployment-worker.yaml
+
+  - it: should mount python-packages volume in runner sidecar at /home/node/.python-packages
+    set:
+      taskRunners:
+        mode: external
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].volumeMounts
+          content:
+            name: python-packages
+            mountPath: /home/node/.python-packages
+        template: deployment-worker.yaml
+
+  - it: should create python-packages emptyDir volume in Deployment worker when persistence is disabled
+    set:
+      taskRunners:
+        mode: external
+      nodes:
+        python:
+          persistence:
+            enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: python-packages
+            emptyDir: {}
+        template: deployment-worker.yaml
+
+  - it: should create python-packages PVC volume in Deployment worker when persistence is enabled
+    set:
+      taskRunners:
+        mode: external
+      nodes:
+        python:
+          persistence:
+            enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: python-packages
+            persistentVolumeClaim:
+              claimName: n8n-python-packages
+        template: deployment-worker.yaml
+
+  - it: should use existingClaim name for python-packages volume in Deployment worker
+    set:
+      taskRunners:
+        mode: external
+      nodes:
+        python:
+          persistence:
+            enabled: true
+            existingClaim: my-existing-pvc
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: python-packages
+            persistentVolumeClaim:
+              claimName: my-existing-pvc
         template: deployment-worker.yaml

--- a/charts/n8n/unittests/deployment-worker_test.yaml
+++ b/charts/n8n/unittests/deployment-worker_test.yaml
@@ -2525,28 +2525,30 @@ tests:
           value: n8nio/runners:2.0.0
         template: deployment-worker.yaml
 
-  - it: should use uv install command when taskRunners.python.packages is set
+  - it: should use uv install command when taskRunners.python.external.packages is set
     set:
       taskRunners:
         mode: external
         python:
           enabled: true
-          packages:
-            - pandas
-            - numpy
+          external:
+            packages:
+              - pandas
+              - numpy
     asserts:
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].command
           value: ["/bin/sh", "-c", "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages pandas numpy && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript python"]
         template: deployment-worker.yaml
 
-  - it: should use direct launcher command when taskRunners.python.packages is empty
+  - it: should use direct launcher command when taskRunners.python.external.packages is empty
     set:
       taskRunners:
         mode: external
         python:
           enabled: true
-          packages: []
+          external:
+            packages: []
     asserts:
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].command

--- a/charts/n8n/unittests/deployment-worker_test.yaml
+++ b/charts/n8n/unittests/deployment-worker_test.yaml
@@ -2621,3 +2621,15 @@ tests:
             persistentVolumeClaim:
               claimName: my-existing-pvc
         template: deployment-worker.yaml
+
+  - it: should not add python-packages volume in Deployment worker when taskRunners.mode is internal
+    set:
+      taskRunners:
+        mode: internal
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: python-packages
+            emptyDir: {}
+        template: deployment-worker.yaml

--- a/charts/n8n/unittests/deployment-worker_test.yaml
+++ b/charts/n8n/unittests/deployment-worker_test.yaml
@@ -1425,6 +1425,30 @@ tests:
               name: n8n-task-runners-configmap
         template: deployment-worker.yaml
 
+  - it: should add python arg to task runner container when taskRunners.python.enabled is true
+    set:
+      taskRunners:
+        mode: external
+        python:
+          enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].args
+          content: python
+        template: deployment-worker.yaml
+
+  - it: should not add python arg when taskRunners.python.enabled is false
+    set:
+      taskRunners:
+        mode: external
+        python:
+          enabled: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].args
+          value: ["javascript"]
+        template: deployment-worker.yaml
+
   - it: should set security context on task runner container when taskRunners.mode is external
     set:
       taskRunners:

--- a/charts/n8n/unittests/deployment-worker_test.yaml
+++ b/charts/n8n/unittests/deployment-worker_test.yaml
@@ -1361,7 +1361,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].image
-          value: n8nio/n8n:1.0.0
+          value: n8nio/runners:1.0.0
         template: deployment-worker.yaml
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].imagePullPolicy

--- a/charts/n8n/unittests/deployment_test.yaml
+++ b/charts/n8n/unittests/deployment_test.yaml
@@ -1361,7 +1361,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].image
-          value: n8nio/n8n:1.0.0
+          value: n8nio/runners:1.0.0
         template: deployment.yaml
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].imagePullPolicy
@@ -1423,6 +1423,21 @@ tests:
           content:
             configMapRef:
               name: n8n-task-runners-configmap
+        template: deployment.yaml
+
+  - it: should not add task runner sidecar on main pod when worker.mode is queue
+    set:
+      taskRunners:
+        mode: external
+      worker:
+        mode: queue
+      db:
+        type: postgresdb
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers
+          content:
+            name: n8n-task-runners
         template: deployment.yaml
 
   - it: should set security context on task runner container when taskRunners.mode is external

--- a/charts/n8n/unittests/deployment_test.yaml
+++ b/charts/n8n/unittests/deployment_test.yaml
@@ -2468,7 +2468,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].command
-          value: ["/bin/sh", "-c", "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages pandas numpy && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript python"]
+          value: ["/bin/sh", "-c", "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /home/node/.python-packages pandas numpy && export PYTHONPATH=/home/node/.python-packages && exec /usr/local/bin/task-runner-launcher javascript python"]
         template: deployment.yaml
 
   - it: should use direct launcher command when nodes.python.external.packages is empty
@@ -2484,4 +2484,79 @@ tests:
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].command
           value: ["/usr/local/bin/task-runner-launcher"]
+        template: deployment.yaml
+
+  - it: should mount python-packages volume in runner sidecar at /home/node/.python-packages
+    set:
+      taskRunners:
+        mode: external
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].volumeMounts
+          content:
+            name: python-packages
+            mountPath: /home/node/.python-packages
+        template: deployment.yaml
+
+  - it: should create python-packages emptyDir volume in Deployment when persistence is disabled
+    set:
+      taskRunners:
+        mode: external
+      nodes:
+        python:
+          persistence:
+            enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: python-packages
+            emptyDir: {}
+        template: deployment.yaml
+
+  - it: should create python-packages PVC volume in Deployment when persistence is enabled
+    set:
+      taskRunners:
+        mode: external
+      nodes:
+        python:
+          persistence:
+            enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: python-packages
+            persistentVolumeClaim:
+              claimName: n8n-python-packages
+        template: deployment.yaml
+
+  - it: should use existingClaim name for python-packages volume in Deployment
+    set:
+      taskRunners:
+        mode: external
+      nodes:
+        python:
+          persistence:
+            enabled: true
+            existingClaim: my-existing-pvc
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: python-packages
+            persistentVolumeClaim:
+              claimName: my-existing-pvc
+        template: deployment.yaml
+
+  - it: should not add python-packages volume when taskRunners.mode is internal
+    set:
+      taskRunners:
+        mode: internal
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: python-packages
+            emptyDir: {}
         template: deployment.yaml

--- a/charts/n8n/unittests/deployment_test.yaml
+++ b/charts/n8n/unittests/deployment_test.yaml
@@ -1389,7 +1389,7 @@ tests:
         template: deployment.yaml
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].livenessProbe.httpGet.port
-          value: http
+          value: runner-health
         template: deployment.yaml
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].readinessProbe.httpGet.path
@@ -1397,7 +1397,7 @@ tests:
         template: deployment.yaml
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].readinessProbe.httpGet.port
-          value: http
+          value: runner-health
         template: deployment.yaml
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].resources

--- a/charts/n8n/unittests/deployment_test.yaml
+++ b/charts/n8n/unittests/deployment_test.yaml
@@ -1440,6 +1440,30 @@ tests:
             name: n8n-task-runners
         template: deployment.yaml
 
+  - it: should add python arg to task runner container when taskRunners.python.enabled is true
+    set:
+      taskRunners:
+        mode: external
+        python:
+          enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].args
+          content: python
+        template: deployment.yaml
+
+  - it: should not add python arg when taskRunners.python.enabled is false
+    set:
+      taskRunners:
+        mode: external
+        python:
+          enabled: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].args
+          value: ["javascript"]
+        template: deployment.yaml
+
   - it: should set security context on task runner container when taskRunners.mode is external
     set:
       taskRunners:

--- a/charts/n8n/unittests/deployment_test.yaml
+++ b/charts/n8n/unittests/deployment_test.yaml
@@ -2560,3 +2560,17 @@ tests:
             name: python-packages
             emptyDir: {}
         template: deployment.yaml
+
+  - it: should not add python-packages volume in main Deployment when worker.mode is queue
+    set:
+      taskRunners:
+        mode: external
+      worker:
+        mode: queue
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: python-packages
+            emptyDir: {}
+        template: deployment.yaml

--- a/charts/n8n/unittests/deployment_test.yaml
+++ b/charts/n8n/unittests/deployment_test.yaml
@@ -1400,6 +1400,18 @@ tests:
           value: runner-health
         template: deployment.yaml
       - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].startupProbe.httpGet.path
+          value: /healthz
+        template: deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].startupProbe.httpGet.port
+          value: runner-health
+        template: deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].startupProbe.failureThreshold
+          value: 30
+        template: deployment.yaml
+      - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].resources
           value:
             requests:
@@ -2438,4 +2450,32 @@ tests:
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].image
           value: n8nio/runners:2.0.0
+        template: deployment.yaml
+
+  - it: should use uv install command when taskRunners.python.packages is set
+    set:
+      taskRunners:
+        mode: external
+        python:
+          enabled: true
+          packages:
+            - pandas
+            - numpy
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].command
+          value: ["/bin/sh", "-c", "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages pandas numpy && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript python"]
+        template: deployment.yaml
+
+  - it: should use direct launcher command when taskRunners.python.packages is empty
+    set:
+      taskRunners:
+        mode: external
+        python:
+          enabled: true
+          packages: []
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].command
+          value: ["/usr/local/bin/task-runner-launcher"]
         template: deployment.yaml

--- a/charts/n8n/unittests/deployment_test.yaml
+++ b/charts/n8n/unittests/deployment_test.yaml
@@ -1452,10 +1452,11 @@ tests:
             name: n8n-task-runners
         template: deployment.yaml
 
-  - it: should add python arg to task runner container when taskRunners.python.enabled is true
+  - it: should add python arg to task runner container when nodes.python.enabled is true
     set:
       taskRunners:
         mode: external
+      nodes:
         python:
           enabled: true
     asserts:
@@ -1464,10 +1465,11 @@ tests:
           content: python
         template: deployment.yaml
 
-  - it: should not add python arg when taskRunners.python.enabled is false
+  - it: should not add python arg when nodes.python.enabled is false
     set:
       taskRunners:
         mode: external
+      nodes:
         python:
           enabled: false
     asserts:
@@ -2452,10 +2454,11 @@ tests:
           value: n8nio/runners:2.0.0
         template: deployment.yaml
 
-  - it: should use uv install command when taskRunners.python.external.packages is set
+  - it: should use uv install command when nodes.python.external.packages is set
     set:
       taskRunners:
         mode: external
+      nodes:
         python:
           enabled: true
           external:
@@ -2468,10 +2471,11 @@ tests:
           value: ["/bin/sh", "-c", "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages pandas numpy && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript python"]
         template: deployment.yaml
 
-  - it: should use direct launcher command when taskRunners.python.external.packages is empty
+  - it: should use direct launcher command when nodes.python.external.packages is empty
     set:
       taskRunners:
         mode: external
+      nodes:
         python:
           enabled: true
           external:

--- a/charts/n8n/unittests/deployment_test.yaml
+++ b/charts/n8n/unittests/deployment_test.yaml
@@ -2574,3 +2574,166 @@ tests:
             name: python-packages
             emptyDir: {}
         template: deployment.yaml
+
+  - it: should set UV_DEFAULT_INDEX when pypiRegistry.enabled and url is set without config file
+    set:
+      taskRunners:
+        mode: external
+      pypiRegistry:
+        enabled: true
+        url: "https://my.registry.com/simple/"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: UV_DEFAULT_INDEX
+            value: "https://my.registry.com/simple/"
+          any: true
+        template: deployment.yaml
+
+  - it: should set UV_CONFIG_FILE when pypiRegistry.enabled and customUvConfig is set
+    set:
+      taskRunners:
+        mode: external
+      pypiRegistry:
+        enabled: true
+        customUvConfig: "[index]\nurl = \"https://my.registry.com/simple/\""
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: UV_CONFIG_FILE
+            value: "/home/node/.uv-config/uv.toml"
+          any: true
+        template: deployment.yaml
+
+  - it: should set UV_CONFIG_FILE when pypiRegistry.enabled and secretName is set
+    set:
+      taskRunners:
+        mode: external
+      pypiRegistry:
+        enabled: true
+        secretName: "my-uv-secret"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: UV_CONFIG_FILE
+            value: "/home/node/.uv-config/uv.toml"
+          any: true
+        template: deployment.yaml
+
+  - it: should set UV_CONFIG_FILE with custom secretKey when pypiRegistry.secretKey is set
+    set:
+      taskRunners:
+        mode: external
+      pypiRegistry:
+        enabled: true
+        secretName: "my-uv-secret"
+        secretKey: "custom.toml"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: UV_CONFIG_FILE
+            value: "/home/node/.uv-config/custom.toml"
+          any: true
+        template: deployment.yaml
+
+  - it: should mount uv-config volume when pypiRegistry.enabled and customUvConfig is set
+    set:
+      taskRunners:
+        mode: external
+      pypiRegistry:
+        enabled: true
+        customUvConfig: "[index]\nurl = \"https://my.registry.com/simple/\""
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].volumeMounts
+          content:
+            name: uv-config
+            mountPath: /home/node/.uv-config
+            readOnly: true
+          any: true
+        template: deployment.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: uv-config
+            secret:
+              secretName: "n8n-pypi-registry-secret"
+              optional: true
+          any: true
+        template: deployment.yaml
+
+  - it: should use existing secret name for uv-config volume when pypiRegistry.secretName is set
+    set:
+      taskRunners:
+        mode: external
+      pypiRegistry:
+        enabled: true
+        secretName: "my-existing-uv-secret"
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: uv-config
+            secret:
+              secretName: "my-existing-uv-secret"
+              optional: true
+          any: true
+        template: deployment.yaml
+
+  - it: should not add pypiRegistry env vars when pypiRegistry is disabled
+    set:
+      taskRunners:
+        mode: external
+      pypiRegistry:
+        enabled: false
+        url: "https://my.registry.com/simple/"
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: UV_DEFAULT_INDEX
+            value: "https://my.registry.com/simple/"
+          any: true
+        template: deployment.yaml
+
+  - it: should not add uv-config volume when pypiRegistry is disabled
+    set:
+      taskRunners:
+        mode: external
+      pypiRegistry:
+        enabled: false
+        customUvConfig: "[index]\nurl = \"https://my.registry.com/simple/\""
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: uv-config
+            secret:
+              secretName: "n8n-pypi-registry-secret"
+              optional: true
+          any: true
+        template: deployment.yaml
+
+  - it: should not add uv-config volume in main Deployment when worker.mode is queue
+    set:
+      taskRunners:
+        mode: external
+      worker:
+        mode: queue
+      pypiRegistry:
+        enabled: true
+        customUvConfig: "[index]\nurl = \"https://my.registry.com/simple/\""
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: uv-config
+            secret:
+              secretName: "n8n-pypi-registry-secret"
+              optional: true
+          any: true
+        template: deployment.yaml

--- a/charts/n8n/unittests/deployment_test.yaml
+++ b/charts/n8n/unittests/deployment_test.yaml
@@ -2416,3 +2416,26 @@ tests:
               key: client.key
     asserts:
       - matchSnapshot: { }
+
+  - it: should set runner-health port name on task runner sidecar container
+    set:
+      taskRunners:
+        mode: external
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].ports[0].name
+          value: runner-health
+        template: deployment.yaml
+
+  - it: should use explicit tag when taskRunners.external.image.tag is set
+    set:
+      taskRunners:
+        mode: external
+        external:
+          image:
+            tag: "2.0.0"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].image
+          value: n8nio/runners:2.0.0
+        template: deployment.yaml

--- a/charts/n8n/unittests/deployment_test.yaml
+++ b/charts/n8n/unittests/deployment_test.yaml
@@ -2452,28 +2452,30 @@ tests:
           value: n8nio/runners:2.0.0
         template: deployment.yaml
 
-  - it: should use uv install command when taskRunners.python.packages is set
+  - it: should use uv install command when taskRunners.python.external.packages is set
     set:
       taskRunners:
         mode: external
         python:
           enabled: true
-          packages:
-            - pandas
-            - numpy
+          external:
+            packages:
+              - pandas
+              - numpy
     asserts:
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].command
           value: ["/bin/sh", "-c", "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages pandas numpy && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript python"]
         template: deployment.yaml
 
-  - it: should use direct launcher command when taskRunners.python.packages is empty
+  - it: should use direct launcher command when taskRunners.python.external.packages is empty
     set:
       taskRunners:
         mode: external
         python:
           enabled: true
-          packages: []
+          external:
+            packages: []
     asserts:
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].command

--- a/charts/n8n/unittests/deployment_test.yaml
+++ b/charts/n8n/unittests/deployment_test.yaml
@@ -2468,7 +2468,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].command
-          value: ["/bin/sh", "-c", "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /home/node/.python-packages pandas numpy && export PYTHONPATH=/home/node/.python-packages && exec /usr/local/bin/task-runner-launcher javascript python"]
+          value: ["/bin/sh", "-c", "UV_CACHE_DIR=/tmp/.uv-cache UV_LINK_MODE=copy uv pip install --target /home/node/.python-packages pandas numpy && export PYTHONPATH=/home/node/.python-packages && exec /usr/local/bin/task-runner-launcher javascript python"]
         template: deployment.yaml
 
   - it: should use direct launcher command when nodes.python.external.packages is empty

--- a/charts/n8n/unittests/hpa_test.yaml
+++ b/charts/n8n/unittests/hpa_test.yaml
@@ -157,3 +157,59 @@ tests:
           enabled: true
     asserts:
       - matchSnapshot: { }
+
+  - it: should not render HPA when nodes.python.persistence is enabled with ReadWriteOnce
+    set:
+      db:
+        type: postgresdb
+      worker:
+        mode: queue
+        autoscaling:
+          enabled: true
+        persistence:
+          accessMode: ReadWriteMany
+      nodes:
+        python:
+          persistence:
+            enabled: true
+            accessMode: ReadWriteOnce
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render HPA when nodes.python.persistence is enabled with ReadWriteMany
+    set:
+      db:
+        type: postgresdb
+      worker:
+        mode: queue
+        autoscaling:
+          enabled: true
+        persistence:
+          accessMode: ReadWriteMany
+      nodes:
+        python:
+          persistence:
+            enabled: true
+            accessMode: ReadWriteMany
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should render HPA when nodes.python.persistence is disabled
+    set:
+      db:
+        type: postgresdb
+      worker:
+        mode: queue
+        autoscaling:
+          enabled: true
+        persistence:
+          accessMode: ReadWriteMany
+      nodes:
+        python:
+          persistence:
+            enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1

--- a/charts/n8n/unittests/pvc_test.yaml
+++ b/charts/n8n/unittests/pvc_test.yaml
@@ -159,3 +159,117 @@ tests:
           enabled: true
     asserts:
       - matchSnapshot: { }
+
+  - it: should not create python-packages PVC when persistence is disabled
+    set:
+      main:
+        persistence:
+          enabled: false
+      worker:
+        persistence:
+          enabled: false
+      taskRunners:
+        mode: external
+      nodes:
+        python:
+          persistence:
+            enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create python-packages PVC when taskRunners.mode is internal
+    set:
+      main:
+        persistence:
+          enabled: false
+      worker:
+        persistence:
+          enabled: false
+      taskRunners:
+        mode: internal
+      nodes:
+        python:
+          persistence:
+            enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create python-packages PVC when existingClaim is set
+    set:
+      main:
+        persistence:
+          enabled: false
+      worker:
+        persistence:
+          enabled: false
+      taskRunners:
+        mode: external
+      nodes:
+        python:
+          persistence:
+            enabled: true
+            existingClaim: my-existing-pvc
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create python-packages PVC when persistence is enabled and taskRunners.mode is external
+    set:
+      main:
+        persistence:
+          enabled: false
+      worker:
+        persistence:
+          enabled: false
+      taskRunners:
+        mode: external
+      nodes:
+        python:
+          persistence:
+            enabled: true
+            storageClass: fast-ssd
+            accessMode: ReadWriteOnce
+            size: 2Gi
+            annotations:
+              test-key: test-value
+    documentSelector:
+      path: metadata.name
+      value: n8n-python-packages
+    asserts:
+      - equal:
+          path: spec.accessModes[0]
+          value: ReadWriteOnce
+      - equal:
+          path: spec.resources.requests.storage
+          value: 2Gi
+      - equal:
+          path: spec.storageClassName
+          value: fast-ssd
+      - equal:
+          path: metadata.annotations.test-key
+          value: test-value
+
+  - it: should create python-packages PVC with ReadWriteMany access mode
+    set:
+      main:
+        persistence:
+          enabled: false
+      worker:
+        persistence:
+          enabled: false
+      taskRunners:
+        mode: external
+      nodes:
+        python:
+          persistence:
+            enabled: true
+            accessMode: ReadWriteMany
+    documentSelector:
+      path: metadata.name
+      value: n8n-python-packages
+    asserts:
+      - equal:
+          path: spec.accessModes[0]
+          value: ReadWriteMany

--- a/charts/n8n/unittests/secret_test.yaml
+++ b/charts/n8n/unittests/secret_test.yaml
@@ -144,6 +144,51 @@ tests:
           value: "registry=https://my-registry.com"
           decodeBase64: true
 
+  - it: should not create pypi registry secret when pypiRegistry is disabled
+    set:
+      pypiRegistry:
+        enabled: false
+        customUvConfig: "[[index]]\nurl = \"https://my.registry.com/simple/\""
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should not create pypi registry secret when secretName is set (existing secret used)
+    set:
+      pypiRegistry:
+        enabled: true
+        secretName: "my-existing-uv-secret"
+        customUvConfig: "[[index]]\nurl = \"https://my.registry.com/simple/\""
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should create pypi registry secret when customUvConfig is set and secretName is empty
+    set:
+      pypiRegistry:
+        enabled: true
+        customUvConfig: "[[index]]\nurl = \"https://my.registry.com/simple/\""
+    documentSelector:
+      path: metadata.name
+      value: n8n-pypi-registry-secret
+    asserts:
+      - isNotEmpty:
+          path: data["uv.toml"]
+
+  - it: should encode customUvConfig as base64 in the pypi registry secret
+    set:
+      pypiRegistry:
+        enabled: true
+        customUvConfig: "[[index]]\nurl = \"https://my.registry.com/simple/\""
+    documentSelector:
+      path: metadata.name
+      value: n8n-pypi-registry-secret
+    asserts:
+      - equal:
+          path: data["uv.toml"]
+          value: "[[index]]\nurl = \"https://my.registry.com/simple/\""
+          decodeBase64: true
+
   - it: should create CA certificate secret when db.type postgresdb, postgresdb.ssl.enabled, and postgresdb.ssl.base64EncodedCertificateAuthorityFile are set
     set:
       db:

--- a/charts/n8n/unittests/statefulset-worker_test.yaml
+++ b/charts/n8n/unittests/statefulset-worker_test.yaml
@@ -2410,28 +2410,30 @@ tests:
           value: n8nio/runners:2.0.0
         template: statefulset-worker.yaml
 
-  - it: should use uv install command when taskRunners.python.packages is set
+  - it: should use uv install command when taskRunners.python.external.packages is set
     set:
       taskRunners:
         mode: external
         python:
           enabled: true
-          packages:
-            - pandas
-            - numpy
+          external:
+            packages:
+              - pandas
+              - numpy
     asserts:
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].command
           value: ["/bin/sh", "-c", "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages pandas numpy && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript python"]
         template: statefulset-worker.yaml
 
-  - it: should use direct launcher command when taskRunners.python.packages is empty
+  - it: should use direct launcher command when taskRunners.python.external.packages is empty
     set:
       taskRunners:
         mode: external
         python:
           enabled: true
-          packages: []
+          external:
+            packages: []
     asserts:
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].command

--- a/charts/n8n/unittests/statefulset-worker_test.yaml
+++ b/charts/n8n/unittests/statefulset-worker_test.yaml
@@ -1312,7 +1312,7 @@ tests:
         template: statefulset-worker.yaml
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].livenessProbe.httpGet.port
-          value: http
+          value: runner-health
         template: statefulset-worker.yaml
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].readinessProbe.httpGet.path
@@ -1320,7 +1320,7 @@ tests:
         template: statefulset-worker.yaml
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].readinessProbe.httpGet.port
-          value: http
+          value: runner-health
         template: statefulset-worker.yaml
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].resources

--- a/charts/n8n/unittests/statefulset-worker_test.yaml
+++ b/charts/n8n/unittests/statefulset-worker_test.yaml
@@ -1284,7 +1284,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].image
-          value: n8nio/n8n:1.0.0
+          value: n8nio/runners:1.0.0
         template: statefulset-worker.yaml
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].imagePullPolicy

--- a/charts/n8n/unittests/statefulset-worker_test.yaml
+++ b/charts/n8n/unittests/statefulset-worker_test.yaml
@@ -2525,3 +2525,15 @@ tests:
             metadata:
               name: python-packages
         template: statefulset-worker.yaml
+
+  - it: should not add python-packages volume in StatefulSet worker when taskRunners.mode is internal
+    set:
+      taskRunners:
+        mode: internal
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: python-packages
+            emptyDir: {}
+        template: statefulset-worker.yaml

--- a/charts/n8n/unittests/statefulset-worker_test.yaml
+++ b/charts/n8n/unittests/statefulset-worker_test.yaml
@@ -2426,7 +2426,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].command
-          value: ["/bin/sh", "-c", "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /home/node/.python-packages pandas numpy && export PYTHONPATH=/home/node/.python-packages && exec /usr/local/bin/task-runner-launcher javascript python"]
+          value: ["/bin/sh", "-c", "UV_CACHE_DIR=/tmp/.uv-cache UV_LINK_MODE=copy uv pip install --target /home/node/.python-packages pandas numpy && export PYTHONPATH=/home/node/.python-packages && exec /usr/local/bin/task-runner-launcher javascript python"]
         template: statefulset-worker.yaml
 
   - it: should use direct launcher command when nodes.python.external.packages is empty

--- a/charts/n8n/unittests/statefulset-worker_test.yaml
+++ b/charts/n8n/unittests/statefulset-worker_test.yaml
@@ -2426,7 +2426,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].command
-          value: ["/bin/sh", "-c", "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages pandas numpy && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript python"]
+          value: ["/bin/sh", "-c", "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /home/node/.python-packages pandas numpy && export PYTHONPATH=/home/node/.python-packages && exec /usr/local/bin/task-runner-launcher javascript python"]
         template: statefulset-worker.yaml
 
   - it: should use direct launcher command when nodes.python.external.packages is empty
@@ -2442,4 +2442,86 @@ tests:
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].command
           value: ["/usr/local/bin/task-runner-launcher"]
+        template: statefulset-worker.yaml
+
+  - it: should mount python-packages volume in StatefulSet worker runner sidecar at /home/node/.python-packages
+    set:
+      taskRunners:
+        mode: external
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].volumeMounts
+          content:
+            name: python-packages
+            mountPath: /home/node/.python-packages
+        template: statefulset-worker.yaml
+
+  - it: should add python-packages emptyDir in StatefulSet worker volumes when persistence is disabled
+    set:
+      taskRunners:
+        mode: external
+      nodes:
+        python:
+          persistence:
+            enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: python-packages
+            emptyDir: {}
+        template: statefulset-worker.yaml
+
+  - it: should add python-packages to StatefulSet worker volumeClaimTemplates when persistence is enabled
+    set:
+      taskRunners:
+        mode: external
+      nodes:
+        python:
+          persistence:
+            enabled: true
+            accessMode: ReadWriteOnce
+            size: 2Gi
+    asserts:
+      - contains:
+          path: spec.volumeClaimTemplates
+          content:
+            metadata:
+              name: python-packages
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 2Gi
+        template: statefulset-worker.yaml
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: python-packages
+            emptyDir: {}
+        template: statefulset-worker.yaml
+
+  - it: should use existingClaim as regular volume in StatefulSet worker when existingClaim is set
+    set:
+      taskRunners:
+        mode: external
+      nodes:
+        python:
+          persistence:
+            enabled: true
+            existingClaim: my-existing-pvc
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: python-packages
+            persistentVolumeClaim:
+              claimName: my-existing-pvc
+        template: statefulset-worker.yaml
+      - notContains:
+          path: spec.volumeClaimTemplates
+          content:
+            metadata:
+              name: python-packages
         template: statefulset-worker.yaml

--- a/charts/n8n/unittests/statefulset-worker_test.yaml
+++ b/charts/n8n/unittests/statefulset-worker_test.yaml
@@ -1323,6 +1323,18 @@ tests:
           value: runner-health
         template: statefulset-worker.yaml
       - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].startupProbe.httpGet.path
+          value: /healthz
+        template: statefulset-worker.yaml
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].startupProbe.httpGet.port
+          value: runner-health
+        template: statefulset-worker.yaml
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].startupProbe.failureThreshold
+          value: 30
+        template: statefulset-worker.yaml
+      - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].resources
           value:
             requests:
@@ -2396,4 +2408,32 @@ tests:
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].image
           value: n8nio/runners:2.0.0
+        template: statefulset-worker.yaml
+
+  - it: should use uv install command when taskRunners.python.packages is set
+    set:
+      taskRunners:
+        mode: external
+        python:
+          enabled: true
+          packages:
+            - pandas
+            - numpy
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].command
+          value: ["/bin/sh", "-c", "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages pandas numpy && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript python"]
+        template: statefulset-worker.yaml
+
+  - it: should use direct launcher command when taskRunners.python.packages is empty
+    set:
+      taskRunners:
+        mode: external
+        python:
+          enabled: true
+          packages: []
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].command
+          value: ["/usr/local/bin/task-runner-launcher"]
         template: statefulset-worker.yaml

--- a/charts/n8n/unittests/statefulset-worker_test.yaml
+++ b/charts/n8n/unittests/statefulset-worker_test.yaml
@@ -1360,10 +1360,11 @@ tests:
               name: n8n-task-runners-configmap
         template: statefulset-worker.yaml
 
-  - it: should add python arg to task runner container when taskRunners.python.enabled is true
+  - it: should add python arg to task runner container when nodes.python.enabled is true
     set:
       taskRunners:
         mode: external
+      nodes:
         python:
           enabled: true
     asserts:
@@ -1372,10 +1373,11 @@ tests:
           content: python
         template: statefulset-worker.yaml
 
-  - it: should not add python arg when taskRunners.python.enabled is false
+  - it: should not add python arg when nodes.python.enabled is false
     set:
       taskRunners:
         mode: external
+      nodes:
         python:
           enabled: false
     asserts:
@@ -2410,10 +2412,11 @@ tests:
           value: n8nio/runners:2.0.0
         template: statefulset-worker.yaml
 
-  - it: should use uv install command when taskRunners.python.external.packages is set
+  - it: should use uv install command when nodes.python.external.packages is set
     set:
       taskRunners:
         mode: external
+      nodes:
         python:
           enabled: true
           external:
@@ -2426,10 +2429,11 @@ tests:
           value: ["/bin/sh", "-c", "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages pandas numpy && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript python"]
         template: statefulset-worker.yaml
 
-  - it: should use direct launcher command when taskRunners.python.external.packages is empty
+  - it: should use direct launcher command when nodes.python.external.packages is empty
     set:
       taskRunners:
         mode: external
+      nodes:
         python:
           enabled: true
           external:

--- a/charts/n8n/unittests/statefulset-worker_test.yaml
+++ b/charts/n8n/unittests/statefulset-worker_test.yaml
@@ -2374,3 +2374,26 @@ tests:
           path: spec.revisionHistoryLimit
           value: 0
         template: statefulset-worker.yaml
+
+  - it: should set runner-health port name on task runner sidecar container
+    set:
+      taskRunners:
+        mode: external
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].ports[0].name
+          value: runner-health
+        template: statefulset-worker.yaml
+
+  - it: should use explicit tag when taskRunners.external.image.tag is set
+    set:
+      taskRunners:
+        mode: external
+        external:
+          image:
+            tag: "2.0.0"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].image
+          value: n8nio/runners:2.0.0
+        template: statefulset-worker.yaml

--- a/charts/n8n/unittests/statefulset-worker_test.yaml
+++ b/charts/n8n/unittests/statefulset-worker_test.yaml
@@ -2537,3 +2537,129 @@ tests:
             name: python-packages
             emptyDir: {}
         template: statefulset-worker.yaml
+
+  - it: should set UV_DEFAULT_INDEX in StatefulSet worker when pypiRegistry.enabled and url is set without config file
+    set:
+      taskRunners:
+        mode: external
+      pypiRegistry:
+        enabled: true
+        url: "https://my.registry.com/simple/"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].env
+          content:
+            name: UV_DEFAULT_INDEX
+            value: "https://my.registry.com/simple/"
+          any: true
+        template: statefulset-worker.yaml
+
+  - it: should set UV_CONFIG_FILE in StatefulSet worker when pypiRegistry.enabled and customUvConfig is set
+    set:
+      taskRunners:
+        mode: external
+      pypiRegistry:
+        enabled: true
+        customUvConfig: "[index]\nurl = \"https://my.registry.com/simple/\""
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].env
+          content:
+            name: UV_CONFIG_FILE
+            value: "/home/node/.uv-config/uv.toml"
+          any: true
+        template: statefulset-worker.yaml
+
+  - it: should set UV_CONFIG_FILE in StatefulSet worker when pypiRegistry.enabled and secretName is set
+    set:
+      taskRunners:
+        mode: external
+      pypiRegistry:
+        enabled: true
+        secretName: "my-uv-secret"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].env
+          content:
+            name: UV_CONFIG_FILE
+            value: "/home/node/.uv-config/uv.toml"
+          any: true
+        template: statefulset-worker.yaml
+
+  - it: should mount uv-config volume in StatefulSet worker when pypiRegistry.enabled and customUvConfig is set
+    set:
+      taskRunners:
+        mode: external
+      pypiRegistry:
+        enabled: true
+        customUvConfig: "[index]\nurl = \"https://my.registry.com/simple/\""
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].volumeMounts
+          content:
+            name: uv-config
+            mountPath: /home/node/.uv-config
+            readOnly: true
+          any: true
+        template: statefulset-worker.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: uv-config
+            secret:
+              secretName: "n8n-pypi-registry-secret"
+              optional: true
+          any: true
+        template: statefulset-worker.yaml
+
+  - it: should use existing secret name for uv-config volume in StatefulSet worker when pypiRegistry.secretName is set
+    set:
+      taskRunners:
+        mode: external
+      pypiRegistry:
+        enabled: true
+        secretName: "my-existing-uv-secret"
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: uv-config
+            secret:
+              secretName: "my-existing-uv-secret"
+              optional: true
+          any: true
+        template: statefulset-worker.yaml
+
+  - it: should not add pypiRegistry env vars in StatefulSet worker when pypiRegistry is disabled
+    set:
+      taskRunners:
+        mode: external
+      pypiRegistry:
+        enabled: false
+        url: "https://my.registry.com/simple/"
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].env
+          content:
+            name: UV_DEFAULT_INDEX
+            value: "https://my.registry.com/simple/"
+          any: true
+        template: statefulset-worker.yaml
+
+  - it: should not add uv-config volume in StatefulSet worker when pypiRegistry is disabled
+    set:
+      taskRunners:
+        mode: external
+      pypiRegistry:
+        enabled: false
+        customUvConfig: "[index]\nurl = \"https://my.registry.com/simple/\""
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: uv-config
+            secret:
+              secretName: "n8n-pypi-registry-secret"
+              optional: true
+          any: true
+        template: statefulset-worker.yaml

--- a/charts/n8n/unittests/statefulset-worker_test.yaml
+++ b/charts/n8n/unittests/statefulset-worker_test.yaml
@@ -1348,6 +1348,30 @@ tests:
               name: n8n-task-runners-configmap
         template: statefulset-worker.yaml
 
+  - it: should add python arg to task runner container when taskRunners.python.enabled is true
+    set:
+      taskRunners:
+        mode: external
+        python:
+          enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].args
+          content: python
+        template: statefulset-worker.yaml
+
+  - it: should not add python arg when taskRunners.python.enabled is false
+    set:
+      taskRunners:
+        mode: external
+        python:
+          enabled: false
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].args
+          value: ["javascript"]
+        template: statefulset-worker.yaml
+
   - it: should set security context on task runner container when taskRunners.mode is external
     set:
       taskRunners:

--- a/charts/n8n/unittests/statefulset_test.yaml
+++ b/charts/n8n/unittests/statefulset_test.yaml
@@ -1312,6 +1312,34 @@ tests:
             name: n8n-task-runners
         template: statefulset.yaml
 
+  - it: should add python arg to task runner container when taskRunners.python.enabled is true
+    set:
+      taskRunners:
+        mode: external
+        python:
+          enabled: true
+      main:
+        forceToUseStatefulset: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].args
+          content: python
+        template: statefulset.yaml
+
+  - it: should not add python arg when taskRunners.python.enabled is false
+    set:
+      taskRunners:
+        mode: external
+        python:
+          enabled: false
+      main:
+        forceToUseStatefulset: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].args
+          value: ["javascript"]
+        template: statefulset.yaml
+
   - it: should set security context on task runner container when taskRunners.mode is external
     set:
       taskRunners:

--- a/charts/n8n/unittests/statefulset_test.yaml
+++ b/charts/n8n/unittests/statefulset_test.yaml
@@ -1270,6 +1270,18 @@ tests:
           value: runner-health
         template: statefulset.yaml
       - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].startupProbe.httpGet.path
+          value: /healthz
+        template: statefulset.yaml
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].startupProbe.httpGet.port
+          value: runner-health
+        template: statefulset.yaml
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].startupProbe.failureThreshold
+          value: 30
+        template: statefulset.yaml
+      - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].resources
           value:
             requests:
@@ -2243,4 +2255,32 @@ tests:
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].image
           value: n8nio/runners:2.0.0
+        template: statefulset.yaml
+
+  - it: should use uv install command when taskRunners.python.packages is set
+    set:
+      taskRunners:
+        mode: external
+        python:
+          enabled: true
+          packages:
+            - pandas
+            - numpy
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].command
+          value: ["/bin/sh", "-c", "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages pandas numpy && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript python"]
+        template: statefulset.yaml
+
+  - it: should use direct launcher command when taskRunners.python.packages is empty
+    set:
+      taskRunners:
+        mode: external
+        python:
+          enabled: true
+          packages: []
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].command
+          value: ["/usr/local/bin/task-runner-launcher"]
         template: statefulset.yaml

--- a/charts/n8n/unittests/statefulset_test.yaml
+++ b/charts/n8n/unittests/statefulset_test.yaml
@@ -2273,7 +2273,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].command
-          value: ["/bin/sh", "-c", "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages pandas numpy && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript python"]
+          value: ["/bin/sh", "-c", "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /home/node/.python-packages pandas numpy && export PYTHONPATH=/home/node/.python-packages && exec /usr/local/bin/task-runner-launcher javascript python"]
         template: statefulset.yaml
 
   - it: should use direct launcher command when nodes.python.external.packages is empty
@@ -2289,4 +2289,86 @@ tests:
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].command
           value: ["/usr/local/bin/task-runner-launcher"]
+        template: statefulset.yaml
+
+  - it: should mount python-packages volume in StatefulSet runner sidecar at /home/node/.python-packages
+    set:
+      taskRunners:
+        mode: external
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].volumeMounts
+          content:
+            name: python-packages
+            mountPath: /home/node/.python-packages
+        template: statefulset.yaml
+
+  - it: should add python-packages emptyDir in StatefulSet volumes when persistence is disabled
+    set:
+      taskRunners:
+        mode: external
+      nodes:
+        python:
+          persistence:
+            enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: python-packages
+            emptyDir: {}
+        template: statefulset.yaml
+
+  - it: should add python-packages to StatefulSet volumeClaimTemplates when persistence is enabled
+    set:
+      taskRunners:
+        mode: external
+      nodes:
+        python:
+          persistence:
+            enabled: true
+            accessMode: ReadWriteOnce
+            size: 2Gi
+    asserts:
+      - contains:
+          path: spec.volumeClaimTemplates
+          content:
+            metadata:
+              name: python-packages
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 2Gi
+        template: statefulset.yaml
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: python-packages
+            emptyDir: {}
+        template: statefulset.yaml
+
+  - it: should use existingClaim as regular volume in StatefulSet when existingClaim is set
+    set:
+      taskRunners:
+        mode: external
+      nodes:
+        python:
+          persistence:
+            enabled: true
+            existingClaim: my-existing-pvc
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: python-packages
+            persistentVolumeClaim:
+              claimName: my-existing-pvc
+        template: statefulset.yaml
+      - notContains:
+          path: spec.volumeClaimTemplates
+          content:
+            metadata:
+              name: python-packages
         template: statefulset.yaml

--- a/charts/n8n/unittests/statefulset_test.yaml
+++ b/charts/n8n/unittests/statefulset_test.yaml
@@ -1231,7 +1231,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].image
-          value: n8nio/n8n:1.0.0
+          value: n8nio/runners:1.0.0
         template: statefulset.yaml
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].imagePullPolicy
@@ -1293,6 +1293,23 @@ tests:
           content:
             configMapRef:
               name: n8n-task-runners-configmap
+        template: statefulset.yaml
+
+  - it: should not add task runner sidecar on main pod when worker.mode is queue
+    set:
+      taskRunners:
+        mode: external
+      worker:
+        mode: queue
+      db:
+        type: postgresdb
+      main:
+        forceToUseStatefulset: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers
+          content:
+            name: n8n-task-runners
         template: statefulset.yaml
 
   - it: should set security context on task runner container when taskRunners.mode is external

--- a/charts/n8n/unittests/statefulset_test.yaml
+++ b/charts/n8n/unittests/statefulset_test.yaml
@@ -1259,7 +1259,7 @@ tests:
         template: statefulset.yaml
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].livenessProbe.httpGet.port
-          value: http
+          value: runner-health
         template: statefulset.yaml
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].readinessProbe.httpGet.path
@@ -1267,7 +1267,7 @@ tests:
         template: statefulset.yaml
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].readinessProbe.httpGet.port
-          value: http
+          value: runner-health
         template: statefulset.yaml
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].resources

--- a/charts/n8n/unittests/statefulset_test.yaml
+++ b/charts/n8n/unittests/statefulset_test.yaml
@@ -2221,3 +2221,26 @@ tests:
               key: client.key
     asserts:
       - matchSnapshot: { }
+
+  - it: should set runner-health port name on task runner sidecar container
+    set:
+      taskRunners:
+        mode: external
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].ports[0].name
+          value: runner-health
+        template: statefulset.yaml
+
+  - it: should use explicit tag when taskRunners.external.image.tag is set
+    set:
+      taskRunners:
+        mode: external
+        external:
+          image:
+            tag: "2.0.0"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].image
+          value: n8nio/runners:2.0.0
+        template: statefulset.yaml

--- a/charts/n8n/unittests/statefulset_test.yaml
+++ b/charts/n8n/unittests/statefulset_test.yaml
@@ -2257,28 +2257,30 @@ tests:
           value: n8nio/runners:2.0.0
         template: statefulset.yaml
 
-  - it: should use uv install command when taskRunners.python.packages is set
+  - it: should use uv install command when taskRunners.python.external.packages is set
     set:
       taskRunners:
         mode: external
         python:
           enabled: true
-          packages:
-            - pandas
-            - numpy
+          external:
+            packages:
+              - pandas
+              - numpy
     asserts:
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].command
           value: ["/bin/sh", "-c", "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages pandas numpy && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript python"]
         template: statefulset.yaml
 
-  - it: should use direct launcher command when taskRunners.python.packages is empty
+  - it: should use direct launcher command when taskRunners.python.external.packages is empty
     set:
       taskRunners:
         mode: external
         python:
           enabled: true
-          packages: []
+          external:
+            packages: []
     asserts:
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].command

--- a/charts/n8n/unittests/statefulset_test.yaml
+++ b/charts/n8n/unittests/statefulset_test.yaml
@@ -2406,3 +2406,165 @@ tests:
             metadata:
               name: python-packages
         template: statefulset.yaml
+
+  - it: should set UV_DEFAULT_INDEX when pypiRegistry.enabled and url is set without config file
+    set:
+      taskRunners:
+        mode: external
+      main:
+        count: 2
+      pypiRegistry:
+        enabled: true
+        url: "https://my.registry.com/simple/"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].env
+          content:
+            name: UV_DEFAULT_INDEX
+            value: "https://my.registry.com/simple/"
+          any: true
+        template: statefulset.yaml
+
+  - it: should set UV_CONFIG_FILE when pypiRegistry.enabled and customUvConfig is set
+    set:
+      taskRunners:
+        mode: external
+      main:
+        count: 2
+      pypiRegistry:
+        enabled: true
+        customUvConfig: "[index]\nurl = \"https://my.registry.com/simple/\""
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].env
+          content:
+            name: UV_CONFIG_FILE
+            value: "/home/node/.uv-config/uv.toml"
+          any: true
+        template: statefulset.yaml
+
+  - it: should set UV_CONFIG_FILE when pypiRegistry.enabled and secretName is set
+    set:
+      taskRunners:
+        mode: external
+      main:
+        count: 2
+      pypiRegistry:
+        enabled: true
+        secretName: "my-uv-secret"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].env
+          content:
+            name: UV_CONFIG_FILE
+            value: "/home/node/.uv-config/uv.toml"
+          any: true
+        template: statefulset.yaml
+
+  - it: should mount uv-config volume when pypiRegistry.enabled and customUvConfig is set
+    set:
+      taskRunners:
+        mode: external
+      main:
+        count: 2
+      pypiRegistry:
+        enabled: true
+        customUvConfig: "[index]\nurl = \"https://my.registry.com/simple/\""
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].volumeMounts
+          content:
+            name: uv-config
+            mountPath: /home/node/.uv-config
+            readOnly: true
+          any: true
+        template: statefulset.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: uv-config
+            secret:
+              secretName: "n8n-pypi-registry-secret"
+              optional: true
+          any: true
+        template: statefulset.yaml
+
+  - it: should use existing secret name for uv-config volume when pypiRegistry.secretName is set
+    set:
+      taskRunners:
+        mode: external
+      main:
+        count: 2
+      pypiRegistry:
+        enabled: true
+        secretName: "my-existing-uv-secret"
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: uv-config
+            secret:
+              secretName: "my-existing-uv-secret"
+              optional: true
+          any: true
+        template: statefulset.yaml
+
+  - it: should not add pypiRegistry env vars when pypiRegistry is disabled
+    set:
+      taskRunners:
+        mode: external
+      main:
+        count: 2
+      pypiRegistry:
+        enabled: false
+        url: "https://my.registry.com/simple/"
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].env
+          content:
+            name: UV_DEFAULT_INDEX
+            value: "https://my.registry.com/simple/"
+          any: true
+        template: statefulset.yaml
+
+  - it: should not add uv-config volume when pypiRegistry is disabled
+    set:
+      taskRunners:
+        mode: external
+      main:
+        count: 2
+      pypiRegistry:
+        enabled: false
+        customUvConfig: "[index]\nurl = \"https://my.registry.com/simple/\""
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: uv-config
+            secret:
+              secretName: "n8n-pypi-registry-secret"
+              optional: true
+          any: true
+        template: statefulset.yaml
+
+  - it: should not add uv-config volume in main StatefulSet when worker.mode is queue
+    set:
+      taskRunners:
+        mode: external
+      worker:
+        mode: queue
+      main:
+        count: 2
+      pypiRegistry:
+        enabled: true
+        customUvConfig: "[index]\nurl = \"https://my.registry.com/simple/\""
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: uv-config
+            secret:
+              secretName: "n8n-pypi-registry-secret"
+              optional: true
+          any: true
+        template: statefulset.yaml

--- a/charts/n8n/unittests/statefulset_test.yaml
+++ b/charts/n8n/unittests/statefulset_test.yaml
@@ -2273,7 +2273,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[?(@.name == "n8n-task-runners")].command
-          value: ["/bin/sh", "-c", "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /home/node/.python-packages pandas numpy && export PYTHONPATH=/home/node/.python-packages && exec /usr/local/bin/task-runner-launcher javascript python"]
+          value: ["/bin/sh", "-c", "UV_CACHE_DIR=/tmp/.uv-cache UV_LINK_MODE=copy uv pip install --target /home/node/.python-packages pandas numpy && export PYTHONPATH=/home/node/.python-packages && exec /usr/local/bin/task-runner-launcher javascript python"]
         template: statefulset.yaml
 
   - it: should use direct launcher command when nodes.python.external.packages is empty

--- a/charts/n8n/unittests/statefulset_test.yaml
+++ b/charts/n8n/unittests/statefulset_test.yaml
@@ -1324,10 +1324,11 @@ tests:
             name: n8n-task-runners
         template: statefulset.yaml
 
-  - it: should add python arg to task runner container when taskRunners.python.enabled is true
+  - it: should add python arg to task runner container when nodes.python.enabled is true
     set:
       taskRunners:
         mode: external
+      nodes:
         python:
           enabled: true
       main:
@@ -1338,10 +1339,11 @@ tests:
           content: python
         template: statefulset.yaml
 
-  - it: should not add python arg when taskRunners.python.enabled is false
+  - it: should not add python arg when nodes.python.enabled is false
     set:
       taskRunners:
         mode: external
+      nodes:
         python:
           enabled: false
       main:
@@ -2257,10 +2259,11 @@ tests:
           value: n8nio/runners:2.0.0
         template: statefulset.yaml
 
-  - it: should use uv install command when taskRunners.python.external.packages is set
+  - it: should use uv install command when nodes.python.external.packages is set
     set:
       taskRunners:
         mode: external
+      nodes:
         python:
           enabled: true
           external:
@@ -2273,10 +2276,11 @@ tests:
           value: ["/bin/sh", "-c", "UV_CACHE_DIR=/tmp/.uv-cache uv pip install --target /tmp/.site-packages pandas numpy && export PYTHONPATH=/tmp/.site-packages && exec /usr/local/bin/task-runner-launcher javascript python"]
         template: statefulset.yaml
 
-  - it: should use direct launcher command when taskRunners.python.external.packages is empty
+  - it: should use direct launcher command when nodes.python.external.packages is empty
     set:
       taskRunners:
         mode: external
+      nodes:
         python:
           enabled: true
           external:

--- a/charts/n8n/unittests/statefulset_test.yaml
+++ b/charts/n8n/unittests/statefulset_test.yaml
@@ -2303,6 +2303,18 @@ tests:
             mountPath: /home/node/.python-packages
         template: statefulset.yaml
 
+  - it: should not add python-packages volume in StatefulSet when taskRunners.mode is internal
+    set:
+      taskRunners:
+        mode: internal
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: python-packages
+            emptyDir: {}
+        template: statefulset.yaml
+
   - it: should add python-packages emptyDir in StatefulSet volumes when persistence is disabled
     set:
       taskRunners:
@@ -2365,6 +2377,28 @@ tests:
             name: python-packages
             persistentVolumeClaim:
               claimName: my-existing-pvc
+        template: statefulset.yaml
+      - notContains:
+          path: spec.volumeClaimTemplates
+          content:
+            metadata:
+              name: python-packages
+        template: statefulset.yaml
+
+  - it: should not add python-packages volume in main StatefulSet when worker.mode is queue
+    set:
+      taskRunners:
+        mode: external
+      worker:
+        mode: queue
+      main:
+        count: 2
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: python-packages
+            emptyDir: {}
         template: statefulset.yaml
       - notContains:
           path: spec.volumeClaimTemplates

--- a/charts/n8n/values-kind.yaml
+++ b/charts/n8n/values-kind.yaml
@@ -47,8 +47,7 @@ postgresql:
     persistence:
       enabled: false
 
-taskRunners:
-  mode: external
+nodes:
   python:
     enabled: true
     builtin:
@@ -58,6 +57,9 @@ taskRunners:
       packages:
         - numpy
         - pandas
+
+taskRunners:
+  mode: external
   external:
     image:
       repository: n8nio/runners

--- a/charts/n8n/values-kind.yaml
+++ b/charts/n8n/values-kind.yaml
@@ -46,3 +46,21 @@ postgresql:
   primary:
     persistence:
       enabled: false
+
+taskRunners:
+  mode: external
+  python:
+    enabled: true
+    stdlibAllow: "*"
+  external:
+    image:
+      repository: n8nio/runners
+      pullPolicy: IfNotPresent
+      tag: ""
+    resources:
+      requests:
+        cpu: 100m
+        memory: 64Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi

--- a/charts/n8n/values-kind.yaml
+++ b/charts/n8n/values-kind.yaml
@@ -52,6 +52,10 @@ taskRunners:
   python:
     enabled: true
     stdlibAllow: "*"
+    externalAllow: "numpy,pandas"
+    packages:
+      - numpy
+      - pandas
   external:
     image:
       repository: n8nio/runners

--- a/charts/n8n/values-kind.yaml
+++ b/charts/n8n/values-kind.yaml
@@ -52,7 +52,6 @@ taskRunners:
   python:
     enabled: true
     stdlibAllow: "*"
-    externalAllow: "numpy,pandas"
     packages:
       - numpy
       - pandas

--- a/charts/n8n/values-kind.yaml
+++ b/charts/n8n/values-kind.yaml
@@ -51,10 +51,13 @@ taskRunners:
   mode: external
   python:
     enabled: true
-    stdlibAllow: "*"
-    packages:
-      - numpy
-      - pandas
+    builtin:
+      modules:
+        - "*"
+    external:
+      packages:
+        - numpy
+        - pandas
   external:
     image:
       repository: n8nio/runners

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -4375,9 +4375,19 @@
               "required": [],
               "title": "externalAllow",
               "type": "string"
+            },
+            "packages": {
+              "default": [],
+              "description": "Python packages to install via uv pip before starting the runner (e.g. [\"pandas\", \"numpy\"])",
+              "items": {
+                "type": "string"
+              },
+              "required": [],
+              "title": "packages",
+              "type": "array"
             }
           },
-          "required": ["enabled", "stdlibAllow", "externalAllow"],
+          "required": ["enabled", "stdlibAllow", "externalAllow", "packages"],
           "title": "python",
           "type": "object"
         }

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -1179,9 +1179,72 @@
           "required": ["image", "resources"],
           "title": "initContainer",
           "type": "object"
+        },
+        "python": {
+          "additionalProperties": false,
+          "description": "Python Code node configuration. Requires n8n 1.111.0+ and taskRunners.mode: external.",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "description": "Enable Python code execution via external task runners (requires n8n 1.111.0+)",
+              "required": [],
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "builtin": {
+              "additionalProperties": false,
+              "description": "Built-in Python module access for the Code node",
+              "properties": {
+                "modules": {
+                  "default": [],
+                  "description": "Python stdlib modules allowed in Code nodes. Use [\"*\"] to allow all.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": true,
+                  "minItems": 0,
+                  "required": [],
+                  "title": "modules",
+                  "type": "array"
+                }
+              },
+              "required": ["modules"],
+              "title": "builtin",
+              "type": "object"
+            },
+            "external": {
+              "additionalProperties": false,
+              "description": "External Python package access for the Code node",
+              "properties": {
+                "allowAll": {
+                  "default": false,
+                  "description": "Allow all external Python packages in Code nodes. When true, sets N8N_RUNNERS_EXTERNAL_ALLOW=* regardless of packages list.",
+                  "required": [],
+                  "title": "allowAll",
+                  "type": "boolean"
+                },
+                "packages": {
+                  "default": [],
+                  "description": "Python packages to install via uv pip before starting the runner (e.g. [\"pandas\", \"numpy\"]). Each listed package is also automatically allowed as an external package in Code nodes.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "required": [],
+                  "title": "packages",
+                  "type": "array"
+                }
+              },
+              "required": ["allowAll", "packages"],
+              "title": "external",
+              "type": "object"
+            }
+          },
+          "required": ["enabled", "builtin", "external"],
+          "title": "python",
+          "type": "object"
         }
       },
-      "required": ["initContainer"],
+      "required": ["initContainer", "python"],
       "title": "nodes",
       "type": "object"
     },
@@ -4350,72 +4413,9 @@
           "required": ["autoShutdownTimeout", "port", "nodeOptions", "image", "resources"],
           "title": "external",
           "type": "object"
-        },
-        "python": {
-          "additionalProperties": false,
-          "description": "Python runner configuration for external task runners",
-          "properties": {
-            "enabled": {
-              "default": false,
-              "description": "Enable Python code execution via external task runners (requires n8n 1.111.0+)",
-              "required": [],
-              "title": "enabled",
-              "type": "boolean"
-            },
-            "builtin": {
-              "additionalProperties": false,
-              "description": "Built-in Python module access for the Code node",
-              "properties": {
-                "modules": {
-                  "default": [],
-                  "description": "Python stdlib modules allowed in Code nodes. Use [\"*\"] to allow all.",
-                  "items": {
-                    "type": "string"
-                  },
-                  "uniqueItems": true,
-                  "minItems": 0,
-                  "required": [],
-                  "title": "modules",
-                  "type": "array"
-                }
-              },
-              "required": ["modules"],
-              "title": "builtin",
-              "type": "object"
-            },
-            "external": {
-              "additionalProperties": false,
-              "description": "External Python package access for the Code node",
-              "properties": {
-                "allowAll": {
-                  "default": false,
-                  "description": "Allow all external Python packages in Code nodes. When true, sets N8N_RUNNERS_EXTERNAL_ALLOW=* regardless of packages list.",
-                  "required": [],
-                  "title": "allowAll",
-                  "type": "boolean"
-                },
-                "packages": {
-                  "default": [],
-                  "description": "Python packages to install via uv pip before starting the runner (e.g. [\"pandas\", \"numpy\"]). Each listed package is also automatically allowed as an external package in Code nodes.",
-                  "items": {
-                    "type": "string"
-                  },
-                  "required": [],
-                  "title": "packages",
-                  "type": "array"
-                }
-              },
-              "required": ["allowAll", "packages"],
-              "title": "external",
-              "type": "object"
-            }
-          },
-          "required": ["enabled", "builtin", "external"],
-          "title": "python",
-          "type": "object"
         }
       },
-      "required": ["mode", "taskTimeout", "taskHeartbeatInterval", "maxConcurrency", "broker", "python"],
+      "required": ["mode", "taskTimeout", "taskHeartbeatInterval", "maxConcurrency", "broker"],
       "if": {
         "properties": {
           "mode": { "const": "external" }

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -4279,6 +4279,37 @@
                 "type": "string"
               }
             },
+            "image": {
+              "additionalProperties": false,
+              "description": "Container image for the external task runner sidecar",
+              "properties": {
+                "repository": {
+                  "default": "n8nio/runners",
+                  "description": "The repository for the external task runner image",
+                  "required": [],
+                  "title": "repository",
+                  "type": "string"
+                },
+                "pullPolicy": {
+                  "default": "IfNotPresent",
+                  "description": "The image pull policy for the external task runner",
+                  "required": [],
+                  "title": "pullPolicy",
+                  "type": "string",
+                  "enum": ["Always", "Never", "IfNotPresent"]
+                },
+                "tag": {
+                  "default": "",
+                  "description": "Override the image tag; defaults to chart appVersion",
+                  "required": [],
+                  "title": "tag",
+                  "type": "string"
+                }
+              },
+              "required": ["repository", "pullPolicy", "tag"],
+              "title": "image",
+              "type": "object"
+            },
             "resources": {
               "additionalProperties": false,
               "properties": {
@@ -4316,7 +4347,7 @@
               "type": "object"
             }
           },
-          "required": ["autoShutdownTimeout", "port", "nodeOptions", "resources"],
+          "required": ["autoShutdownTimeout", "port", "nodeOptions", "image", "resources"],
           "title": "external",
           "type": "object"
         }

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -1300,6 +1300,45 @@
       "title": "nodes",
       "type": "object"
     },
+    "pypiRegistry": {
+      "type": "object",
+      "title": "pypiRegistry",
+      "description": "Configuration for private Python package (PyPI) registry",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "enabled",
+          "description": "Enable private PyPI registry support for the runner sidecar",
+          "default": false
+        },
+        "url": {
+          "type": "string",
+          "title": "url",
+          "description": "URL of the private PyPI index. Sets UV_DEFAULT_INDEX when no config file is provided.",
+          "default": ""
+        },
+        "secretName": {
+          "type": "string",
+          "title": "secretName",
+          "description": "Name of an existing Kubernetes secret containing a uv.toml config file",
+          "default": ""
+        },
+        "secretKey": {
+          "type": "string",
+          "title": "secretKey",
+          "description": "Key within the secret that holds the uv.toml content",
+          "default": "uv.toml"
+        },
+        "customUvConfig": {
+          "type": "string",
+          "title": "customUvConfig",
+          "description": "Inline uv.toml content. When set and secretName is empty, the chart creates a Secret from this content.",
+          "default": ""
+        }
+      },
+      "required": ["enabled", "url", "secretName", "secretKey", "customUvConfig"]
+    },
     "npmRegistry": {
       "type": "object",
       "title": "npmRegistry",
@@ -5205,6 +5244,7 @@
     "service",
     "log",
     "nodes",
+    "pypiRegistry",
     "npmRegistry",
     "binaryData",
     "db",

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -4369,13 +4369,6 @@
               "title": "stdlibAllow",
               "type": "string"
             },
-            "externalAllow": {
-              "default": "",
-              "description": "Third-party Python modules allowed in Code nodes, comma-separated. Use * to allow all.",
-              "required": [],
-              "title": "externalAllow",
-              "type": "string"
-            },
             "packages": {
               "default": [],
               "description": "Python packages to install via uv pip before starting the runner (e.g. [\"pandas\", \"numpy\"])",
@@ -4387,7 +4380,7 @@
               "type": "array"
             }
           },
-          "required": ["enabled", "stdlibAllow", "externalAllow", "packages"],
+          "required": ["enabled", "stdlibAllow", "packages"],
           "title": "python",
           "type": "object"
         }

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -4350,9 +4350,39 @@
           "required": ["autoShutdownTimeout", "port", "nodeOptions", "image", "resources"],
           "title": "external",
           "type": "object"
+        },
+        "python": {
+          "additionalProperties": false,
+          "description": "Python runner configuration for external task runners",
+          "properties": {
+            "enabled": {
+              "default": false,
+              "description": "Enable Python code execution via external task runners (requires n8n 1.111.0+)",
+              "required": [],
+              "title": "enabled",
+              "type": "boolean"
+            },
+            "stdlibAllow": {
+              "default": "",
+              "description": "Python standard library modules allowed in Code nodes, comma-separated. Use * to allow all.",
+              "required": [],
+              "title": "stdlibAllow",
+              "type": "string"
+            },
+            "externalAllow": {
+              "default": "",
+              "description": "Third-party Python modules allowed in Code nodes, comma-separated. Use * to allow all.",
+              "required": [],
+              "title": "externalAllow",
+              "type": "string"
+            }
+          },
+          "required": ["enabled", "stdlibAllow", "externalAllow"],
+          "title": "python",
+          "type": "object"
         }
       },
-      "required": ["mode", "taskTimeout", "taskHeartbeatInterval", "maxConcurrency", "broker"],
+      "required": ["mode", "taskTimeout", "taskHeartbeatInterval", "maxConcurrency", "broker", "python"],
       "if": {
         "properties": {
           "mode": { "const": "external" }

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -4362,25 +4362,55 @@
               "title": "enabled",
               "type": "boolean"
             },
-            "stdlibAllow": {
-              "default": "",
-              "description": "Python standard library modules allowed in Code nodes, comma-separated. Use * to allow all.",
-              "required": [],
-              "title": "stdlibAllow",
-              "type": "string"
-            },
-            "packages": {
-              "default": [],
-              "description": "Python packages to install via uv pip before starting the runner (e.g. [\"pandas\", \"numpy\"])",
-              "items": {
-                "type": "string"
+            "builtin": {
+              "additionalProperties": false,
+              "description": "Built-in Python module access for the Code node",
+              "properties": {
+                "modules": {
+                  "default": [],
+                  "description": "Python stdlib modules allowed in Code nodes. Use [\"*\"] to allow all.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": true,
+                  "minItems": 0,
+                  "required": [],
+                  "title": "modules",
+                  "type": "array"
+                }
               },
-              "required": [],
-              "title": "packages",
-              "type": "array"
+              "required": ["modules"],
+              "title": "builtin",
+              "type": "object"
+            },
+            "external": {
+              "additionalProperties": false,
+              "description": "External Python package access for the Code node",
+              "properties": {
+                "allowAll": {
+                  "default": false,
+                  "description": "Allow all external Python packages in Code nodes. When true, sets N8N_RUNNERS_EXTERNAL_ALLOW=* regardless of packages list.",
+                  "required": [],
+                  "title": "allowAll",
+                  "type": "boolean"
+                },
+                "packages": {
+                  "default": [],
+                  "description": "Python packages to install via uv pip before starting the runner (e.g. [\"pandas\", \"numpy\"]). Each listed package is also automatically allowed as an external package in Code nodes.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "required": [],
+                  "title": "packages",
+                  "type": "array"
+                }
+              },
+              "required": ["allowAll", "packages"],
+              "title": "external",
+              "type": "object"
             }
           },
-          "required": ["enabled", "stdlibAllow", "packages"],
+          "required": ["enabled", "builtin", "external"],
           "title": "python",
           "type": "object"
         }

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -1237,9 +1237,61 @@
               "required": ["allowAll", "packages"],
               "title": "external",
               "type": "object"
+            },
+            "persistence": {
+              "additionalProperties": false,
+              "description": "Persistence for Python packages installed by uv. Optional PVC so packages survive pod restarts without re-downloading.",
+              "properties": {
+                "enabled": {
+                  "default": false,
+                  "description": "Enable persistence. When false, packages are installed into an emptyDir and lost on pod restart.",
+                  "required": [],
+                  "title": "enabled",
+                  "type": "boolean"
+                },
+                "existingClaim": {
+                  "default": "",
+                  "description": "Use an existing PVC instead of creating one. When set, no PVC is created by this chart.",
+                  "required": [],
+                  "title": "existingClaim",
+                  "type": "string"
+                },
+                "storageClass": {
+                  "default": "",
+                  "description": "Storage class for the PVC. Empty string uses the cluster default.",
+                  "required": [],
+                  "title": "storageClass",
+                  "type": "string"
+                },
+                "accessMode": {
+                  "default": "ReadWriteOnce",
+                  "description": "Access mode. Use ReadWriteMany when worker pods may be scheduled on different nodes.",
+                  "enum": ["ReadWriteOnce", "ReadWriteMany"],
+                  "required": [],
+                  "title": "accessMode",
+                  "type": "string"
+                },
+                "size": {
+                  "default": "1Gi",
+                  "description": "Size of the PVC.",
+                  "required": [],
+                  "title": "size",
+                  "type": "string"
+                },
+                "annotations": {
+                  "additionalProperties": true,
+                  "description": "Additional annotations for the PVC.",
+                  "required": [],
+                  "title": "annotations",
+                  "type": "object"
+                }
+              },
+              "required": ["enabled", "existingClaim", "storageClass", "accessMode", "size", "annotations"],
+              "title": "persistence",
+              "type": "object"
             }
           },
-          "required": ["enabled", "builtin", "external"],
+          "required": ["enabled", "builtin", "external", "persistence"],
           "title": "python",
           "type": "object"
         }

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -845,6 +845,8 @@ taskRunners:
     stdlibAllow: ""
     # -- Third-party Python modules allowed in Code nodes (comma-separated). Use * to allow all.
     externalAllow: ""
+    # -- Python packages to install via uv before starting the runner (e.g. ["pandas", "numpy"]).
+    packages: []
 
   # -- The address for the broker of the external task runner
   broker:

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -841,10 +841,19 @@ taskRunners:
   python:
     # -- Enable Python code execution in the Code node via external task runners.
     enabled: false
-    # -- Python standard library modules allowed in Code nodes (comma-separated). Use * to allow all.
-    stdlibAllow: ""
-    # -- Python packages to install via uv before starting the runner (e.g. ["pandas", "numpy"]). Each listed package is also automatically allowed as an external package in Code nodes.
-    packages: []
+    # -- Built-in Python module access for the Code node.
+    builtin:
+      # -- Python standard library modules allowed in Code nodes. Use ['*'] to allow all.
+      modules: []
+        # - "*"
+    # -- External Python package access for the Code node.
+    external:
+      # -- Allow all external Python packages in Code nodes. When true, sets N8N_RUNNERS_EXTERNAL_ALLOW=* regardless of packages list.
+      allowAll: false
+      # -- Python packages to install via uv before starting the runner (e.g. ["pandas", "numpy"]). Each listed package is also automatically allowed as an external package in Code nodes.
+      packages: []
+        # - pandas
+        # - numpy
 
   # -- The address for the broker of the external task runner
   broker:

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -154,6 +154,23 @@ nodes:
       # limits:
       #   cpu: 500m
       #   memory: 256Mi
+  # -- Python Code node configuration. Requires n8n 1.111.0+ and taskRunners.mode: external.
+  python:
+    # -- Enable Python code execution in the Code node via external task runners.
+    enabled: false
+    # -- Built-in Python module access for the Code node.
+    builtin:
+      # -- Python standard library modules allowed in Code nodes. Use ['*'] to allow all.
+      modules: []
+        # - "*"
+    # -- External Python package access for the Code node.
+    external:
+      # -- Allow all external Python packages in Code nodes. When true, sets N8N_RUNNERS_EXTERNAL_ALLOW=* regardless of packages list.
+      allowAll: false
+      # -- Python packages to install via uv before starting the runner (e.g. ["pandas", "numpy"]). Each listed package is also automatically allowed as an external package in Code nodes.
+      packages: []
+        # - pandas
+        # - numpy
 
 # -- Configuration for private npm registry
 npmRegistry:
@@ -836,24 +853,6 @@ taskRunners:
   taskHeartbeatInterval: 30
   # -- The maximum concurrency for the task
   maxConcurrency: 5
-
-  # -- Python runner configuration. Requires n8n 1.111.0+ and external task runner mode.
-  python:
-    # -- Enable Python code execution in the Code node via external task runners.
-    enabled: false
-    # -- Built-in Python module access for the Code node.
-    builtin:
-      # -- Python standard library modules allowed in Code nodes. Use ['*'] to allow all.
-      modules: []
-        # - "*"
-    # -- External Python package access for the Code node.
-    external:
-      # -- Allow all external Python packages in Code nodes. When true, sets N8N_RUNNERS_EXTERNAL_ALLOW=* regardless of packages list.
-      allowAll: false
-      # -- Python packages to install via uv before starting the runner (e.g. ["pandas", "numpy"]). Each listed package is also automatically allowed as an external package in Code nodes.
-      packages: []
-        # - pandas
-        # - numpy
 
   # -- The address for the broker of the external task runner
   broker:

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -859,6 +859,15 @@ taskRunners:
       - "--max-semi-space-size=16"
       - "--max-old-space-size=300"
 
+    # -- The image for the external task runner sidecar. Tag must match the n8n appVersion.
+    image:
+      # -- The repository for the external task runner image
+      repository: n8nio/runners
+      # -- This sets the pull policy for images.
+      pullPolicy: IfNotPresent
+      # -- Overrides the image tag whose default is the chart appVersion.
+      tag: ""
+
     # -- The resources for the external task runner
     resources:
       # -- The resources requests for the external task runner

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -843,9 +843,7 @@ taskRunners:
     enabled: false
     # -- Python standard library modules allowed in Code nodes (comma-separated). Use * to allow all.
     stdlibAllow: ""
-    # -- Third-party Python modules allowed in Code nodes (comma-separated). Use * to allow all.
-    externalAllow: ""
-    # -- Python packages to install via uv before starting the runner (e.g. ["pandas", "numpy"]).
+    # -- Python packages to install via uv before starting the runner (e.g. ["pandas", "numpy"]). Each listed package is also automatically allowed as an external package in Code nodes.
     packages: []
 
   # -- The address for the broker of the external task runner

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -186,6 +186,23 @@ nodes:
       # -- Additional annotations for the PVC.
       annotations: {}
 
+# -- Configuration for private Python package (PyPI) registry. Used by the runner sidecar when nodes.python.external.packages is set.
+pypiRegistry:
+  # -- Enable private PyPI registry support for the runner sidecar.
+  enabled: false
+  # -- URL of the private PyPI index (e.g. https://my.jfrog.io/artifactory/api/pypi/pypi/simple/).
+  # Used when no config file is provided; sets UV_DEFAULT_INDEX in the sidecar.
+  # For authenticated registries embed credentials inline or use customUvConfig/secretName instead.
+  url: ""
+  # -- Name of an existing Kubernetes secret whose data contains a uv.toml config file.
+  # When set, the file is mounted into the runner sidecar and UV_CONFIG_FILE is set.
+  secretName: ""
+  # -- Key within the secret that holds the uv.toml content.
+  secretKey: "uv.toml"
+  # -- Inline uv.toml content. When set and secretName is empty, the chart creates a Secret
+  # from this content (mirrors customNpmrc behaviour). Mutually exclusive with url.
+  customUvConfig: ""
+
 # -- Configuration for private npm registry
 npmRegistry:
   # -- Enable private npm registry

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -837,6 +837,15 @@ taskRunners:
   # -- The maximum concurrency for the task
   maxConcurrency: 5
 
+  # -- Python runner configuration. Requires n8n 1.111.0+ and external task runner mode.
+  python:
+    # -- Enable Python code execution in the Code node via external task runners.
+    enabled: false
+    # -- Python standard library modules allowed in Code nodes (comma-separated). Use * to allow all.
+    stdlibAllow: ""
+    # -- Third-party Python modules allowed in Code nodes (comma-separated). Use * to allow all.
+    externalAllow: ""
+
   # -- The address for the broker of the external task runner
   broker:
     # -- The address for the broker of the external task runner

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -171,6 +171,20 @@ nodes:
       packages: []
         # - pandas
         # - numpy
+    # -- Persistence for Python packages installed by uv. Optional PVC so packages survive pod restarts without re-downloading.
+    persistence:
+      # -- Enable persistence. When false, packages are installed into an emptyDir and lost on pod restart.
+      enabled: false
+      # -- Use an existing PVC instead of creating one. When set, no PVC is created by this chart.
+      existingClaim: ""
+      # -- Storage class for the PVC. Empty string uses the cluster default.
+      storageClass: ""
+      # -- Access mode. Use ReadWriteMany when worker pods may be scheduled on different nodes.
+      accessMode: ReadWriteOnce
+      # -- Size of the PVC.
+      size: 1Gi
+      # -- Additional annotations for the PVC.
+      annotations: {}
 
 # -- Configuration for private npm registry
 npmRegistry:


### PR DESCRIPTION
#### What this PR does / why we need it

This PR consolidates fixes for six open issues related to task runner configuration, adds full Python runner support with package installation and persistence, and adds private PyPI registry support.

---

**1. Remove deprecated `N8N_RUNNERS_ENABLED` env var** (closes #412, #436, #474)

Every pod was logging on startup:
```
N8N_RUNNERS_ENABLED -> Remove this environment variable; it is no longer needed.
```
Marked `SAFE_TO_REMOVE` upstream since n8n 1.69.0. Removed from `configmap.yaml`, `deployment-webhook.yaml`, and `deployment-mcp-webhook.yaml`.

**2. Use `n8nio/runners` image for the external task runner sidecar** (closes #329, #434)

The sidecar was using `n8nio/n8n` which does not contain `task-runner-launcher`, causing:
```
exec: "/usr/local/bin/task-runner-launcher": stat /usr/local/bin/task-runner-launcher: no such file or directory
```
Changed to `n8nio/runners`. A new `taskRunners.external.image` block is exposed so users can pin a tag (defaults to `Chart.AppVersion`).

**3. Skip runner sidecar on main pod when `worker.mode: queue`** (closes #414)

In queue mode (`OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS=true`) the main pod does not execute workflows and does not need a runner sidecar. Added guard to `deployment.yaml` and `statefulset.yaml`. Also fixed the orphaned `python-packages` volume that was rendered even when the sidecar was suppressed.

**4. Fix duplicate port name on runner sidecar**

The sidecar had a hardcoded `http` port name that collided with the main container's `service.name` port. Renamed to `runner-health` in all four templates.

**5. Python runner support** (requires n8n 1.111.0+)

New `nodes.python` block enables the Python Code node and its runner:

```yaml
nodes:
  python:
    enabled: true               # adds `python` arg to launcher, sets N8N_NATIVE_PYTHON_RUNNER
    builtin:
      modules: ["*"]            # N8N_RUNNERS_STDLIB_ALLOW / N8N_NODES_INCLUDE_SCRATCHPAD_IN_AI_CONTEXT (broker)
    external:
      packages:                 # install via uv pip install before runner starts
        - pandas
        - numpy
      allowAll: false           # N8N_RUNNERS_EXTERNAL_ALLOW (derived from packages automatically)
      reinstallMissingPackages: false

taskRunners:
  mode: external
```

`N8N_RUNNERS_STDLIB_ALLOW` and `N8N_RUNNERS_EXTERNAL_ALLOW` are set on the task-broker configmap (n8n enforces the security policy) rather than on the runner sidecar.

**6. Python package persistence**

```yaml
nodes:
  python:
    persistence:
      enabled: true
      size: 2Gi
      accessMode: ReadWriteOnce   # ReadWriteMany required for HPA / multi-node Deployment
```

Packages are stored at `/home/node/.python-packages`. When persistence is disabled an `emptyDir` is used and packages re-install on every restart. StatefulSet deployments receive per-pod PVCs via `volumeClaimTemplates`. The HPA is blocked when `ReadWriteOnce` persistence is enabled to prevent PVC mount failures.

**7. Private PyPI registry support** (mirrors `npmRegistry` pattern)

```yaml
# URL-only (unauthenticated / inline credentials):
pypiRegistry:
  enabled: true
  url: "https://my.jfrog.io/artifactory/api/pypi/pypi-virtual/simple/"

# Config-file (authenticated / multiple indexes):
pypiRegistry:
  enabled: true
  customUvConfig: |
    [[index]]
    name = "private"
    url = "https://my.jfrog.io/artifactory/api/pypi/pypi-virtual/simple/"
    default = true

# Reference an existing secret:
pypiRegistry:
  enabled: true
  secretName: "my-uv-config-secret"
  secretKey: "uv.toml"
```

URL-only sets `UV_DEFAULT_INDEX`; config-file mode mounts a `uv.toml` from a K8s Secret and sets `UV_CONFIG_FILE`.

**8. Fix uv cross-device link warning**

Added `UV_LINK_MODE=copy` to the `uv pip install` command so uv copies files rather than hardlinks when the cache (`/tmp/.uv-cache`, emptyDir) and target (`/home/node/.python-packages`, PVC/emptyDir) are on different volume mounts.

---

#### Which issues this PR fixes
- fixes #412
- fixes #436
- fixes #474
- fixes #329
- fixes #434
- fixes #414

#### Special notes for your reviewer

- `taskRunners.external.image.tag` defaults to `""` → resolves to `Chart.AppVersion`. Keep the runners image tag in sync with the n8n image tag.
- `nodes.python.enabled` defaults to `false` — no behavioral change for existing users.
- When `worker.autoscaling.enabled: true` you **must** use `nodes.python.persistence.accessMode: ReadWriteMany` (or leave persistence disabled); the HPA will not render otherwise.
- `pypiRegistry.url` and `pypiRegistry.customUvConfig`/`secretName` are mutually exclusive — when a config file is provided the index URL belongs inside the `uv.toml`.
- Snapshot tests regenerated with `--update-snapshot` to reflect removed `N8N_RUNNERS_ENABLED`, updated image reference, and renamed `runner-health` port.
- Verified on a local colima k8s cluster: all pods healthy (main 1/1, workers 2/2 with runner sidecar, webhook, postgresql, redis), no warnings.

#### Checklist
- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart version bumped
- [x] Chart `artifacthub.io/changes` field updated
- [x] Title of the PR starts with chart name (e.g. `[n8n]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated