### PR TITLE
[n8n] Fix npm cache, community packages persistence, and PVC condition bugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a community Helm chart repository hosting production-grade Kubernetes charts for: `actualbudget`, `cloudflared`, `drone`, `kserve`, `mlflow`, `n8n`, `outline`, and `pypiserver`. Charts are published to GitHub Pages via the `chart-releaser` action.
 
-## External Documentation
-
-### n8n
-
-When working on the `n8n` chart, use `https://docs.n8n.io/llms.txt` as the entry point for official n8n documentation. That file lists available documentation pages — fetch individual pages from it as needed for accurate, up-to-date details on configuration, environment variables, and features.
+Chart-specific guidance (architecture, external docs, non-obvious patterns) lives in `charts/<name>/CLAUDE.md`. Read that file when working on a specific chart.
 
 ## Common Commands
 

--- a/charts/n8n/.helmignore
+++ b/charts/n8n/.helmignore
@@ -24,3 +24,4 @@
 
 README.md.gotmpl
 values-kind.yaml
+CLAUDE.md

--- a/charts/n8n/CLAUDE.md
+++ b/charts/n8n/CLAUDE.md
@@ -1,0 +1,67 @@
+# n8n Chart — Claude Guidance
+
+## External Documentation
+
+Use `https://docs.n8n.io/llms.txt` as the entry point for official n8n documentation. That file lists all available pages — fetch individual pages from it for accurate, up-to-date details on configuration, environment variables, and features.
+
+## Chart Architecture
+
+### Operating Modes
+
+The chart has two orthogonal mode axes that interact heavily:
+
+**Task runner mode** (`taskRunners.mode`):
+- `internal` — task runner runs inside the main n8n process (default)
+- `external` — task runner runs as a sidecar container on the same pod. Exception: when `worker.mode: queue`, the main pod runs alone with no sidecar (the sidecar moves to worker pods instead).
+
+**Worker mode** (`worker.mode`):
+- `regular` — no separate worker pods; the main pod handles everything
+- `queue` — separate worker pods are deployed (requires `db.type: postgresdb` + Redis). Workers each run their own task runner sidecar when `taskRunners.mode: external`.
+
+### Pod Types
+
+| Scenario | Template rendered |
+|---|---|
+| `main.count == 1` or `ReadWriteMany` or persistence off | `deployment.yaml` |
+| `main.count > 1` + `ReadWriteOnce` + no `existingClaim` | `statefulset.yaml` (per-pod PVCs via `volumeClaimTemplates`) |
+| `worker.mode: queue` + single worker or `ReadWriteMany` | `deployment-worker.yaml` |
+| `worker.mode: queue` + multi-worker + `ReadWriteOnce` | `statefulset-worker.yaml` (per-pod PVCs) |
+
+### Community Node Packages (`nodes.external.packages`)
+
+Community packages are installed by an `npm-install` init container and need to be visible to the main n8n process at `/home/node/.n8n/nodes/node_modules/`.
+
+**Volume routing logic** (helpers `n8n.main.coversCommunityNodes` / `n8n.worker.coversCommunityNodes` in `_helpers.tpl`):
+
+- When `main.persistence.enabled: true` AND default `mountPath` (`/home/node/.n8n`) AND no `subPath`: the init container mounts the **main PVC** twice — at `/npmdata` (full root) and at `/nodesdata/nodes` with `subPath: nodes`. No separate `community-node-modules` volume is created. Packages persist automatically inside the main PVC.
+- Otherwise: a dedicated `community-node-modules` volume is used (emptyDir by default, or a PVC when `nodes.external.persistence.enabled: true`).
+- The same logic applies to worker pods using `worker.persistence`.
+
+The `nodes.external.persistence` PVC is only created when the `community-node-modules` volume will actually be used (i.e., when neither the main nor the relevant worker persistence covers the path).
+
+### npm Init Container
+
+- Uses `--ignore-scripts` to prevent `postinstall` hooks (e.g. `only-allow pnpm`) from crashing on a fresh emptyDir.
+- Sets `NPM_CONFIG_CACHE=/npmdata/.npm-cache` so the cache goes to a writable path, compatible with `readOnlyRootFilesystem: true`.
+- The main container sets `NPM_CONFIG_CACHE=/home/node/.cache/npm` for the same reason.
+
+### Python Packages (`nodes.python`)
+
+Python packages are only relevant when `taskRunners.mode: external`. The `python-packages` volume uses `nodes.python.persistence` (same PVC/emptyDir toggle pattern as community packages).
+
+## Key Values Interactions
+
+- `nodes.external.persistence` is only meaningful when `main.persistence` (and `worker.persistence` in queue mode) does **not** cover `/home/node/.n8n`. If main persistence is already enabled, community packages persist via the main PVC automatically.
+- `main.forceToUseStatefulset: true` forces StatefulSet regardless of replica count.
+- `worker.autoscaling.enabled: true` requires `ReadWriteMany` for any shared PVCs.
+
+## Template Helpers to Know
+
+| Helper | Purpose |
+|---|---|
+| `n8n.main.coversCommunityNodes` | True when main persistence covers `/home/node/.n8n/nodes` |
+| `n8n.worker.coversCommunityNodes` | True when worker persistence covers `/home/node/.n8n/nodes` |
+| `n8n-community.packages.fullname` | Community PVC name (respects `existingClaim`) |
+| `n8n-python.packages.fullname` | Python PVC name (respects `existingClaim`) |
+| `n8n.npmInstallScript` | Full npm install shell script for the init container |
+| `n8n.taskRunners.uvInstallCommand` | uv pip install command for the task runner sidecar |

--- a/charts/n8n/CLAUDE.md
+++ b/charts/n8n/CLAUDE.md
@@ -49,6 +49,37 @@ The `nodes.external.persistence` PVC is only created when the `community-node-mo
 
 Python packages are only relevant when `taskRunners.mode: external`. The `python-packages` volume uses `nodes.python.persistence` (same PVC/emptyDir toggle pattern as community packages).
 
+## PVC Lifecycle Rules
+
+Three non-obvious invariants govern how PVCs are created and must stay in sync across templates:
+
+### Worker PVC condition must mirror `deployment-worker.yaml`
+
+`pvc.yaml` creates the worker PVC only when `deployment-worker.yaml` renders AND persistence is needed. The condition **must** be kept in sync:
+
+```
+worker.persistence.enabled AND NOT existingClaim AND NOT forceToUseStatefulset
+  AND ( (count==1 AND NOT autoscaling) OR accessMode==ReadWriteMany )
+```
+
+If `deployment-worker.yaml`'s render gate ever changes, update `pvc.yaml` to match. Divergence means pods reference a PVC that doesn't exist.
+
+### `forceToUseStatefulset` guard in `pvc.yaml`
+
+Any PVC created in `pvc.yaml` **must** include `(not .Values.X.forceToUseStatefulset)`. When `forceToUseStatefulset: true`, the StatefulSet's `volumeClaimTemplates` creates per-pod PVCs — if `pvc.yaml` also creates one (same logical name, different physical name), the shared PVC is orphaned and wastes storage.
+
+### Community packages follow the python-packages pattern in StatefulSets
+
+In `statefulset.yaml` and `statefulset-worker.yaml`, the `community-node-modules` volume uses the **same three-way split** as `python-packages`:
+
+| Condition | Where the volume lives |
+|---|---|
+| `persistence.enabled: false` | `volumes:` as `emptyDir` |
+| `persistence.existingClaim` set | `volumes:` as `persistentVolumeClaim` |
+| `persistence.enabled: true` AND no `existingClaim` | `volumeClaimTemplates` (per-pod PVC) |
+
+This means `volumes:` never holds a dynamically-provisioned PVC in StatefulSet context. Keep these two templates identical in structure for community packages and python packages.
+
 ## Key Values Interactions
 
 - `nodes.external.persistence` is only meaningful when `main.persistence` (and `worker.persistence` in queue mode) does **not** cover `/home/node/.n8n`. If main persistence is already enabled, community packages persist via the main PVC automatically.

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.22.4
+version: 1.22.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -50,11 +50,11 @@ annotations:
       url: https://docs.n8n.io/
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
-    - kind: changed
-      description: Update n8nio/n8n image version to 2.26.6
+    - kind: fixed
+      description: Set NPM_CONFIG_CACHE env var in main container to allow community package installation with readOnlyRootFilesystem enabled
       links:
-        - name: Upstream Project
-          url: https://github.com/n8n-io/n8n
+        - name: GitHub Issue
+          url: https://github.com/community-charts/helm-charts/issues/508
   artifacthub.io/images: |
     - name: n8n
       image: n8nio/n8n:2.26.6

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -57,6 +57,10 @@ annotations:
           url: https://github.com/community-charts/helm-charts/issues/508
         - name: GitHub Issue
           url: https://github.com/community-charts/community-charts.github.io/issues/102
+    - kind: fixed
+      description: Fix community node packages not available to n8n process in external task runner mode and add --ignore-scripts to prevent postinstall script failures
+    - kind: added
+      description: Add optional PVC persistence for community node packages via nodes.external.persistence
   artifacthub.io/images: |
     - name: n8n
       image: n8nio/n8n:2.26.6

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -63,6 +63,10 @@ annotations:
       description: Add optional PVC persistence for community node packages via nodes.external.persistence
     - kind: fixed
       description: Route community package installs into the main/worker PVC when its mountPath already covers /home/node/.n8n/nodes, eliminating a redundant separate volume
+    - kind: fixed
+      description: Fix worker PVC not created when worker.count > 1 with ReadWriteMany access mode
+    - kind: fixed
+      description: Fix community packages sharing a ReadWriteOnce PVC across StatefulSet replicas when forceToUseStatefulset is true
   artifacthub.io/images: |
     - name: n8n
       image: n8nio/n8n:2.26.6

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -61,6 +61,8 @@ annotations:
       description: Fix community node packages not available to n8n process in external task runner mode and add --ignore-scripts to prevent postinstall script failures
     - kind: added
       description: Add optional PVC persistence for community node packages via nodes.external.persistence
+    - kind: fixed
+      description: Route community package installs into the main/worker PVC when its mountPath already covers /home/node/.n8n/nodes, eliminating a redundant separate volume
   artifacthub.io/images: |
     - name: n8n
       image: n8nio/n8n:2.26.6

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -55,6 +55,8 @@ annotations:
       links:
         - name: GitHub Issue
           url: https://github.com/community-charts/helm-charts/issues/508
+        - name: GitHub Issue
+          url: https://github.com/community-charts/community-charts.github.io/issues/102
   artifacthub.io/images: |
     - name: n8n
       image: n8nio/n8n:2.26.6

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.22.4](https://img.shields.io/badge/Version-1.22.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.26.6](https://img.shields.io/badge/AppVersion-2.26.6-informational?style=flat-square)
+![Version: 1.22.5](https://img.shields.io/badge/Version-1.22.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.26.6](https://img.shields.io/badge/AppVersion-2.26.6-informational?style=flat-square)
 
 ## Official Documentation
 

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -866,7 +866,11 @@ By setting `nodes.external.allowAll` to `true`, the chart bypasses the Node.js T
 
 #### Persist Community Node Packages
 
-Enable `nodes.external.persistence` to store pre-installed community packages on a PVC so they survive pod restarts. When enabled, the init container skips re-downloading packages that are already present on the volume.
+Community node packages are stored at `/home/node/.n8n/nodes` inside the container. The chart routes package storage automatically based on whether `main.persistence` (or `worker.persistence` for queue-mode workers) is already enabled:
+
+- **When `main.persistence.enabled: true`** (default `mountPath: /home/node/.n8n`): community packages are written directly into the main PVC's `nodes/` subdirectory by the init container. No separate PVC is created and `nodes.external.persistence` is ignored for the main pod. Packages persist as long as the main PVC exists.
+
+- **When `main.persistence.enabled: false`** (the default): enable `nodes.external.persistence` to store packages on a dedicated PVC. Without it, an `emptyDir` volume is used and packages are re-downloaded on every pod restart.
 
 ```yaml
 nodes:
@@ -880,11 +884,11 @@ nodes:
       accessMode: ReadWriteOnce  # use ReadWriteMany if workers span multiple nodes
 ```
 
-Packages are stored at `/home/node/.n8n/nodes` inside the container. When `persistence.enabled` is `false` (the default), an `emptyDir` volume is used and packages are re-downloaded on every pod restart.
+The same logic applies to queue-mode workers: when `worker.persistence.enabled: true`, the worker PVC stores community packages; otherwise the dedicated PVC (or emptyDir) is used.
 
-> **Note**: When running workers in queue mode (`worker.mode: queue`), the main n8n pod and worker pods each mount the same community packages PVC. Use `accessMode: ReadWriteMany` with a compatible storage class (NFS, CephFS, etc.) if those pods are scheduled on different nodes.
+> **Note**: When `worker.mode: queue` is set and workers do not have their own persistence, the community packages PVC is shared between the main pod and worker pods. Use `accessMode: ReadWriteMany` with a compatible storage class (NFS, CephFS, etc.) if those pods are scheduled on different nodes.
 
-> **Warning**: When `worker.autoscaling.enabled: true`, you **must** set `nodes.external.persistence.accessMode: ReadWriteMany` (or leave persistence disabled), because scaling workers across nodes with `ReadWriteOnce` will cause PVC mount failures.
+> **Warning**: When `worker.autoscaling.enabled: true`, you **must** either enable `worker.persistence` (which provides per-pod storage via StatefulSet), set `nodes.external.persistence.accessMode: ReadWriteMany`, or leave persistence disabled — scaling workers across nodes with a `ReadWriteOnce` shared PVC will cause mount failures.
 
 ### Using Private NPM Packages
 

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -864,6 +864,28 @@ nodes:
 
 By setting `nodes.external.allowAll` to `true`, the chart bypasses the Node.js Task Runner's limitations for scoped packages, ensuring smooth installation of all listed packages. You can include both scoped (e.g., `@stdlib/math`) and non-scoped packages in the `nodes.external.packages` list, with or without specific versions.
 
+#### Persist Community Node Packages
+
+Enable `nodes.external.persistence` to store pre-installed community packages on a PVC so they survive pod restarts. When enabled, the init container skips re-downloading packages that are already present on the volume.
+
+```yaml
+nodes:
+  external:
+    packages:
+      - "n8n-nodes-evolution-api"
+      - "n8n-nodes-chatwoot@0.1.40"
+    persistence:
+      enabled: true
+      size: 1Gi
+      accessMode: ReadWriteOnce  # use ReadWriteMany if workers span multiple nodes
+```
+
+Packages are stored at `/home/node/.n8n/nodes` inside the container. When `persistence.enabled` is `false` (the default), an `emptyDir` volume is used and packages are re-downloaded on every pod restart.
+
+> **Note**: When running workers in queue mode (`worker.mode: queue`), the main n8n pod and worker pods each mount the same community packages PVC. Use `accessMode: ReadWriteMany` with a compatible storage class (NFS, CephFS, etc.) if those pods are scheduled on different nodes.
+
+> **Warning**: When `worker.autoscaling.enabled: true`, you **must** set `nodes.external.persistence.accessMode: ReadWriteMany` (or leave persistence disabled), because scaling workers across nodes with `ReadWriteOnce` will cause PVC mount failures.
+
 ### Using Private NPM Packages
 
 For packages hosted in a private NPM registry, configure access by providing a valid `.npmrc` file. You can either reference an existing Kubernetes secret containing the `.npmrc` content or define custom `.npmrc` content directly in the chart values.
@@ -1422,13 +1444,20 @@ helm upgrade [RELEASE_NAME] community-charts/n8n
 | minio.users[0].secretKey | string | `"Change_Me"` | n8n user secret key |
 | nameOverride | string | `""` | This is to override the chart name. |
 | nodeSelector | object | `{}` | For more information checkout: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
-| nodes | object | `{"builtin":{"enabled":false,"modules":[]},"external":{"allowAll":false,"packages":[],"reinstallMissingPackages":false},"initContainer":{"image":{"pullPolicy":"IfNotPresent","repository":"node","tag":"20-alpine"},"resources":{}},"python":{"builtin":{"modules":[]},"enabled":false,"external":{"allowAll":false,"packages":[]},"persistence":{"accessMode":"ReadWriteOnce","annotations":{},"enabled":false,"existingClaim":"","size":"1Gi","storageClass":""}}}` | Node configurations for built-in and external npm packages |
+| nodes | object | `{"builtin":{"enabled":false,"modules":[]},"external":{"allowAll":false,"packages":[],"persistence":{"accessMode":"ReadWriteOnce","annotations":{},"enabled":false,"existingClaim":"","size":"1Gi","storageClass":""},"reinstallMissingPackages":false},"initContainer":{"image":{"pullPolicy":"IfNotPresent","repository":"node","tag":"20-alpine"},"resources":{}},"python":{"builtin":{"modules":[]},"enabled":false,"external":{"allowAll":false,"packages":[]},"persistence":{"accessMode":"ReadWriteOnce","annotations":{},"enabled":false,"existingClaim":"","size":"1Gi","storageClass":""}}}` | Node configurations for built-in and external npm packages |
 | nodes.builtin | object | `{"enabled":false,"modules":[]}` | Enable built-in node functions (e.g., HTTP Request, Code Node, etc.) |
 | nodes.builtin.enabled | bool | `false` | Enable built-in modules for the Code node |
 | nodes.builtin.modules | list | `[]` | List of built-in Node.js modules to allow in the Code node (e.g., crypto, fs). Use '*' to allow all. |
-| nodes.external | object | `{"allowAll":false,"packages":[],"reinstallMissingPackages":false}` | External npm packages to install and allow in the Code node |
+| nodes.external | object | `{"allowAll":false,"packages":[],"persistence":{"accessMode":"ReadWriteOnce","annotations":{},"enabled":false,"existingClaim":"","size":"1Gi","storageClass":""},"reinstallMissingPackages":false}` | External npm packages to install and allow in the Code node |
 | nodes.external.allowAll | bool | `false` | Allow all external npm packages |
 | nodes.external.packages | list | `[]` | List of npm package names and versions (e.g., "package-name@1.0.0") |
+| nodes.external.persistence | object | `{"accessMode":"ReadWriteOnce","annotations":{},"enabled":false,"existingClaim":"","size":"1Gi","storageClass":""}` | Persistence for community node packages installed by the init container. Optional PVC so packages survive pod restarts without re-downloading. |
+| nodes.external.persistence.accessMode | string | `"ReadWriteOnce"` | Access mode. Use ReadWriteMany when worker pods may be scheduled on different nodes. |
+| nodes.external.persistence.annotations | object | `{}` | Additional annotations for the PVC. |
+| nodes.external.persistence.enabled | bool | `false` | Enable persistence. When false, packages are installed into an emptyDir and lost on pod restart. |
+| nodes.external.persistence.existingClaim | string | `""` | Use an existing PVC instead of creating one. When set, no PVC is created by this chart. |
+| nodes.external.persistence.size | string | `"1Gi"` | Size of the PVC. |
+| nodes.external.persistence.storageClass | string | `""` | Storage class for the PVC. Empty string uses the cluster default. |
 | nodes.external.reinstallMissingPackages | bool | `false` | Whether to reinstall missing packages. For more information, see https://docs.n8n.io/integrations/community-nodes/troubleshooting/#error-missing-packages |
 | nodes.initContainer | object | `{"image":{"pullPolicy":"IfNotPresent","repository":"node","tag":"20-alpine"},"resources":{}}` | Image for the init container to install npm packages |
 | nodes.initContainer.image | object | `{"pullPolicy":"IfNotPresent","repository":"node","tag":"20-alpine"}` | Image for the init container to install npm packages |

--- a/charts/n8n/README.md.gotmpl
+++ b/charts/n8n/README.md.gotmpl
@@ -864,6 +864,28 @@ nodes:
 
 By setting `nodes.external.allowAll` to `true`, the chart bypasses the Node.js Task Runner's limitations for scoped packages, ensuring smooth installation of all listed packages. You can include both scoped (e.g., `@stdlib/math`) and non-scoped packages in the `nodes.external.packages` list, with or without specific versions.
 
+#### Persist Community Node Packages
+
+Enable `nodes.external.persistence` to store pre-installed community packages on a PVC so they survive pod restarts. When enabled, the init container skips re-downloading packages that are already present on the volume.
+
+```yaml
+nodes:
+  external:
+    packages:
+      - "n8n-nodes-evolution-api"
+      - "n8n-nodes-chatwoot@0.1.40"
+    persistence:
+      enabled: true
+      size: 1Gi
+      accessMode: ReadWriteOnce  # use ReadWriteMany if workers span multiple nodes
+```
+
+Packages are stored at `/home/node/.n8n/nodes` inside the container. When `persistence.enabled` is `false` (the default), an `emptyDir` volume is used and packages are re-downloaded on every pod restart.
+
+> **Note**: When running workers in queue mode (`worker.mode: queue`), the main n8n pod and worker pods each mount the same community packages PVC. Use `accessMode: ReadWriteMany` with a compatible storage class (NFS, CephFS, etc.) if those pods are scheduled on different nodes.
+
+> **Warning**: When `worker.autoscaling.enabled: true`, you **must** set `nodes.external.persistence.accessMode: ReadWriteMany` (or leave persistence disabled), because scaling workers across nodes with `ReadWriteOnce` will cause PVC mount failures.
+
 ### Using Private NPM Packages
 
 For packages hosted in a private NPM registry, configure access by providing a valid `.npmrc` file. You can either reference an existing Kubernetes secret containing the `.npmrc` content or define custom `.npmrc` content directly in the chart values.

--- a/charts/n8n/README.md.gotmpl
+++ b/charts/n8n/README.md.gotmpl
@@ -866,7 +866,11 @@ By setting `nodes.external.allowAll` to `true`, the chart bypasses the Node.js T
 
 #### Persist Community Node Packages
 
-Enable `nodes.external.persistence` to store pre-installed community packages on a PVC so they survive pod restarts. When enabled, the init container skips re-downloading packages that are already present on the volume.
+Community node packages are stored at `/home/node/.n8n/nodes` inside the container. The chart routes package storage automatically based on whether `main.persistence` (or `worker.persistence` for queue-mode workers) is already enabled:
+
+- **When `main.persistence.enabled: true`** (default `mountPath: /home/node/.n8n`): community packages are written directly into the main PVC's `nodes/` subdirectory by the init container. No separate PVC is created and `nodes.external.persistence` is ignored for the main pod. Packages persist as long as the main PVC exists.
+
+- **When `main.persistence.enabled: false`** (the default): enable `nodes.external.persistence` to store packages on a dedicated PVC. Without it, an `emptyDir` volume is used and packages are re-downloaded on every pod restart.
 
 ```yaml
 nodes:
@@ -880,11 +884,11 @@ nodes:
       accessMode: ReadWriteOnce  # use ReadWriteMany if workers span multiple nodes
 ```
 
-Packages are stored at `/home/node/.n8n/nodes` inside the container. When `persistence.enabled` is `false` (the default), an `emptyDir` volume is used and packages are re-downloaded on every pod restart.
+The same logic applies to queue-mode workers: when `worker.persistence.enabled: true`, the worker PVC stores community packages; otherwise the dedicated PVC (or emptyDir) is used.
 
-> **Note**: When running workers in queue mode (`worker.mode: queue`), the main n8n pod and worker pods each mount the same community packages PVC. Use `accessMode: ReadWriteMany` with a compatible storage class (NFS, CephFS, etc.) if those pods are scheduled on different nodes.
+> **Note**: When `worker.mode: queue` is set and workers do not have their own persistence, the community packages PVC is shared between the main pod and worker pods. Use `accessMode: ReadWriteMany` with a compatible storage class (NFS, CephFS, etc.) if those pods are scheduled on different nodes.
 
-> **Warning**: When `worker.autoscaling.enabled: true`, you **must** set `nodes.external.persistence.accessMode: ReadWriteMany` (or leave persistence disabled), because scaling workers across nodes with `ReadWriteOnce` will cause PVC mount failures.
+> **Warning**: When `worker.autoscaling.enabled: true`, you **must** either enable `worker.persistence` (which provides per-pod storage via StatefulSet), set `nodes.external.persistence.accessMode: ReadWriteMany`, or leave persistence disabled — scaling workers across nodes with a `ReadWriteOnce` shared PVC will cause mount failures.
 
 ### Using Private NPM Packages
 

--- a/charts/n8n/templates/_helpers.tpl
+++ b/charts/n8n/templates/_helpers.tpl
@@ -434,10 +434,10 @@ export NON_COMMUNITY_PACKAGES="{{ include "n8n.nonCommunityPackages" . }}"
 echo "$PACKAGES" | sha256sum > /npmdata/packages.hash.new
 if [ ! -f /npmdata/packages.hash ] || ! cmp /npmdata/packages.hash /npmdata/packages.hash.new; then
   if [ -n "$NON_COMMUNITY_PACKAGES" ]; then
-    npm install --loglevel {{ include "n8n.npmLogLevel" .Values.log.level }} --no-save $NON_COMMUNITY_PACKAGES --prefix /npmdata
+    npm install --loglevel {{ include "n8n.npmLogLevel" .Values.log.level }} --no-save --ignore-scripts $NON_COMMUNITY_PACKAGES --prefix /npmdata
   fi
   if [ -n "$COMMUNITY_PACKAGES" ]; then
-    npm install --loglevel {{ include "n8n.npmLogLevel" .Values.log.level }} --no-save $COMMUNITY_PACKAGES --prefix /nodesdata/nodes
+    npm install --loglevel {{ include "n8n.npmLogLevel" .Values.log.level }} --no-save --ignore-scripts $COMMUNITY_PACKAGES --prefix /nodesdata/nodes
   fi
   mv /npmdata/packages.hash.new /npmdata/packages.hash
 else

--- a/charts/n8n/templates/_helpers.tpl
+++ b/charts/n8n/templates/_helpers.tpl
@@ -418,6 +418,20 @@ n8n python packages PVC full name (respects existingClaim)
 {{- end -}}
 
 {{/*
+n8n community packages PVC name
+*/}}
+{{- define "n8n-community.packages.name" -}}
+{{- printf "%s-community-packages" (include "n8n.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
+n8n community packages PVC full name (respects existingClaim)
+*/}}
+{{- define "n8n-community.packages.fullname" -}}
+{{- default (include "n8n-community.packages.name" .) .Values.nodes.external.persistence.existingClaim -}}
+{{- end -}}
+
+{{/*
 n8n task runner uv install shell command string (unquoted)
 */}}
 {{- define "n8n.taskRunners.uvInstallCommand" -}}

--- a/charts/n8n/templates/_helpers.tpl
+++ b/charts/n8n/templates/_helpers.tpl
@@ -432,6 +432,27 @@ n8n community packages PVC full name (respects existingClaim)
 {{- end -}}
 
 {{/*
+Returns "true" when main.persistence already covers /home/node/.n8n/nodes,
+making a separate community-node-modules volume redundant.
+Only true when persistence is enabled, mountPath is the default, and no subPath
+is redirecting the mount to a subdirectory of the PVC.
+*/}}
+{{- define "n8n.main.coversCommunityNodes" -}}
+{{- if and .Values.main.persistence.enabled (not .Values.main.persistence.subPath) (eq .Values.main.persistence.mountPath "/home/node/.n8n") -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Same check as n8n.main.coversCommunityNodes but for the worker persistence volume.
+*/}}
+{{- define "n8n.worker.coversCommunityNodes" -}}
+{{- if and .Values.worker.persistence.enabled (not .Values.worker.persistence.subPath) (eq .Values.worker.persistence.mountPath "/home/node/.n8n") -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
 n8n task runner uv install shell command string (unquoted)
 */}}
 {{- define "n8n.taskRunners.uvInstallCommand" -}}

--- a/charts/n8n/templates/deployment-worker.yaml
+++ b/charts/n8n/templates/deployment-worker.yaml
@@ -119,9 +119,16 @@ spec:
             - name: {{ default "node-modules" .Values.worker.persistence.volumeName }}
               mountPath: "/npmdata"
               readOnly: false
+            {{- if eq (include "n8n.worker.coversCommunityNodes" .) "true" }}
+            - name: {{ default "node-modules" .Values.worker.persistence.volumeName }}
+              mountPath: "/nodesdata/nodes"
+              subPath: nodes
+              readOnly: false
+            {{- else }}
             - name: community-node-modules
               mountPath: "/nodesdata/nodes"
               readOnly: false
+            {{- end }}
           {{- with .Values.nodes.initContainer.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -293,7 +300,7 @@ spec:
               subPath: {{ .Values.worker.persistence.subPath }}
               {{- end }}
               readOnly: false
-          {{- if .Values.nodes.external.packages }}
+          {{- if and .Values.nodes.external.packages (not (eq (include "n8n.worker.coversCommunityNodes" .) "true")) }}
             - name: community-node-modules
               mountPath: "/home/node/.n8n/nodes"
               readOnly: false
@@ -410,7 +417,7 @@ spec:
               subPath: {{ .Values.worker.persistence.subPath }}
               {{- end }}
               readOnly: false
-          {{- if .Values.nodes.external.packages }}
+          {{- if and .Values.nodes.external.packages (not (eq (include "n8n.worker.coversCommunityNodes" .) "true")) }}
             - name: community-node-modules
               mountPath: "/home/node/.n8n/nodes"
               readOnly: false
@@ -441,7 +448,7 @@ spec:
         - name: {{ default "node-modules" .Values.worker.persistence.volumeName }}
           emptyDir: {}
       {{- end }}
-      {{- if .Values.nodes.external.packages }}
+      {{- if and .Values.nodes.external.packages (not (eq (include "n8n.worker.coversCommunityNodes" .) "true")) }}
         - name: community-node-modules
           {{- if .Values.nodes.external.persistence.enabled }}
           persistentVolumeClaim:

--- a/charts/n8n/templates/deployment-worker.yaml
+++ b/charts/n8n/templates/deployment-worker.yaml
@@ -443,7 +443,12 @@ spec:
       {{- end }}
       {{- if .Values.nodes.external.packages }}
         - name: community-node-modules
+          {{- if .Values.nodes.external.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "n8n-community.packages.fullname" . }}
+          {{- else }}
           emptyDir: {}
+          {{- end }}
       {{- end }}
       {{- if and (eq .Values.taskRunners.mode "external") .Values.pypiRegistry.enabled (or .Values.pypiRegistry.secretName .Values.pypiRegistry.customUvConfig) }}
         - name: uv-config

--- a/charts/n8n/templates/deployment-worker.yaml
+++ b/charts/n8n/templates/deployment-worker.yaml
@@ -293,7 +293,7 @@ spec:
               subPath: {{ .Values.worker.persistence.subPath }}
               {{- end }}
               readOnly: false
-          {{- if and .Values.nodes.external.packages (eq .Values.taskRunners.mode "internal") }}
+          {{- if .Values.nodes.external.packages }}
             - name: community-node-modules
               mountPath: "/home/node/.n8n/nodes"
               readOnly: false

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -425,7 +425,12 @@ spec:
       {{- end }}
       {{- if .Values.nodes.external.packages }}
         - name: community-node-modules
+          {{- if .Values.nodes.external.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "n8n-community.packages.fullname" . }}
+          {{- else }}
           emptyDir: {}
+          {{- end }}
       {{- end }}
       {{- if and (eq .Values.taskRunners.mode "external") (ne .Values.worker.mode "queue") .Values.pypiRegistry.enabled (or .Values.pypiRegistry.secretName .Values.pypiRegistry.customUvConfig) }}
         - name: uv-config

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -275,7 +275,7 @@ spec:
               subPath: {{ .Values.main.persistence.subPath }}
               {{- end }}
               readOnly: false
-          {{- if and .Values.nodes.external.packages (eq .Values.taskRunners.mode "internal") }}
+          {{- if .Values.nodes.external.packages }}
             - name: community-node-modules
               mountPath: "/home/node/.n8n/nodes"
               readOnly: false

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -133,6 +133,8 @@ spec:
               value: {{ .Values.timezone | quote }}
             - name: N8N_GRACEFUL_SHUTDOWN_TIMEOUT
               value: {{ .Values.gracefulShutdownTimeout | quote }}
+            - name: NPM_CONFIG_CACHE
+              value: /home/node/.cache/npm
           {{- if .Values.main.editorBaseUrl }}
             - name: N8N_EDITOR_BASE_URL
               value: {{ .Values.main.editorBaseUrl | quote }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -81,9 +81,16 @@ spec:
             - name: {{ default "node-modules" .Values.main.persistence.volumeName }}
               mountPath: "/npmdata"
               readOnly: false
+            {{- if eq (include "n8n.main.coversCommunityNodes" .) "true" }}
+            - name: {{ default "node-modules" .Values.main.persistence.volumeName }}
+              mountPath: "/nodesdata/nodes"
+              subPath: nodes
+              readOnly: false
+            {{- else }}
             - name: community-node-modules
               mountPath: "/nodesdata/nodes"
               readOnly: false
+            {{- end }}
           {{- with .Values.nodes.initContainer.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -275,7 +282,7 @@ spec:
               subPath: {{ .Values.main.persistence.subPath }}
               {{- end }}
               readOnly: false
-          {{- if .Values.nodes.external.packages }}
+          {{- if and .Values.nodes.external.packages (not (eq (include "n8n.main.coversCommunityNodes" .) "true")) }}
             - name: community-node-modules
               mountPath: "/home/node/.n8n/nodes"
               readOnly: false
@@ -392,7 +399,7 @@ spec:
               subPath: {{ .Values.main.persistence.subPath }}
               {{- end }}
               readOnly: false
-          {{- if .Values.nodes.external.packages }}
+          {{- if and .Values.nodes.external.packages (not (eq (include "n8n.main.coversCommunityNodes" .) "true")) }}
             - name: community-node-modules
               mountPath: "/home/node/.n8n/nodes"
               readOnly: false
@@ -423,7 +430,7 @@ spec:
         - name: {{ default "node-modules" .Values.main.persistence.volumeName }}
           emptyDir: {}
       {{- end }}
-      {{- if .Values.nodes.external.packages }}
+      {{- if and .Values.nodes.external.packages (not (eq (include "n8n.main.coversCommunityNodes" .) "true")) }}
         - name: community-node-modules
           {{- if .Values.nodes.external.persistence.enabled }}
           persistentVolumeClaim:

--- a/charts/n8n/templates/pvc.yaml
+++ b/charts/n8n/templates/pvc.yaml
@@ -56,6 +56,30 @@ spec:
     {{- end }}
   {{- end }}
 {{- end }}
+{{- if and .Values.nodes.external.persistence.enabled (not .Values.nodes.external.persistence.existingClaim) .Values.nodes.external.packages }}
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "n8n-community.packages.fullname" . }}
+  {{- with .Values.nodes.external.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.nodes.external.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.nodes.external.persistence.size }}
+  {{- if .Values.nodes.external.persistence.storageClass }}
+    {{- if (eq "-" .Values.nodes.external.persistence.storageClass) }}
+  storageClassName: ""
+    {{- else }}
+  storageClassName: {{ .Values.nodes.external.persistence.storageClass | quote }}
+    {{- end }}
+  {{- end }}
+{{- end }}
 {{- if and .Values.nodes.python.persistence.enabled (not .Values.nodes.python.persistence.existingClaim) (eq .Values.taskRunners.mode "external") }}
 ---
 kind: PersistentVolumeClaim

--- a/charts/n8n/templates/pvc.yaml
+++ b/charts/n8n/templates/pvc.yaml
@@ -56,7 +56,10 @@ spec:
     {{- end }}
   {{- end }}
 {{- end }}
-{{- if and .Values.nodes.external.persistence.enabled (not .Values.nodes.external.persistence.existingClaim) .Values.nodes.external.packages }}
+{{- $mainCoversNodes := eq (include "n8n.main.coversCommunityNodes" .) "true" }}
+{{- $workerCoversNodes := eq (include "n8n.worker.coversCommunityNodes" .) "true" }}
+{{- $pvcNeeded := or (not $mainCoversNodes) (and (eq .Values.worker.mode "queue") (not $workerCoversNodes)) }}
+{{- if and .Values.nodes.external.persistence.enabled (not .Values.nodes.external.persistence.existingClaim) .Values.nodes.external.packages $pvcNeeded }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/charts/n8n/templates/pvc.yaml
+++ b/charts/n8n/templates/pvc.yaml
@@ -27,7 +27,7 @@ spec:
     {{- end }}
   {{- end }}
 {{- end }}
-{{- if and .Values.worker.persistence.enabled (not .Values.worker.persistence.existingClaim) (eq (int .Values.worker.count) 1) }}
+{{- if and .Values.worker.persistence.enabled (not .Values.worker.persistence.existingClaim) (not .Values.worker.forceToUseStatefulset) (or (and (eq (int .Values.worker.count) 1) (not .Values.worker.autoscaling.enabled)) (eq .Values.worker.persistence.accessMode "ReadWriteMany")) }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -58,7 +58,7 @@ spec:
 {{- end }}
 {{- $mainCoversNodes := eq (include "n8n.main.coversCommunityNodes" .) "true" }}
 {{- $workerCoversNodes := eq (include "n8n.worker.coversCommunityNodes" .) "true" }}
-{{- $pvcNeeded := or (not $mainCoversNodes) (and (eq .Values.worker.mode "queue") (not $workerCoversNodes)) }}
+{{- $pvcNeeded := or (and (not $mainCoversNodes) (not .Values.main.forceToUseStatefulset)) (and (eq .Values.worker.mode "queue") (not $workerCoversNodes) (not .Values.worker.forceToUseStatefulset)) }}
 {{- if and .Values.nodes.external.persistence.enabled (not .Values.nodes.external.persistence.existingClaim) .Values.nodes.external.packages $pvcNeeded }}
 ---
 kind: PersistentVolumeClaim

--- a/charts/n8n/templates/statefulset-worker.yaml
+++ b/charts/n8n/templates/statefulset-worker.yaml
@@ -426,13 +426,14 @@ spec:
         {{- end }}
       {{- end }}
       {{- if and .Values.nodes.external.packages (not (eq (include "n8n.worker.coversCommunityNodes" .) "true")) }}
+        {{- if not .Values.nodes.external.persistence.enabled }}
         - name: community-node-modules
-          {{- if .Values.nodes.external.persistence.enabled }}
+          emptyDir: {}
+        {{- else if .Values.nodes.external.persistence.existingClaim }}
+        - name: community-node-modules
           persistentVolumeClaim:
             claimName: {{ include "n8n-community.packages.fullname" . }}
-          {{- else }}
-          emptyDir: {}
-          {{- end }}
+        {{- end }}
       {{- end }}
       {{- if and (eq .Values.taskRunners.mode "external") .Values.pypiRegistry.enabled (or .Values.pypiRegistry.secretName .Values.pypiRegistry.customUvConfig) }}
         - name: uv-config
@@ -522,6 +523,23 @@ spec:
         storageClassName: ""
           {{- else }}
         storageClassName: {{ .Values.nodes.python.persistence.storageClass | quote }}
+          {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- if and .Values.nodes.external.packages (not (eq (include "n8n.worker.coversCommunityNodes" .) "true")) .Values.nodes.external.persistence.enabled (not .Values.nodes.external.persistence.existingClaim) }}
+    - metadata:
+        name: community-node-modules
+      spec:
+        accessModes:
+          - {{ .Values.nodes.external.persistence.accessMode }}
+        resources:
+          requests:
+            storage: {{ .Values.nodes.external.persistence.size }}
+        {{- if .Values.nodes.external.persistence.storageClass }}
+          {{- if (eq "-" .Values.nodes.external.persistence.storageClass) }}
+        storageClassName: ""
+          {{- else }}
+        storageClassName: {{ .Values.nodes.external.persistence.storageClass | quote }}
           {{- end }}
         {{- end }}
     {{- end }}

--- a/charts/n8n/templates/statefulset-worker.yaml
+++ b/charts/n8n/templates/statefulset-worker.yaml
@@ -103,9 +103,16 @@ spec:
             - name: {{ default "node-modules" .Values.worker.persistence.volumeName }}
               mountPath: "/npmdata"
               readOnly: false
+            {{- if eq (include "n8n.worker.coversCommunityNodes" .) "true" }}
+            - name: {{ default "node-modules" .Values.worker.persistence.volumeName }}
+              mountPath: "/nodesdata/nodes"
+              subPath: nodes
+              readOnly: false
+            {{- else }}
             - name: community-node-modules
               mountPath: "/nodesdata/nodes"
               readOnly: false
+            {{- end }}
           {{- with .Values.nodes.initContainer.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -277,7 +284,7 @@ spec:
               subPath: {{ .Values.worker.persistence.subPath }}
               {{- end }}
               readOnly: false
-          {{- if .Values.nodes.external.packages }}
+          {{- if and .Values.nodes.external.packages (not (eq (include "n8n.worker.coversCommunityNodes" .) "true")) }}
             - name: community-node-modules
               mountPath: "/home/node/.n8n/nodes"
               readOnly: false
@@ -394,7 +401,7 @@ spec:
               subPath: {{ .Values.worker.persistence.subPath }}
               {{- end }}
               readOnly: false
-          {{- if .Values.nodes.external.packages }}
+          {{- if and .Values.nodes.external.packages (not (eq (include "n8n.worker.coversCommunityNodes" .) "true")) }}
             - name: community-node-modules
               mountPath: "/home/node/.n8n/nodes"
               readOnly: false
@@ -418,7 +425,7 @@ spec:
             claimName: {{ include "n8n-python.packages.fullname" . }}
         {{- end }}
       {{- end }}
-      {{- if .Values.nodes.external.packages }}
+      {{- if and .Values.nodes.external.packages (not (eq (include "n8n.worker.coversCommunityNodes" .) "true")) }}
         - name: community-node-modules
           {{- if .Values.nodes.external.persistence.enabled }}
           persistentVolumeClaim:

--- a/charts/n8n/templates/statefulset-worker.yaml
+++ b/charts/n8n/templates/statefulset-worker.yaml
@@ -420,7 +420,12 @@ spec:
       {{- end }}
       {{- if .Values.nodes.external.packages }}
         - name: community-node-modules
+          {{- if .Values.nodes.external.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "n8n-community.packages.fullname" . }}
+          {{- else }}
           emptyDir: {}
+          {{- end }}
       {{- end }}
       {{- if and (eq .Values.taskRunners.mode "external") .Values.pypiRegistry.enabled (or .Values.pypiRegistry.secretName .Values.pypiRegistry.customUvConfig) }}
         - name: uv-config

--- a/charts/n8n/templates/statefulset-worker.yaml
+++ b/charts/n8n/templates/statefulset-worker.yaml
@@ -277,7 +277,7 @@ spec:
               subPath: {{ .Values.worker.persistence.subPath }}
               {{- end }}
               readOnly: false
-          {{- if and .Values.nodes.external.packages (eq .Values.taskRunners.mode "internal") }}
+          {{- if .Values.nodes.external.packages }}
             - name: community-node-modules
               mountPath: "/home/node/.n8n/nodes"
               readOnly: false

--- a/charts/n8n/templates/statefulset.yaml
+++ b/charts/n8n/templates/statefulset.yaml
@@ -263,7 +263,7 @@ spec:
               subPath: {{ .Values.main.persistence.subPath }}
               {{- end }}
               readOnly: false
-          {{- if and .Values.nodes.external.packages (eq .Values.taskRunners.mode "internal") }}
+          {{- if .Values.nodes.external.packages }}
             - name: community-node-modules
               mountPath: "/home/node/.n8n/nodes"
               readOnly: false

--- a/charts/n8n/templates/statefulset.yaml
+++ b/charts/n8n/templates/statefulset.yaml
@@ -406,7 +406,12 @@ spec:
       {{- end }}
       {{- if .Values.nodes.external.packages }}
         - name: community-node-modules
+          {{- if .Values.nodes.external.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "n8n-community.packages.fullname" . }}
+          {{- else }}
           emptyDir: {}
+          {{- end }}
       {{- end }}
       {{- if and (eq .Values.taskRunners.mode "external") (ne .Values.worker.mode "queue") .Values.pypiRegistry.enabled (or .Values.pypiRegistry.secretName .Values.pypiRegistry.customUvConfig) }}
         - name: uv-config

--- a/charts/n8n/templates/statefulset.yaml
+++ b/charts/n8n/templates/statefulset.yaml
@@ -412,13 +412,14 @@ spec:
         {{- end }}
       {{- end }}
       {{- if and .Values.nodes.external.packages (not (eq (include "n8n.main.coversCommunityNodes" .) "true")) }}
+        {{- if not .Values.nodes.external.persistence.enabled }}
         - name: community-node-modules
-          {{- if .Values.nodes.external.persistence.enabled }}
+          emptyDir: {}
+        {{- else if .Values.nodes.external.persistence.existingClaim }}
+        - name: community-node-modules
           persistentVolumeClaim:
             claimName: {{ include "n8n-community.packages.fullname" . }}
-          {{- else }}
-          emptyDir: {}
-          {{- end }}
+        {{- end }}
       {{- end }}
       {{- if and (eq .Values.taskRunners.mode "external") (ne .Values.worker.mode "queue") .Values.pypiRegistry.enabled (or .Values.pypiRegistry.secretName .Values.pypiRegistry.customUvConfig) }}
         - name: uv-config
@@ -508,6 +509,23 @@ spec:
         storageClassName: ""
           {{- else }}
         storageClassName: {{ .Values.nodes.python.persistence.storageClass | quote }}
+          {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- if and .Values.nodes.external.packages (not (eq (include "n8n.main.coversCommunityNodes" .) "true")) .Values.nodes.external.persistence.enabled (not .Values.nodes.external.persistence.existingClaim) }}
+    - metadata:
+        name: community-node-modules
+      spec:
+        accessModes:
+          - {{ .Values.nodes.external.persistence.accessMode }}
+        resources:
+          requests:
+            storage: {{ .Values.nodes.external.persistence.size }}
+        {{- if .Values.nodes.external.persistence.storageClass }}
+          {{- if (eq "-" .Values.nodes.external.persistence.storageClass) }}
+        storageClassName: ""
+          {{- else }}
+        storageClassName: {{ .Values.nodes.external.persistence.storageClass | quote }}
           {{- end }}
         {{- end }}
     {{- end }}

--- a/charts/n8n/templates/statefulset.yaml
+++ b/charts/n8n/templates/statefulset.yaml
@@ -131,6 +131,8 @@ spec:
               value: {{ .Values.timezone | quote }}
             - name: N8N_GRACEFUL_SHUTDOWN_TIMEOUT
               value: {{ .Values.gracefulShutdownTimeout | quote }}
+            - name: NPM_CONFIG_CACHE
+              value: /home/node/.cache/npm
           {{- if eq .Values.db.type "postgresdb" }}
             - name: DB_POSTGRESDB_USER
               value: {{ include "n8n.postgresql.username" . }}

--- a/charts/n8n/templates/statefulset.yaml
+++ b/charts/n8n/templates/statefulset.yaml
@@ -79,9 +79,16 @@ spec:
             - name: {{ default "node-modules" .Values.main.persistence.volumeName }}
               mountPath: "/npmdata"
               readOnly: false
+            {{- if eq (include "n8n.main.coversCommunityNodes" .) "true" }}
+            - name: {{ default "node-modules" .Values.main.persistence.volumeName }}
+              mountPath: "/nodesdata/nodes"
+              subPath: nodes
+              readOnly: false
+            {{- else }}
             - name: community-node-modules
               mountPath: "/nodesdata/nodes"
               readOnly: false
+            {{- end }}
           {{- with .Values.nodes.initContainer.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -263,7 +270,7 @@ spec:
               subPath: {{ .Values.main.persistence.subPath }}
               {{- end }}
               readOnly: false
-          {{- if .Values.nodes.external.packages }}
+          {{- if and .Values.nodes.external.packages (not (eq (include "n8n.main.coversCommunityNodes" .) "true")) }}
             - name: community-node-modules
               mountPath: "/home/node/.n8n/nodes"
               readOnly: false
@@ -380,7 +387,7 @@ spec:
               subPath: {{ .Values.main.persistence.subPath }}
               {{- end }}
               readOnly: false
-          {{- if .Values.nodes.external.packages }}
+          {{- if and .Values.nodes.external.packages (not (eq (include "n8n.main.coversCommunityNodes" .) "true")) }}
             - name: community-node-modules
               mountPath: "/home/node/.n8n/nodes"
               readOnly: false
@@ -404,7 +411,7 @@ spec:
             claimName: {{ include "n8n-python.packages.fullname" . }}
         {{- end }}
       {{- end }}
-      {{- if .Values.nodes.external.packages }}
+      {{- if and .Values.nodes.external.packages (not (eq (include "n8n.main.coversCommunityNodes" .) "true")) }}
         - name: community-node-modules
           {{- if .Values.nodes.external.persistence.enabled }}
           persistentVolumeClaim:

--- a/charts/n8n/unittests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/n8n/unittests/__snapshot__/deployment_test.yaml.snap
@@ -186,6 +186,8 @@ should match snapshot of default values:
                   value: Europe/Berlin
                 - name: N8N_GRACEFUL_SHUTDOWN_TIMEOUT
                   value: "30"
+                - name: NPM_CONFIG_CACHE
+                  value: /home/node/.cache/npm
               envFrom:
                 - configMapRef:
                     name: n8n-database-configmap
@@ -460,6 +462,8 @@ should match snapshot of main persistence:
                   value: Europe/Berlin
                 - name: N8N_GRACEFUL_SHUTDOWN_TIMEOUT
                   value: "30"
+                - name: NPM_CONFIG_CACHE
+                  value: /home/node/.cache/npm
               envFrom:
                 - configMapRef:
                     name: n8n-database-configmap
@@ -735,6 +739,8 @@ should match snapshot of main persistence with multiple main node and mode read 
                   value: Europe/Berlin
                 - name: N8N_GRACEFUL_SHUTDOWN_TIMEOUT
                   value: "30"
+                - name: NPM_CONFIG_CACHE
+                  value: /home/node/.cache/npm
                 - name: N8N_MULTI_MAIN_SETUP_ENABLED
                   value: "true"
               envFrom:
@@ -1022,6 +1028,8 @@ should match snapshot of postgres ssl certificate values:
                   value: Europe/Berlin
                 - name: N8N_GRACEFUL_SHUTDOWN_TIMEOUT
                   value: "30"
+                - name: NPM_CONFIG_CACHE
+                  value: /home/node/.cache/npm
                 - name: DB_POSTGRESDB_USER
                   value: postgres
                 - name: DB_POSTGRESDB_PASSWORD

--- a/charts/n8n/unittests/__snapshot__/statefulset_test.yaml.snap
+++ b/charts/n8n/unittests/__snapshot__/statefulset_test.yaml.snap
@@ -200,6 +200,8 @@ should match snapshot of default values:
                   value: Europe/Berlin
                 - name: N8N_GRACEFUL_SHUTDOWN_TIMEOUT
                   value: "30"
+                - name: NPM_CONFIG_CACHE
+                  value: /home/node/.cache/npm
                 - name: N8N_MULTI_MAIN_SETUP_ENABLED
                   value: "true"
               envFrom:
@@ -504,6 +506,8 @@ should match snapshot of postgres ssl certificate values:
                   value: Europe/Berlin
                 - name: N8N_GRACEFUL_SHUTDOWN_TIMEOUT
                   value: "30"
+                - name: NPM_CONFIG_CACHE
+                  value: /home/node/.cache/npm
                 - name: DB_POSTGRESDB_USER
                   value: postgres
                 - name: DB_POSTGRESDB_PASSWORD

--- a/charts/n8n/unittests/deployment-worker_test.yaml
+++ b/charts/n8n/unittests/deployment-worker_test.yaml
@@ -1848,10 +1848,10 @@ tests:
             echo "$PACKAGES" | sha256sum > /npmdata/packages.hash.new
             if [ ! -f /npmdata/packages.hash ] || ! cmp /npmdata/packages.hash /npmdata/packages.hash.new; then
               if [ -n "$NON_COMMUNITY_PACKAGES" ]; then
-                npm install --loglevel info --no-save $NON_COMMUNITY_PACKAGES --prefix /npmdata
+                npm install --loglevel info --no-save --ignore-scripts $NON_COMMUNITY_PACKAGES --prefix /npmdata
               fi
               if [ -n "$COMMUNITY_PACKAGES" ]; then
-                npm install --loglevel info --no-save $COMMUNITY_PACKAGES --prefix /nodesdata/nodes
+                npm install --loglevel info --no-save --ignore-scripts $COMMUNITY_PACKAGES --prefix /nodesdata/nodes
               fi
               mv /npmdata/packages.hash.new /npmdata/packages.hash
             else

--- a/charts/n8n/unittests/deployment_test.yaml
+++ b/charts/n8n/unittests/deployment_test.yaml
@@ -1575,6 +1575,16 @@ tests:
           any: true
         template: deployment.yaml
 
+  - it: should set NPM_CONFIG_CACHE on main container
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "n8n-main")].env
+          content:
+            name: NPM_CONFIG_CACHE
+            value: /home/node/.cache/npm
+          any: true
+        template: deployment.yaml
+
   - it: should always mount data dir in main container even without persistence or external packages
     asserts:
       - contains:

--- a/charts/n8n/unittests/deployment_test.yaml
+++ b/charts/n8n/unittests/deployment_test.yaml
@@ -2174,6 +2174,102 @@ tests:
           any: true
         template: deployment.yaml
 
+  - it: should use main persistence volume with subPath nodes in init container when main.persistence covers community nodes
+    set:
+      main:
+        persistence:
+          enabled: true
+          existingClaim: my-n8n-pvc
+      nodes:
+        external:
+          packages:
+            - "n8n-nodes-evolution-api"
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[?(@.name == "npm-install")].volumeMounts
+          content:
+            name: node-modules
+            mountPath: "/nodesdata/nodes"
+            subPath: nodes
+            readOnly: false
+          any: true
+        template: deployment.yaml
+      - notContains:
+          path: spec.template.spec.initContainers[?(@.name == "npm-install")].volumeMounts
+          content:
+            name: community-node-modules
+            mountPath: "/nodesdata/nodes"
+            readOnly: false
+          any: true
+        template: deployment.yaml
+
+  - it: should not mount community-node-modules in main container when main.persistence covers community nodes
+    set:
+      main:
+        persistence:
+          enabled: true
+          existingClaim: my-n8n-pvc
+      nodes:
+        external:
+          packages:
+            - "n8n-nodes-evolution-api"
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[?(@.name == "n8n-main")].volumeMounts
+          content:
+            name: community-node-modules
+            mountPath: "/home/node/.n8n/nodes"
+            readOnly: false
+          any: true
+        template: deployment.yaml
+
+  - it: should not define community-node-modules volume when main.persistence covers community nodes
+    set:
+      main:
+        persistence:
+          enabled: true
+          existingClaim: my-n8n-pvc
+      nodes:
+        external:
+          packages:
+            - "n8n-nodes-evolution-api"
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: community-node-modules
+            emptyDir: {}
+          any: true
+        template: deployment.yaml
+
+  - it: should still use community-node-modules when main.persistence has custom subPath set
+    set:
+      main:
+        persistence:
+          enabled: true
+          existingClaim: my-n8n-pvc
+          subPath: "n8n-data"
+      nodes:
+        external:
+          packages:
+            - "n8n-nodes-evolution-api"
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[?(@.name == "npm-install")].volumeMounts
+          content:
+            name: community-node-modules
+            mountPath: "/nodesdata/nodes"
+            readOnly: false
+          any: true
+        template: deployment.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: community-node-modules
+            emptyDir: {}
+          any: true
+        template: deployment.yaml
+
   - it: should add init container to main pod when main.initContainers is defined
     set:
       main:

--- a/charts/n8n/unittests/deployment_test.yaml
+++ b/charts/n8n/unittests/deployment_test.yaml
@@ -2007,10 +2007,10 @@ tests:
             echo "$PACKAGES" | sha256sum > /npmdata/packages.hash.new
             if [ ! -f /npmdata/packages.hash ] || ! cmp /npmdata/packages.hash /npmdata/packages.hash.new; then
               if [ -n "$NON_COMMUNITY_PACKAGES" ]; then
-                npm install --loglevel info --no-save $NON_COMMUNITY_PACKAGES --prefix /npmdata
+                npm install --loglevel info --no-save --ignore-scripts $NON_COMMUNITY_PACKAGES --prefix /npmdata
               fi
               if [ -n "$COMMUNITY_PACKAGES" ]; then
-                npm install --loglevel info --no-save $COMMUNITY_PACKAGES --prefix /nodesdata/nodes
+                npm install --loglevel info --no-save --ignore-scripts $COMMUNITY_PACKAGES --prefix /nodesdata/nodes
               fi
               mv /npmdata/packages.hash.new /npmdata/packages.hash
             else

--- a/charts/n8n/unittests/deployment_test.yaml
+++ b/charts/n8n/unittests/deployment_test.yaml
@@ -2138,6 +2138,42 @@ tests:
           any: true
         template: deployment.yaml
 
+  - it: should use PVC for community-node-modules volume when persistence is enabled
+    set:
+      nodes:
+        external:
+          packages:
+            - "n8n-nodes-evolution-api"
+          persistence:
+            enabled: true
+            existingClaim: my-community-pvc
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: community-node-modules
+            persistentVolumeClaim:
+              claimName: my-community-pvc
+          any: true
+        template: deployment.yaml
+
+  - it: should use emptyDir for community-node-modules volume when persistence is disabled
+    set:
+      nodes:
+        external:
+          packages:
+            - "n8n-nodes-evolution-api"
+          persistence:
+            enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: community-node-modules
+            emptyDir: {}
+          any: true
+        template: deployment.yaml
+
   - it: should add init container to main pod when main.initContainers is defined
     set:
       main:

--- a/charts/n8n/unittests/pvc_test.yaml
+++ b/charts/n8n/unittests/pvc_test.yaml
@@ -432,3 +432,54 @@ tests:
           path: spec.accessModes[0]
           value: ReadWriteOnce
 
+  - it: should create worker PVC when worker.count is 3 and accessMode is ReadWriteMany
+    set:
+      main:
+        persistence:
+          enabled: false
+      worker:
+        count: 3
+        persistence:
+          accessMode: ReadWriteMany
+    documentSelector:
+      path: metadata.name
+      value: n8n-worker-persistence
+    asserts:
+      - equal:
+          path: spec.accessModes[0]
+          value: ReadWriteMany
+
+  - it: should not create worker PVC when worker.forceToUseStatefulset is true
+    set:
+      main:
+        persistence:
+          enabled: false
+      worker:
+        count: 1
+        forceToUseStatefulset: true
+        mode: queue
+      db:
+        type: postgresdb
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create community-packages PVC when main.forceToUseStatefulset is true and main.persistence is disabled
+    set:
+      main:
+        forceToUseStatefulset: true
+        persistence:
+          enabled: false
+      worker:
+        persistence:
+          enabled: false
+      nodes:
+        external:
+          packages:
+            - "n8n-nodes-evolution-api"
+          persistence:
+            enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+

--- a/charts/n8n/unittests/pvc_test.yaml
+++ b/charts/n8n/unittests/pvc_test.yaml
@@ -387,3 +387,48 @@ tests:
           path: spec.accessModes[0]
           value: ReadWriteMany
 
+  - it: should not create community-packages PVC when main.persistence covers community nodes
+    set:
+      main:
+        persistence:
+          enabled: true
+          existingClaim: my-n8n-pvc
+      worker:
+        persistence:
+          enabled: false
+      nodes:
+        external:
+          packages:
+            - "n8n-nodes-evolution-api"
+          persistence:
+            enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create community-packages PVC when main.persistence enabled but worker queue mode has no worker persistence
+    set:
+      main:
+        persistence:
+          enabled: true
+          existingClaim: my-n8n-pvc
+      worker:
+        mode: queue
+        persistence:
+          enabled: false
+      db:
+        type: postgresdb
+      nodes:
+        external:
+          packages:
+            - "n8n-nodes-evolution-api"
+          persistence:
+            enabled: true
+    documentSelector:
+      path: metadata.name
+      value: n8n-community-packages
+    asserts:
+      - equal:
+          path: spec.accessModes[0]
+          value: ReadWriteOnce
+

--- a/charts/n8n/unittests/pvc_test.yaml
+++ b/charts/n8n/unittests/pvc_test.yaml
@@ -273,3 +273,117 @@ tests:
       - equal:
           path: spec.accessModes[0]
           value: ReadWriteMany
+
+  - it: should not create community-packages PVC when persistence is disabled
+    set:
+      main:
+        persistence:
+          enabled: false
+      worker:
+        persistence:
+          enabled: false
+      nodes:
+        external:
+          packages:
+            - "n8n-nodes-evolution-api"
+          persistence:
+            enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create community-packages PVC when packages list is empty
+    set:
+      main:
+        persistence:
+          enabled: false
+      worker:
+        persistence:
+          enabled: false
+      nodes:
+        external:
+          packages: []
+          persistence:
+            enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create community-packages PVC when existingClaim is set
+    set:
+      main:
+        persistence:
+          enabled: false
+      worker:
+        persistence:
+          enabled: false
+      nodes:
+        external:
+          packages:
+            - "n8n-nodes-evolution-api"
+          persistence:
+            enabled: true
+            existingClaim: my-existing-pvc
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create community-packages PVC when persistence is enabled and packages are set
+    set:
+      main:
+        persistence:
+          enabled: false
+      worker:
+        persistence:
+          enabled: false
+      nodes:
+        external:
+          packages:
+            - "n8n-nodes-evolution-api"
+          persistence:
+            enabled: true
+            storageClass: fast-ssd
+            accessMode: ReadWriteOnce
+            size: 2Gi
+            annotations:
+              test-key: test-value
+    documentSelector:
+      path: metadata.name
+      value: n8n-community-packages
+    asserts:
+      - equal:
+          path: spec.accessModes[0]
+          value: ReadWriteOnce
+      - equal:
+          path: spec.resources.requests.storage
+          value: 2Gi
+      - equal:
+          path: spec.storageClassName
+          value: fast-ssd
+      - equal:
+          path: metadata.annotations.test-key
+          value: test-value
+
+  - it: should create community-packages PVC with ReadWriteMany access mode
+    set:
+      main:
+        persistence:
+          enabled: false
+      worker:
+        persistence:
+          enabled: false
+      nodes:
+        external:
+          packages:
+            - "n8n-nodes-evolution-api"
+          persistence:
+            enabled: true
+            accessMode: ReadWriteMany
+    documentSelector:
+      path: metadata.name
+      value: n8n-community-packages
+    asserts:
+      - equal:
+          path: spec.accessModes[0]
+          value: ReadWriteMany
+

--- a/charts/n8n/unittests/statefulset-worker_test.yaml
+++ b/charts/n8n/unittests/statefulset-worker_test.yaml
@@ -1757,10 +1757,10 @@ tests:
             echo "$PACKAGES" | sha256sum > /npmdata/packages.hash.new
             if [ ! -f /npmdata/packages.hash ] || ! cmp /npmdata/packages.hash /npmdata/packages.hash.new; then
               if [ -n "$NON_COMMUNITY_PACKAGES" ]; then
-                npm install --loglevel info --no-save $NON_COMMUNITY_PACKAGES --prefix /npmdata
+                npm install --loglevel info --no-save --ignore-scripts $NON_COMMUNITY_PACKAGES --prefix /npmdata
               fi
               if [ -n "$COMMUNITY_PACKAGES" ]; then
-                npm install --loglevel info --no-save $COMMUNITY_PACKAGES --prefix /nodesdata/nodes
+                npm install --loglevel info --no-save --ignore-scripts $COMMUNITY_PACKAGES --prefix /nodesdata/nodes
               fi
               mv /npmdata/packages.hash.new /npmdata/packages.hash
             else

--- a/charts/n8n/unittests/statefulset-worker_test.yaml
+++ b/charts/n8n/unittests/statefulset-worker_test.yaml
@@ -2666,3 +2666,85 @@ tests:
               optional: true
           any: true
         template: statefulset-worker.yaml
+
+  - it: should add community-node-modules to volumeClaimTemplates in worker StatefulSet when forceToUseStatefulset and community persistence enabled
+    set:
+      worker:
+        forceToUseStatefulset: true
+        persistence:
+          enabled: false
+      nodes:
+        external:
+          packages:
+            - "n8n-nodes-evolution-api"
+          persistence:
+            enabled: true
+            accessMode: ReadWriteOnce
+            size: 2Gi
+    asserts:
+      - contains:
+          path: spec.volumeClaimTemplates
+          content:
+            metadata:
+              name: community-node-modules
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 2Gi
+        template: statefulset-worker.yaml
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: community-node-modules
+            emptyDir: {}
+        template: statefulset-worker.yaml
+
+  - it: should use existingClaim as regular volume in worker StatefulSet when community existingClaim is set
+    set:
+      worker:
+        forceToUseStatefulset: true
+        persistence:
+          enabled: false
+      nodes:
+        external:
+          packages:
+            - "n8n-nodes-evolution-api"
+          persistence:
+            enabled: true
+            existingClaim: my-existing-community-pvc
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: community-node-modules
+            persistentVolumeClaim:
+              claimName: my-existing-community-pvc
+        template: statefulset-worker.yaml
+      - notContains:
+          path: spec.volumeClaimTemplates
+          content:
+            metadata:
+              name: community-node-modules
+        template: statefulset-worker.yaml
+
+  - it: should add community-node-modules emptyDir in worker StatefulSet when forceToUseStatefulset and community persistence disabled
+    set:
+      worker:
+        forceToUseStatefulset: true
+        persistence:
+          enabled: false
+      nodes:
+        external:
+          packages:
+            - "n8n-nodes-evolution-api"
+          persistence:
+            enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: community-node-modules
+            emptyDir: {}
+        template: statefulset-worker.yaml

--- a/charts/n8n/unittests/statefulset-worker_test.yaml
+++ b/charts/n8n/unittests/statefulset-worker_test.yaml
@@ -1589,8 +1589,9 @@ tests:
       - contains:
           path: spec.template.spec.initContainers[?(@.name == "npm-install")].volumeMounts
           content:
-            name: community-node-modules
+            name: node-modules
             mountPath: "/nodesdata/nodes"
+            subPath: nodes
             readOnly: false
           any: true
         template: statefulset-worker.yaml
@@ -1665,8 +1666,9 @@ tests:
       - contains:
           path: spec.template.spec.initContainers[?(@.name == "npm-install")].volumeMounts
           content:
-            name: community-node-modules
+            name: node-modules
             mountPath: "/nodesdata/nodes"
+            subPath: nodes
             readOnly: false
           any: true
         template: statefulset-worker.yaml
@@ -1855,8 +1857,9 @@ tests:
       - contains:
           path: spec.template.spec.initContainers[?(@.name == "npm-install")].volumeMounts
           content:
-            name: community-node-modules
+            name: node-modules
             mountPath: "/nodesdata/nodes"
+            subPath: nodes
             readOnly: false
           any: true
         template: statefulset-worker.yaml

--- a/charts/n8n/unittests/statefulset_test.yaml
+++ b/charts/n8n/unittests/statefulset_test.yaml
@@ -1451,6 +1451,16 @@ tests:
           any: true
         template: statefulset.yaml
 
+  - it: should set NPM_CONFIG_CACHE on main container
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "n8n-main")].env
+          content:
+            name: NPM_CONFIG_CACHE
+            value: /home/node/.cache/npm
+          any: true
+        template: statefulset.yaml
+
   - it: should always mount data dir in main container
     asserts:
       - contains:

--- a/charts/n8n/unittests/statefulset_test.yaml
+++ b/charts/n8n/unittests/statefulset_test.yaml
@@ -1869,10 +1869,10 @@ tests:
             echo "$PACKAGES" | sha256sum > /npmdata/packages.hash.new
             if [ ! -f /npmdata/packages.hash ] || ! cmp /npmdata/packages.hash /npmdata/packages.hash.new; then
               if [ -n "$NON_COMMUNITY_PACKAGES" ]; then
-                npm install --loglevel info --no-save $NON_COMMUNITY_PACKAGES --prefix /npmdata
+                npm install --loglevel info --no-save --ignore-scripts $NON_COMMUNITY_PACKAGES --prefix /npmdata
               fi
               if [ -n "$COMMUNITY_PACKAGES" ]; then
-                npm install --loglevel info --no-save $COMMUNITY_PACKAGES --prefix /nodesdata/nodes
+                npm install --loglevel info --no-save --ignore-scripts $COMMUNITY_PACKAGES --prefix /nodesdata/nodes
               fi
               mv /npmdata/packages.hash.new /npmdata/packages.hash
             else

--- a/charts/n8n/unittests/statefulset_test.yaml
+++ b/charts/n8n/unittests/statefulset_test.yaml
@@ -2581,3 +2581,85 @@ tests:
               optional: true
           any: true
         template: statefulset.yaml
+
+  - it: should add community-node-modules to volumeClaimTemplates when forceToUseStatefulset and community persistence enabled
+    set:
+      main:
+        forceToUseStatefulset: true
+        persistence:
+          enabled: false
+      nodes:
+        external:
+          packages:
+            - "n8n-nodes-evolution-api"
+          persistence:
+            enabled: true
+            accessMode: ReadWriteOnce
+            size: 2Gi
+    asserts:
+      - contains:
+          path: spec.volumeClaimTemplates
+          content:
+            metadata:
+              name: community-node-modules
+            spec:
+              accessModes:
+                - ReadWriteOnce
+              resources:
+                requests:
+                  storage: 2Gi
+        template: statefulset.yaml
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: community-node-modules
+            emptyDir: {}
+        template: statefulset.yaml
+
+  - it: should use existingClaim as regular volume in StatefulSet when community existingClaim is set
+    set:
+      main:
+        forceToUseStatefulset: true
+        persistence:
+          enabled: false
+      nodes:
+        external:
+          packages:
+            - "n8n-nodes-evolution-api"
+          persistence:
+            enabled: true
+            existingClaim: my-existing-community-pvc
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: community-node-modules
+            persistentVolumeClaim:
+              claimName: my-existing-community-pvc
+        template: statefulset.yaml
+      - notContains:
+          path: spec.volumeClaimTemplates
+          content:
+            metadata:
+              name: community-node-modules
+        template: statefulset.yaml
+
+  - it: should add community-node-modules emptyDir in StatefulSet when forceToUseStatefulset and community persistence disabled
+    set:
+      main:
+        forceToUseStatefulset: true
+        persistence:
+          enabled: false
+      nodes:
+        external:
+          packages:
+            - "n8n-nodes-evolution-api"
+          persistence:
+            enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: community-node-modules
+            emptyDir: {}
+        template: statefulset.yaml

--- a/charts/n8n/unittests/statefulset_test.yaml
+++ b/charts/n8n/unittests/statefulset_test.yaml
@@ -1701,8 +1701,9 @@ tests:
       - contains:
           path: spec.template.spec.initContainers[?(@.name == "npm-install")].volumeMounts
           content:
-            name: community-node-modules
+            name: node-modules
             mountPath: "/nodesdata/nodes"
+            subPath: nodes
             readOnly: false
           any: true
         template: statefulset.yaml
@@ -1777,8 +1778,9 @@ tests:
       - contains:
           path: spec.template.spec.initContainers[?(@.name == "npm-install")].volumeMounts
           content:
-            name: community-node-modules
+            name: node-modules
             mountPath: "/nodesdata/nodes"
+            subPath: nodes
             readOnly: false
           any: true
         template: statefulset.yaml
@@ -1967,8 +1969,9 @@ tests:
       - contains:
           path: spec.template.spec.initContainers[?(@.name == "npm-install")].volumeMounts
           content:
-            name: community-node-modules
+            name: node-modules
             mountPath: "/nodesdata/nodes"
+            subPath: nodes
             readOnly: false
           any: true
         template: statefulset.yaml

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -1080,9 +1080,61 @@
               "required": [],
               "title": "packages",
               "type": "array"
+            },
+            "persistence": {
+              "additionalProperties": false,
+              "description": "Persistence for community node packages installed by the init container. Optional PVC so packages survive pod restarts without re-downloading.",
+              "properties": {
+                "enabled": {
+                  "default": false,
+                  "description": "Enable persistence. When false, packages are installed into an emptyDir and lost on pod restart.",
+                  "required": [],
+                  "title": "enabled",
+                  "type": "boolean"
+                },
+                "existingClaim": {
+                  "default": "",
+                  "description": "Use an existing PVC instead of creating one. When set, no PVC is created by this chart.",
+                  "required": [],
+                  "title": "existingClaim",
+                  "type": "string"
+                },
+                "storageClass": {
+                  "default": "",
+                  "description": "Storage class for the PVC. Empty string uses the cluster default.",
+                  "required": [],
+                  "title": "storageClass",
+                  "type": "string"
+                },
+                "accessMode": {
+                  "default": "ReadWriteOnce",
+                  "description": "Access mode. Use ReadWriteMany when worker pods may be scheduled on different nodes.",
+                  "enum": ["ReadWriteOnce", "ReadWriteMany"],
+                  "required": [],
+                  "title": "accessMode",
+                  "type": "string"
+                },
+                "size": {
+                  "default": "1Gi",
+                  "description": "Size of the PVC.",
+                  "required": [],
+                  "title": "size",
+                  "type": "string"
+                },
+                "annotations": {
+                  "additionalProperties": true,
+                  "description": "Additional annotations for the PVC.",
+                  "required": [],
+                  "title": "annotations",
+                  "type": "object"
+                }
+              },
+              "required": ["enabled", "existingClaim", "storageClass", "accessMode", "size", "annotations"],
+              "title": "persistence",
+              "type": "object"
             }
           },
-          "required": ["allowAll", "reinstallMissingPackages", "packages"],
+          "required": ["allowAll", "reinstallMissingPackages", "packages", "persistence"],
           "title": "external",
           "type": "object"
         },

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -136,6 +136,20 @@ nodes:
     packages: []
       # - "moment@2.29.4"
       # - "lodash@4.17.21"
+    # -- Persistence for community node packages installed by the init container. Optional PVC so packages survive pod restarts without re-downloading.
+    persistence:
+      # -- Enable persistence. When false, packages are installed into an emptyDir and lost on pod restart.
+      enabled: false
+      # -- Use an existing PVC instead of creating one. When set, no PVC is created by this chart.
+      existingClaim: ""
+      # -- Storage class for the PVC. Empty string uses the cluster default.
+      storageClass: ""
+      # -- Access mode. Use ReadWriteMany when worker pods may be scheduled on different nodes.
+      accessMode: ReadWriteOnce
+      # -- Size of the PVC.
+      size: 1Gi
+      # -- Additional annotations for the PVC.
+      annotations: {}
   # -- Image for the init container to install npm packages
   initContainer:
     # -- Image for the init container to install npm packages


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes three related issues with the n8n community node packages feature and PVC lifecycle:

1. **`readOnlyRootFilesystem: true` breaks npm cache** — npm tries to write its cache to `/home/node/.npm` which is read-only. Fixed by setting `NPM_CONFIG_CACHE=/npmdata/.npm-cache` in the init container and `NPM_CONFIG_CACHE=/home/node/.cache/npm` in the main container.

2. **Community packages not visible in external task runner mode** — the `community-node-modules` volume was not mounted in the task runner sidecar or on worker pods. Fixed by adding the missing mounts.

3. **`postinstall` scripts crash the init container** — community packages like `n8n-nodes-evolution-api` contain `only-allow pnpm` hooks. Fixed by passing `--ignore-scripts` to `npm install`.

4. **Optional PVC persistence for community node packages** — adds `nodes.external.persistence` (same pattern as `nodes.python.persistence`) so packages survive pod restarts instead of being re-downloaded every time.

5. **Community packages routed into main/worker PVC when it already covers the path** — when `main.persistence.mountPath=/home/node/.n8n` (default) the init container now installs directly into the main PVC via `subPath: nodes`, eliminating a redundant `community-node-modules` volume.

6. **Worker PVC not created with `count > 1` + `ReadWriteMany`** — `pvc.yaml` only created the worker PVC when `count == 1`. Fixed by aligning the condition with `deployment-worker.yaml`'s render gate (adds `ReadWriteMany`, `forceToUseStatefulset`, and `autoscaling` guards).

7. **Community packages share a `ReadWriteOnce` PVC across StatefulSet replicas when `forceToUseStatefulset: true`** — moved community-node-modules from `volumes:` to `volumeClaimTemplates` in `statefulset.yaml` and `statefulset-worker.yaml`, matching the existing python-packages pattern.

#### Which issue this PR fixes
- fixes #508
- fixes https://github.com/community-charts/community-charts.github.io/issues/102

#### Special notes for your reviewer:

- `n8n.main.coversCommunityNodes` / `n8n.worker.coversCommunityNodes` are new template helpers in `_helpers.tpl` that decide whether community packages should be installed into the main/worker PVC directly (via `subPath: nodes`) or into a dedicated `community-node-modules` volume.
- The `nodes.external.persistence` PVC is only created when the `community-node-modules` volume is actually needed (i.e. when neither the main nor the relevant worker persistence covers the path) and when not using StatefulSet `volumeClaimTemplates`.
- A new `charts/n8n/CLAUDE.md` file documents chart-specific guidance for AI-assisted development (added to `.helmignore` so it is not packaged).

#### Checklist
- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[n8n]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated