### PR TITLE
[cloudflared] Update cloudflared chart to 2026.6.0

### DIFF
--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.8
+version: 2.2.9
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2026.5.2"
+appVersion: "2026.6.0"
 kubeVersion: ">=1.21.0-0"
 home: https://github.com/cloudflare/cloudflared
 maintainers:
@@ -53,13 +53,13 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update cloudflare/cloudflared image version to 2026.5.2
+      description: Update cloudflare/cloudflared image version to 2026.6.0
       links:
         - name: Upstream Project
           url: https://hub.docker.com/r/cloudflare/cloudflared
   artifacthub.io/images: |
     - name: cloudflared
-      image: cloudflare/cloudflared:2026.5.2
+      image: cloudflare/cloudflared:2026.6.0
       platforms:
         - linux/amd64
         - linux/arm64

--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -57,6 +57,8 @@ annotations:
       links:
         - name: Upstream Project
           url: https://hub.docker.com/r/cloudflare/cloudflared
+    - kind: added
+      description: Add configurable liveness and readiness probes
   artifacthub.io/images: |
     - name: cloudflared
       image: cloudflare/cloudflared:2026.6.0

--- a/charts/cloudflared/README.md
+++ b/charts/cloudflared/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for cloudflare tunnel
 
-![Version: 2.2.8](https://img.shields.io/badge/Version-2.2.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.5.2](https://img.shields.io/badge/AppVersion-2026.5.2-informational?style=flat-square)
+![Version: 2.2.9](https://img.shields.io/badge/Version-2.2.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.6.0](https://img.shields.io/badge/AppVersion-2026.6.0-informational?style=flat-square)
 
 ## Official Documentation
 

--- a/charts/cloudflared/README.md
+++ b/charts/cloudflared/README.md
@@ -163,11 +163,13 @@ helm upgrade [RELEASE_NAME] community-charts/cloudflared
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
 | ingress | list | `[{"hostname":"example.com","service":"http://traefik.kube-system.svc.cluster.local:80"},{"service":"http_status:404"}]` | Cloudflare ingress rules. More information can be found here: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/configure-tunnels/local-management/configuration-file/#how-traffic-is-matched |
+| livenessProbe | object | `{"failureThreshold":1,"httpGet":{"path":"/ready","port":2000},"initialDelaySeconds":10,"periodSeconds":10}` | This is for configuring the liveness probe. For more information checkout: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ |
 | nameOverride | string | `""` | This is to override the chart name. |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | For more information checkout: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | podAnnotations | object | `{}` | This is for setting Kubernetes Annotations to a Pod. For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
 | podLabels | object | `{}` | This is for setting Kubernetes Labels to a Pod. For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ |
 | podSecurityContext | object | `{"fsGroup":65532,"fsGroupChangePolicy":"OnRootMismatch","sysctls":[{"name":"net.ipv4.ping_group_range","value":"0 2147483647"}]}` | This is for setting Security Context to a Pod. For more information checkout: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
+| readinessProbe | object | `{"httpGet":{"path":"/ready","port":2000},"initialDelaySeconds":10,"periodSeconds":10}` | This is for configuring the readiness probe. For more information checkout: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ |
 | replica | object | `{"allNodes":true,"count":1}` | This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/ |
 | replica.allNodes | bool | `true` | This will use DaemonSet to deploy cloudflared to all nodes |
 | replica.count | int | `1` | If previous flag disabled, this will use Deployment to deploy cloudflared only number of following count |

--- a/charts/cloudflared/templates/deployment.yaml
+++ b/charts/cloudflared/templates/deployment.yaml
@@ -6,6 +6,8 @@ kind: Deployment
 {{- end }}
 metadata:
   name: {{ include "cloudflared.fullname" . }}
+  annotations:
+    ignore-check.kube-linter.io/unsafe-sysctls: "net.ipv4.ping_group_range is required for cloudflared ICMP tunneling support"
   labels:
     {{- include "cloudflared.labels" . | nindent 4 }}
 spec:
@@ -57,12 +59,9 @@ spec:
             - name: TUNNEL_ORIGIN_CERT
               value: {{ printf "/etc/cloudflared/creds/%s" (default "cert.pem" .Values.tunnelSecrets.existingPemFileSecret.key) | quote }}
           livenessProbe:
-            httpGet:
-              path: /ready
-              port: 2000
-            failureThreshold: 1
-            initialDelaySeconds: 10
-            periodSeconds: 10
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
           volumeMounts:
             - name: config
               mountPath: /etc/cloudflared/config

--- a/charts/cloudflared/unittests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/cloudflared/unittests/__snapshot__/deployment_test.yaml.snap
@@ -10,6 +10,8 @@ should match snapshot of default values:
     apiVersion: apps/v1
     kind: DaemonSet
     metadata:
+      annotations:
+        ignore-check.kube-linter.io/unsafe-sysctls: net.ipv4.ping_group_range is required for cloudflared ICMP tunneling support
       labels:
         app: cloudflared
         app.kubernetes.io/instance: cloudflared
@@ -56,6 +58,12 @@ should match snapshot of default values:
                 - containerPort: 2000
                   name: active-con-stat
                   protocol: TCP
+              readinessProbe:
+                httpGet:
+                  path: /ready
+                  port: 2000
+                initialDelaySeconds: 10
+                periodSeconds: 10
               resources: {}
               securityContext:
                 allowPrivilegeEscalation: false

--- a/charts/cloudflared/unittests/deployment_test.yaml
+++ b/charts/cloudflared/unittests/deployment_test.yaml
@@ -184,6 +184,47 @@ tests:
             value: /etc/cloudflared/creds/custom.pem
         template: deployment.yaml
 
+  - it: should use custom liveness probe when set
+    set:
+      tunnelConfig:
+        name: unittest
+      livenessProbe:
+        httpGet:
+          path: /ready
+          port: 2000
+        failureThreshold: 3
+        initialDelaySeconds: 5
+        periodSeconds: 5
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "cloudflared")].livenessProbe.failureThreshold
+          value: 3
+        template: deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "cloudflared")].livenessProbe.initialDelaySeconds
+          value: 5
+        template: deployment.yaml
+
+  - it: should use custom readiness probe when set
+    set:
+      tunnelConfig:
+        name: unittest
+      readinessProbe:
+        httpGet:
+          path: /ready
+          port: 2000
+        initialDelaySeconds: 15
+        periodSeconds: 20
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "cloudflared")].readinessProbe.initialDelaySeconds
+          value: 15
+        template: deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "cloudflared")].readinessProbe.periodSeconds
+          value: 20
+        template: deployment.yaml
+
   - it: should match snapshot of default values
     set:
       tunnelConfig:

--- a/charts/cloudflared/values.schema.json
+++ b/charts/cloudflared/values.schema.json
@@ -62,6 +62,312 @@
       "title": "imagePullSecrets",
       "type": "array"
     },
+    "livenessProbe": {
+      "additionalProperties": false,
+      "description": "This is for configuring the liveness probe. For more information checkout: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/",
+      "properties": {
+        "exec": {
+          "additionalProperties": false,
+          "description": "Exec specifies a command to execute in the container.",
+          "properties": {
+            "command": {
+              "description": "Command to execute inside the container.",
+              "items": { "type": "string" },
+              "minItems": 1,
+              "title": "command",
+              "type": "array"
+            }
+          },
+          "required": ["command"],
+          "title": "exec",
+          "type": "object"
+        },
+        "httpGet": {
+          "additionalProperties": false,
+          "description": "HTTPGet specifies an HTTP GET request to perform.",
+          "properties": {
+            "host": {
+              "default": "",
+              "description": "Hostname to connect to, defaults to the pod IP.",
+              "title": "host",
+              "type": "string"
+            },
+            "httpHeaders": {
+              "description": "Custom headers to set in the request.",
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "name": { "title": "name", "type": "string" },
+                  "value": { "title": "value", "type": "string" }
+                },
+                "required": ["name", "value"],
+                "type": "object"
+              },
+              "title": "httpHeaders",
+              "type": "array"
+            },
+            "path": {
+              "default": "/",
+              "description": "Path to access on the HTTP server.",
+              "title": "path",
+              "type": "string"
+            },
+            "port": {
+              "description": "Port number or name to access on the container.",
+              "title": "port",
+              "type": ["integer", "string"]
+            },
+            "scheme": {
+              "default": "HTTP",
+              "description": "Scheme to use for connecting to the host.",
+              "enum": ["HTTP", "HTTPS"],
+              "title": "scheme",
+              "type": "string"
+            }
+          },
+          "required": ["path", "port"],
+          "title": "httpGet",
+          "type": "object"
+        },
+        "tcpSocket": {
+          "additionalProperties": false,
+          "description": "TCPSocket specifies a TCP port to connect to.",
+          "properties": {
+            "host": {
+              "default": "",
+              "description": "Hostname to connect to, defaults to the pod IP.",
+              "title": "host",
+              "type": "string"
+            },
+            "port": {
+              "description": "Port number or name to access on the container.",
+              "title": "port",
+              "type": ["integer", "string"]
+            }
+          },
+          "required": ["port"],
+          "title": "tcpSocket",
+          "type": "object"
+        },
+        "grpc": {
+          "additionalProperties": false,
+          "description": "GRPC specifies a gRPC HealthCheckRequest.",
+          "properties": {
+            "port": {
+              "description": "Port number of the gRPC service.",
+              "title": "port",
+              "type": "integer"
+            },
+            "service": {
+              "default": "",
+              "description": "Service is the name of the service to place in the gRPC HealthCheckRequest.",
+              "title": "service",
+              "type": "string"
+            }
+          },
+          "required": ["port"],
+          "title": "grpc",
+          "type": "object"
+        },
+        "initialDelaySeconds": {
+          "default": 0,
+          "description": "Seconds after the container starts before probes are initiated.",
+          "minimum": 0,
+          "title": "initialDelaySeconds",
+          "type": "integer"
+        },
+        "periodSeconds": {
+          "default": 10,
+          "description": "How often (in seconds) to perform the probe.",
+          "minimum": 1,
+          "title": "periodSeconds",
+          "type": "integer"
+        },
+        "timeoutSeconds": {
+          "default": 1,
+          "description": "Seconds after which the probe times out.",
+          "minimum": 1,
+          "title": "timeoutSeconds",
+          "type": "integer"
+        },
+        "successThreshold": {
+          "default": 1,
+          "description": "Minimum consecutive successes for the probe to be considered successful after having failed.",
+          "minimum": 1,
+          "title": "successThreshold",
+          "type": "integer"
+        },
+        "failureThreshold": {
+          "default": 3,
+          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.",
+          "minimum": 1,
+          "title": "failureThreshold",
+          "type": "integer"
+        },
+        "terminationGracePeriodSeconds": {
+          "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.",
+          "minimum": 1,
+          "title": "terminationGracePeriodSeconds",
+          "type": "integer"
+        }
+      },
+      "required": [],
+      "title": "livenessProbe",
+      "type": "object"
+    },
+    "readinessProbe": {
+      "additionalProperties": false,
+      "description": "This is for configuring the readiness probe. For more information checkout: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/",
+      "properties": {
+        "exec": {
+          "additionalProperties": false,
+          "description": "Exec specifies a command to execute in the container.",
+          "properties": {
+            "command": {
+              "description": "Command to execute inside the container.",
+              "items": { "type": "string" },
+              "minItems": 1,
+              "title": "command",
+              "type": "array"
+            }
+          },
+          "required": ["command"],
+          "title": "exec",
+          "type": "object"
+        },
+        "httpGet": {
+          "additionalProperties": false,
+          "description": "HTTPGet specifies an HTTP GET request to perform.",
+          "properties": {
+            "host": {
+              "default": "",
+              "description": "Hostname to connect to, defaults to the pod IP.",
+              "title": "host",
+              "type": "string"
+            },
+            "httpHeaders": {
+              "description": "Custom headers to set in the request.",
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "name": { "title": "name", "type": "string" },
+                  "value": { "title": "value", "type": "string" }
+                },
+                "required": ["name", "value"],
+                "type": "object"
+              },
+              "title": "httpHeaders",
+              "type": "array"
+            },
+            "path": {
+              "default": "/",
+              "description": "Path to access on the HTTP server.",
+              "title": "path",
+              "type": "string"
+            },
+            "port": {
+              "description": "Port number or name to access on the container.",
+              "title": "port",
+              "type": ["integer", "string"]
+            },
+            "scheme": {
+              "default": "HTTP",
+              "description": "Scheme to use for connecting to the host.",
+              "enum": ["HTTP", "HTTPS"],
+              "title": "scheme",
+              "type": "string"
+            }
+          },
+          "required": ["path", "port"],
+          "title": "httpGet",
+          "type": "object"
+        },
+        "tcpSocket": {
+          "additionalProperties": false,
+          "description": "TCPSocket specifies a TCP port to connect to.",
+          "properties": {
+            "host": {
+              "default": "",
+              "description": "Hostname to connect to, defaults to the pod IP.",
+              "title": "host",
+              "type": "string"
+            },
+            "port": {
+              "description": "Port number or name to access on the container.",
+              "title": "port",
+              "type": ["integer", "string"]
+            }
+          },
+          "required": ["port"],
+          "title": "tcpSocket",
+          "type": "object"
+        },
+        "grpc": {
+          "additionalProperties": false,
+          "description": "GRPC specifies a gRPC HealthCheckRequest.",
+          "properties": {
+            "port": {
+              "description": "Port number of the gRPC service.",
+              "title": "port",
+              "type": "integer"
+            },
+            "service": {
+              "default": "",
+              "description": "Service is the name of the service to place in the gRPC HealthCheckRequest.",
+              "title": "service",
+              "type": "string"
+            }
+          },
+          "required": ["port"],
+          "title": "grpc",
+          "type": "object"
+        },
+        "initialDelaySeconds": {
+          "default": 0,
+          "description": "Seconds after the container starts before probes are initiated.",
+          "minimum": 0,
+          "title": "initialDelaySeconds",
+          "type": "integer"
+        },
+        "periodSeconds": {
+          "default": 10,
+          "description": "How often (in seconds) to perform the probe.",
+          "minimum": 1,
+          "title": "periodSeconds",
+          "type": "integer"
+        },
+        "timeoutSeconds": {
+          "default": 1,
+          "description": "Seconds after which the probe times out.",
+          "minimum": 1,
+          "title": "timeoutSeconds",
+          "type": "integer"
+        },
+        "successThreshold": {
+          "default": 1,
+          "description": "Minimum consecutive successes for the probe to be considered successful after having failed.",
+          "minimum": 1,
+          "title": "successThreshold",
+          "type": "integer"
+        },
+        "failureThreshold": {
+          "default": 3,
+          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.",
+          "minimum": 1,
+          "title": "failureThreshold",
+          "type": "integer"
+        },
+        "terminationGracePeriodSeconds": {
+          "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.",
+          "minimum": 1,
+          "title": "terminationGracePeriodSeconds",
+          "type": "integer"
+        }
+      },
+      "required": [],
+      "title": "readinessProbe",
+      "type": "object"
+    },
     "ingress": {
       "items": {
         "additionalProperties": false,
@@ -713,6 +1019,8 @@
     "securityContext",
     "tunnelSecrets",
     "tunnelConfig",
+    "livenessProbe",
+    "readinessProbe",
     "ingress",
     "resources",
     "nodeSelector",

--- a/charts/cloudflared/values.yaml
+++ b/charts/cloudflared/values.yaml
@@ -113,6 +113,23 @@ ingress:
 
   - service: http_status:404
 
+# -- This is for configuring the liveness probe. For more information checkout: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  httpGet:
+    path: /ready
+    port: 2000
+  failureThreshold: 1
+  initialDelaySeconds: 10
+  periodSeconds: 10
+
+# -- This is for configuring the readiness probe. For more information checkout: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: 2000
+  initialDelaySeconds: 10
+  periodSeconds: 10
+
 # -- This block is for setting up the resource management for the pod more information can be found here: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the cloudflared chart to use the latest image version 2026.6.0 from cloudflare/cloudflared. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated