### PR TITLE
[n8n] Update n8n chart to 2.26.7

### DIFF
--- a/charts/n8n/Chart.lock
+++ b/charts/n8n/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 27.0.10
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 18.7.5
+  version: 18.7.6
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:1ce251044860a5cecbf25005936592fe0ffecf31613476d9f498889fb934cff8
-generated: "2026-06-17T02:47:49.691704203Z"
+digest: sha256:1fb3665164ebb0e8af5900e05c8ac35ea9e3b70c5eba66a00d71e522344a780a
+generated: "2026-06-19T02:48:32.259807229Z"

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.22.5
+version: 1.22.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.26.6"
+appVersion: "2.26.7"
 kubeVersion: ">=1.23.0-0"
 home: https://n8n.io
 maintainers:
@@ -50,26 +50,19 @@ annotations:
       url: https://docs.n8n.io/
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
-    - kind: fixed
-      description: Set NPM_CONFIG_CACHE env var in main container to allow community package installation with readOnlyRootFilesystem enabled
+    - kind: changed
+      description: Update n8nio/n8n image version to 2.26.7
       links:
-        - name: GitHub Issue
-          url: https://github.com/community-charts/helm-charts/issues/508
-        - name: GitHub Issue
-          url: https://github.com/community-charts/community-charts.github.io/issues/102
-    - kind: fixed
-      description: Fix community node packages not available to n8n process in external task runner mode and add --ignore-scripts to prevent postinstall script failures
-    - kind: added
-      description: Add optional PVC persistence for community node packages via nodes.external.persistence
-    - kind: fixed
-      description: Route community package installs into the main/worker PVC when its mountPath already covers /home/node/.n8n/nodes, eliminating a redundant separate volume
-    - kind: fixed
-      description: Fix worker PVC not created when worker.count > 1 with ReadWriteMany access mode
-    - kind: fixed
-      description: Fix community packages sharing a ReadWriteOnce PVC across StatefulSet replicas when forceToUseStatefulset is true
+        - name: Upstream Project
+          url: https://github.com/n8n-io/n8n
+    - kind: changed
+      description: Update dependency postgresql from 18.7.5 to 18.7.6
+      links:
+        - name: ArtifactHub
+          url: https://artifacthub.io/packages/helm/bitnami/postgresql
   artifacthub.io/images: |
     - name: n8n
-      image: n8nio/n8n:2.26.6
+      image: n8nio/n8n:2.26.7
       platforms:
         - linux/amd64
         - linux/arm64
@@ -130,7 +123,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: postgresql
-    version: 18.7.5
+    version: 18.7.6
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: minio

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.22.5](https://img.shields.io/badge/Version-1.22.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.26.6](https://img.shields.io/badge/AppVersion-2.26.6-informational?style=flat-square)
+![Version: 1.22.6](https://img.shields.io/badge/Version-1.22.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.26.7](https://img.shields.io/badge/AppVersion-2.26.7-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -1245,7 +1245,7 @@ Kubernetes: `>=1.23.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 18.7.5 |
+| https://charts.bitnami.com/bitnami | postgresql | 18.7.6 |
 | https://charts.bitnami.com/bitnami | redis | 27.0.10 |
 | https://charts.min.io/ | minio | 5.4.0 |
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the n8n chart to use the latest image version 2.26.7 from n8nio/n8n. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated