### PR TITLE
[n8n] use only package name (without scope) for community node check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ on:
 env:
   HELM_VERSION: v3.18.3
   HELM_UNITTEST_VERSION: v0.8.2
+  HELM_DOCS_VERSION: v1.14.2
 
 jobs:
   lint-ah:
@@ -39,8 +40,34 @@ jobs:
           done
           echo "All charts linted successfully."
 
+  check-helm-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Install helm-docs
+        run: |
+          VERSION="${{ env.HELM_DOCS_VERSION }}"
+          VERSION_NUMBER="${VERSION#v}"
+          wget -q -O /tmp/helm-docs.tar.gz \
+            "https://github.com/norwoodj/helm-docs/releases/download/${VERSION}/helm-docs_${VERSION_NUMBER}_Linux_x86_64.tar.gz"
+          tar -xzf /tmp/helm-docs.tar.gz -C /tmp helm-docs
+          sudo mv /tmp/helm-docs /usr/local/bin/helm-docs
+
+      - name: Run helm-docs
+        run: helm-docs --chart-search-root=charts --template-files=README.md.gotmpl
+
+      - name: Check for README drift
+        run: |
+          if ! git diff --exit-code charts/*/README.md; then
+            echo "README.md is out of date — run helm-docs locally and commit the updated file(s)"
+            exit 1
+          fi
+
   lint-test:
-    needs: lint-ah
+    needs: [lint-ah, check-helm-docs]
 
     runs-on: ubuntu-latest
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ Every chart follows this layout:
 charts/<name>/
 ├── Chart.yaml          # Chart metadata, version, appVersion, ArtifactHub annotations
 ├── Chart.lock          # Locked dependency versions
+├── .helmignore         # Excludes dev/test files from the packaged chart tarball
 ├── values.yaml         # Default values
 ├── values.schema.json  # JSON Schema validation for values (additionalProperties: false)
 ├── values-kind.yaml    # Minimal values for kind cluster CI testing
@@ -87,6 +88,17 @@ charts/<name>/
 └── unittests/
     └── *_test.yaml     # helm-unittest test suites (run via `helm unittest`)
 ```
+
+Every non-deprecated chart's `.helmignore` must exclude files that are not needed in the packaged tarball. At minimum it must contain:
+
+```
+README.md.gotmpl
+values-kind.yaml
+CLAUDE.md
+unittests/
+```
+
+Do not apply `.helmignore` changes to deprecated charts (currently: `kserve`).
 
 ### Versioning Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,12 @@ Do not apply `.helmignore` changes to deprecated charts (currently: `kserve`).
 - **Any change** to a chart (including docs) requires a `version` bump in `Chart.yaml` following semver.
 - `appVersion` tracks the upstream application version.
 - Breaking changes bump MAJOR version and must document manual upgrade steps in `README.md.gotmpl` under an "Upgrading" section.
-- The `artifacthub.io/changes` annotation in `Chart.yaml` is used to auto-generate release notes — always populate it for every change.
+- The `artifacthub.io/changes` annotation in `Chart.yaml` is used to auto-generate release notes — always populate it for every change. When linking to a GitHub issue, use `name: GitHub Issue` (not `Issue` or any other variant):
+  ```yaml
+  links:
+    - name: GitHub Issue
+      url: https://github.com/community-charts/helm-charts/issues/<number>
+  ```
 - **Bump `version` only once per branch/PR.** After the first bump, do not bump again for subsequent commits on the same branch — all changes in the PR are released together under the single bumped version.
 
 ### CI Pipeline

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,8 +113,9 @@ Do not apply `.helmignore` changes to deprecated charts (currently: `kserve`).
 **`.github/workflows/release.yml`** (runs on all PRs/pushes):
 
 1. **lint-ah**: Runs `ah lint` on all charts for ArtifactHub compliance.
-2. **lint-test**: Runs `ct lint` (which also calls `helm unittest`) and `ct install` on changed charts only. Charts with a `.skip-kind-test` file skip the `ct install` step.
-3. **release**: On merge to `main`, runs `chart-releaser` to package, GPG-sign, and publish changed charts to GitHub Pages.
+2. **check-helm-docs**: Runs `helm-docs` and fails if any `README.md` differs from what is committed — catches PRs where `README.md.gotmpl` or `values.yaml` doc comments were updated without regenerating the README.
+3. **lint-test**: Runs `ct lint` (which also calls `helm unittest`) and `ct install` on changed charts only. Requires both `lint-ah` and `check-helm-docs` to pass. Charts with a `.skip-kind-test` file skip the `ct install` step.
+4. **release**: On merge to `main`, runs `chart-releaser` to package, GPG-sign, and publish changed charts to GitHub Pages.
 
 **`.github/workflows/security-scan.yml`** (runs on changes to `charts/**`):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,8 @@ metadata:
 
 Tests live in `unittests/` as YAML files using [helm-unittest](https://github.com/helm-unittest/helm-unittest) syntax. Tests assert on rendered template output using `set:` to override values. Snapshot tests use `__snapshot__/` subdirectories.
 
+When asserting a specific value within a larger rendered string (e.g. one line in a multi-line script), use `matchRegex` with a targeted pattern rather than `equal` on the full string — keeps tests focused and resilient to unrelated boilerplate changes. `matchRegex` does substring matching (no anchoring needed); escape regex metacharacters in patterns (e.g. `\.` for literal dots in version strings).
+
 Always validate field types against the official schema before writing tests:
 `https://raw.githubusercontent.com/helm-unittest/helm-unittest/refs/heads/main/schema/helm-testsuite.json`
 Suite-level `capabilities` can be overridden per-test using the same fields.

--- a/charts/n8n/.helmignore
+++ b/charts/n8n/.helmignore
@@ -25,3 +25,4 @@
 README.md.gotmpl
 values-kind.yaml
 CLAUDE.md
+unittests/

--- a/charts/n8n/CLAUDE.md
+++ b/charts/n8n/CLAUDE.md
@@ -96,3 +96,4 @@ This means `volumes:` never holds a dynamically-provisioned PVC in StatefulSet c
 | `n8n-python.packages.fullname` | Python PVC name (respects `existingClaim`) |
 | `n8n.npmInstallScript` | Full npm install shell script for the init container |
 | `n8n.taskRunners.uvInstallCommand` | uv pip install command for the task runner sidecar |
+| `n8n.isCommunityPackage` | Returns `"true"` if a package (with or without `@version`/`@scope`) has a name starting with `n8n-nodes-`; used by `n8n.communityPackages` and `n8n.nonCommunityPackages` |

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -50,7 +50,7 @@ annotations:
       url: https://docs.n8n.io/
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
-    - kind: fix
+    - kind: fixed
       description: Change community node detection to allow scoped community nodes (e.g. @myorg/n8n-nodes-mynode)
   artifacthub.io/images: |
     - name: n8n

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -52,6 +52,9 @@ annotations:
   artifacthub.io/changes: |-
     - kind: fixed
       description: Change community node detection to allow scoped community nodes (e.g. @myorg/n8n-nodes-mynode)
+      links:
+        - name: Issue
+          url: https://github.com/community-charts/helm-charts/issues/241
   artifacthub.io/images: |
     - name: n8n
       image: n8nio/n8n:2.26.7

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.22.6
+version: 1.22.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -50,16 +50,8 @@ annotations:
       url: https://docs.n8n.io/
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
-    - kind: changed
-      description: Update n8nio/n8n image version to 2.26.7
-      links:
-        - name: Upstream Project
-          url: https://github.com/n8n-io/n8n
-    - kind: changed
-      description: Update dependency postgresql from 18.7.5 to 18.7.6
-      links:
-        - name: ArtifactHub
-          url: https://artifacthub.io/packages/helm/bitnami/postgresql
+    - kind: fix
+      description: Change community node detection to allow scoped community nodes (e.g. @myorg/n8n-nodes-mynode)
   artifacthub.io/images: |
     - name: n8n
       image: n8nio/n8n:2.26.7

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -53,7 +53,7 @@ annotations:
     - kind: fixed
       description: Change community node detection to allow scoped community nodes (e.g. @myorg/n8n-nodes-mynode)
       links:
-        - name: Issue
+        - name: GitHub Issue
           url: https://github.com/community-charts/helm-charts/issues/241
   artifacthub.io/images: |
     - name: n8n

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.22.6](https://img.shields.io/badge/Version-1.22.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.26.7](https://img.shields.io/badge/AppVersion-2.26.7-informational?style=flat-square)
+![Version: 1.22.7](https://img.shields.io/badge/Version-1.22.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.26.7](https://img.shields.io/badge/AppVersion-2.26.7-informational?style=flat-square)
 
 ## Official Documentation
 

--- a/charts/n8n/templates/_helpers.tpl
+++ b/charts/n8n/templates/_helpers.tpl
@@ -280,6 +280,20 @@ app.kubernetes.io/component: task-runners
 {{- end }}
 
 {{/*
+Extract package names from a list of strings
+*/}}
+{{- define "n8n.packageNames" -}}
+{{- $packageNames := list -}}
+{{- range . -}}
+  {{- $matches := regexFindAll "^@?[^@]+" . 1 -}}
+  {{- if and $matches (not (hasPrefix "n8n-nodes-" (index $matches 0))) -}}
+    {{- $packageNames = append $packageNames (index $matches 0) -}}
+  {{- end -}}
+{{- end -}}
+{{- join "," $packageNames -}}
+{{- end -}}
+
+{{/*
 Return a non-empty string if the package is a community package.
 */}}
 {{- define "n8n.isCommunityPackage" -}}

--- a/charts/n8n/templates/_helpers.tpl
+++ b/charts/n8n/templates/_helpers.tpl
@@ -280,26 +280,24 @@ app.kubernetes.io/component: task-runners
 {{- end }}
 
 {{/*
-Extract package names from a list of strings
+Return a non-empty string if the package is a community package.
 */}}
-{{- define "n8n.packageNames" -}}
-{{- $packageNames := list -}}
-{{- range . -}}
-  {{- $matches := regexFindAll "^@?[^@]+" . 1 -}}
-  {{- if and $matches (not (hasPrefix "n8n-nodes-" (index $matches 0))) -}}
-    {{- $packageNames = append $packageNames (index $matches 0) -}}
-  {{- end -}}
+{{- define "n8n.isCommunityPackage" -}}
+{{- $pkg := regexReplaceAll "@[^/@]+$" . "" -}}
+{{- $name := $pkg -}}
+{{- if hasPrefix "@" $pkg -}}
+  {{- $name = (splitList "/" $pkg | last) -}}
 {{- end -}}
-{{- join "," $packageNames -}}
+{{- if hasPrefix "n8n-nodes-" $name -}}true{{- end -}}
 {{- end -}}
 
 {{/*
-Filter community packages (starting with n8n-nodes-)
+Filter community packages (starting with n8n-nodes-, also if scoped)
 */}}
 {{- define "n8n.communityPackages" -}}
 {{- $community := list -}}
 {{- range .Values.nodes.external.packages -}}
-{{- if hasPrefix "n8n-nodes-" . -}}
+{{- if include "n8n.isCommunityPackage" . -}}
 {{- $community = append $community . -}}
 {{- end -}}
 {{- end -}}
@@ -312,7 +310,7 @@ Filter non-community packages (as a space-separated string)
 {{- define "n8n.nonCommunityPackages" -}}
 {{- $nonCommunity := list -}}
 {{- range .Values.nodes.external.packages -}}
-{{- if not (hasPrefix "n8n-nodes-" .) -}}
+{{- if not (include "n8n.isCommunityPackage" .) -}}
 {{- $nonCommunity = append $nonCommunity . -}}
 {{- end -}}
 {{- end -}}

--- a/charts/n8n/unittests/deployment_test.yaml
+++ b/charts/n8n/unittests/deployment_test.yaml
@@ -1995,24 +1995,13 @@ tests:
             - "n8n-nodes-python@0.1.4"
             - "n8n-nodes-chatwoot@0.1.40"
     asserts:
-      - equal:
+      - matchRegex:
           path: spec.template.spec.initContainers[?(@.name == "npm-install")].args[0]
-          value: |
-            export PACKAGES="n8n-nodes-python@0.1.4 n8n-nodes-chatwoot@0.1.40"
-            export COMMUNITY_PACKAGES="n8n-nodes-python@0.1.4 n8n-nodes-chatwoot@0.1.40"
-            export NON_COMMUNITY_PACKAGES=""
-            echo "$PACKAGES" | sha256sum > /npmdata/packages.hash.new
-            if [ ! -f /npmdata/packages.hash ] || ! cmp /npmdata/packages.hash /npmdata/packages.hash.new; then
-              if [ -n "$NON_COMMUNITY_PACKAGES" ]; then
-                npm install --loglevel info --no-save --ignore-scripts $NON_COMMUNITY_PACKAGES --prefix /npmdata
-              fi
-              if [ -n "$COMMUNITY_PACKAGES" ]; then
-                npm install --loglevel info --no-save --ignore-scripts $COMMUNITY_PACKAGES --prefix /nodesdata/nodes
-              fi
-              mv /npmdata/packages.hash.new /npmdata/packages.hash
-            else
-              rm /npmdata/packages.hash.new
-            fi
+          pattern: 'export COMMUNITY_PACKAGES="n8n-nodes-python@0\.1\.4 n8n-nodes-chatwoot@0\.1\.40"'
+        template: deployment.yaml
+      - matchRegex:
+          path: spec.template.spec.initContainers[?(@.name == "npm-install")].args[0]
+          pattern: 'export NON_COMMUNITY_PACKAGES=""'
         template: deployment.yaml
   
   - it: should add scoped community packages to install script
@@ -2022,24 +2011,13 @@ tests:
           packages:
             - "@mycompany/n8n-nodes-test@1.0.0"
     asserts:
-      - equal:
+      - matchRegex:
           path: spec.template.spec.initContainers[?(@.name == "npm-install")].args[0]
-          value: |
-            export PACKAGES="@mycompany/n8n-nodes-test@1.0.0"
-            export COMMUNITY_PACKAGES="@mycompany/n8n-nodes-test@1.0.0"
-            export NON_COMMUNITY_PACKAGES=""
-            echo "$PACKAGES" | sha256sum > /npmdata/packages.hash.new
-            if [ ! -f /npmdata/packages.hash ] || ! cmp /npmdata/packages.hash /npmdata/packages.hash.new; then
-              if [ -n "$NON_COMMUNITY_PACKAGES" ]; then
-                npm install --loglevel info --no-save --ignore-scripts $NON_COMMUNITY_PACKAGES --prefix /npmdata
-              fi
-              if [ -n "$COMMUNITY_PACKAGES" ]; then
-                npm install --loglevel info --no-save --ignore-scripts $COMMUNITY_PACKAGES --prefix /nodesdata/nodes
-              fi
-              mv /npmdata/packages.hash.new /npmdata/packages.hash
-            else
-              rm /npmdata/packages.hash.new
-            fi
+          pattern: 'export COMMUNITY_PACKAGES="@mycompany/n8n-nodes-test@1\.0\.0"'
+        template: deployment.yaml
+      - matchRegex:
+          path: spec.template.spec.initContainers[?(@.name == "npm-install")].args[0]
+          pattern: 'export NON_COMMUNITY_PACKAGES=""'
         template: deployment.yaml
   
   - it: should not add non-node packages to community node installer script
@@ -2050,24 +2028,13 @@ tests:
             - "example@2.29.4"
             - "@scope/example@1.0.0"
     asserts:
-      - equal:
+      - matchRegex:
           path: spec.template.spec.initContainers[?(@.name == "npm-install")].args[0]
-          value: |
-            export PACKAGES="example@2.29.4 @scope/example@1.0.0"
-            export COMMUNITY_PACKAGES=""
-            export NON_COMMUNITY_PACKAGES="example@2.29.4 @scope/example@1.0.0"
-            echo "$PACKAGES" | sha256sum > /npmdata/packages.hash.new
-            if [ ! -f /npmdata/packages.hash ] || ! cmp /npmdata/packages.hash /npmdata/packages.hash.new; then
-              if [ -n "$NON_COMMUNITY_PACKAGES" ]; then
-                npm install --loglevel info --no-save --ignore-scripts $NON_COMMUNITY_PACKAGES --prefix /npmdata
-              fi
-              if [ -n "$COMMUNITY_PACKAGES" ]; then
-                npm install --loglevel info --no-save --ignore-scripts $COMMUNITY_PACKAGES --prefix /nodesdata/nodes
-              fi
-              mv /npmdata/packages.hash.new /npmdata/packages.hash
-            else
-              rm /npmdata/packages.hash.new
-            fi
+          pattern: 'export COMMUNITY_PACKAGES=""'
+        template: deployment.yaml
+      - matchRegex:
+          path: spec.template.spec.initContainers[?(@.name == "npm-install")].args[0]
+          pattern: 'export NON_COMMUNITY_PACKAGES="example@2\.29\.4 @scope/example@1\.0\.0"'
         template: deployment.yaml
 
   - it: should only keep npm packages and not community packages when nodes.external.packages is set and taskRunners.mode is internal

--- a/charts/n8n/unittests/deployment_test.yaml
+++ b/charts/n8n/unittests/deployment_test.yaml
@@ -1986,6 +1986,89 @@ tests:
             value: "fs,crypto"
           any: true
         template: deployment.yaml
+  
+  - it: should add unscoped community packages to install script
+    set:
+      nodes:
+        external:
+          packages:
+            - "n8n-nodes-python@0.1.4"
+            - "n8n-nodes-chatwoot@0.1.40"
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name == "npm-install")].args[0]
+          value: |
+            export PACKAGES="n8n-nodes-python@0.1.4 n8n-nodes-chatwoot@0.1.40"
+            export COMMUNITY_PACKAGES="n8n-nodes-python@0.1.4 n8n-nodes-chatwoot@0.1.40"
+            export NON_COMMUNITY_PACKAGES=""
+            echo "$PACKAGES" | sha256sum > /npmdata/packages.hash.new
+            if [ ! -f /npmdata/packages.hash ] || ! cmp /npmdata/packages.hash /npmdata/packages.hash.new; then
+              if [ -n "$NON_COMMUNITY_PACK  AGES" ]; then
+                npm install --loglevel info --no-save --ignore-scripts $NON_COMMUNITY_PACKAGES --prefix /npmdata
+              fi
+              if [ -n "$COMMUNITY_PACKAGES" ]; then
+                npm install --loglevel info --no-save --ignore-scripts $COMMUNITY_PACKAGES --prefix /nodesdata/nodes
+              fi
+              mv /npmdata/packages.hash.new /npmdata/packages.hash
+            else
+              rm /npmdata/packages.hash.new
+            fi
+        template: deployment.yaml
+  
+  - it: should add scoped community packages to install script
+    set:
+      nodes:
+        external:
+          packages:
+            - "@mycompany/custom-n8n-functions@1.0.0"
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name == "npm-install")].args[0]
+          value: |
+            export PACKAGES="@mycompany/custom-n8n-functions@1.0.0"
+            export COMMUNITY_PACKAGES="@mycompany/custom-n8n-functions@1.0.0"
+            export NON_COMMUNITY_PACKAGES=""
+            echo "$PACKAGES" | sha256sum > /npmdata/packages.hash.new
+            if [ ! -f /npmdata/packages.hash ] || ! cmp /npmdata/packages.hash /npmdata/packages.hash.new; then
+              if [ -n "$NON_COMMUNITY_PACKAGES" ]; then
+                npm install --loglevel info --no-save --ignore-scripts $NON_COMMUNITY_PACKAGES --prefix /npmdata
+              fi
+              if [ -n "$COMMUNITY_PACKAGES" ]; then
+                npm install --loglevel info --no-save --ignore-scripts $COMMUNITY_PACKAGES --prefix /nodesdata/nodes
+              fi
+              mv /npmdata/packages.hash.new /npmdata/packages.hash
+            else
+              rm /npmdata/packages.hash.new
+            fi
+        template: deployment.yaml
+  
+  - it: should not add non-node packages to community node installer script
+    set:
+      nodes:
+        external:
+          packages:
+            - "example@2.29.4"
+            - "@scope/example@1.0.0"
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[?(@.name == "npm-install")].args[0]
+          value: |
+            export PACKAGES="example@2.29.4 @scope/example@1.0.0"
+            export COMMUNITY_PACKAGES=""
+            export NON_COMMUNITY_PACKAGES="example@2.29.4 @scope/example@1.0.0"
+            echo "$PACKAGES" | sha256sum > /npmdata/packages.hash.new
+            if [ ! -f /npmdata/packages.hash ] || ! cmp /npmdata/packages.hash /npmdata/packages.hash.new; then
+              if [ -n "$NON_COMMUNITY_PACKAGES" ]; then
+                npm install --loglevel info --no-save --ignore-scripts $NON_COMMUNITY_PACKAGES --prefix /npmdata
+              fi
+              if [ -n "$COMMUNITY_PACKAGES" ]; then
+                npm install --loglevel info --no-save --ignore-scripts $COMMUNITY_PACKAGES --prefix /nodesdata/nodes
+              fi
+              mv /npmdata/packages.hash.new /npmdata/packages.hash
+            else
+              rm /npmdata/packages.hash.new
+            fi
+        template: deployment.yaml
 
   - it: should only keep npm packages and not community packages when nodes.external.packages is set and taskRunners.mode is internal
     set:

--- a/charts/n8n/unittests/deployment_test.yaml
+++ b/charts/n8n/unittests/deployment_test.yaml
@@ -2020,13 +2020,13 @@ tests:
       nodes:
         external:
           packages:
-            - "@mycompany/custom-n8n-functions@1.0.0"
+            - "@mycompany/n8n-nodes-test@1.0.0"
     asserts:
       - equal:
           path: spec.template.spec.initContainers[?(@.name == "npm-install")].args[0]
           value: |
-            export PACKAGES="@mycompany/custom-n8n-functions@1.0.0"
-            export COMMUNITY_PACKAGES="@mycompany/custom-n8n-functions@1.0.0"
+            export PACKAGES="@mycompany/n8n-nodes-test@1.0.0"
+            export COMMUNITY_PACKAGES="@mycompany/n8n-nodes-test@1.0.0"
             export NON_COMMUNITY_PACKAGES=""
             echo "$PACKAGES" | sha256sum > /npmdata/packages.hash.new
             if [ ! -f /npmdata/packages.hash ] || ! cmp /npmdata/packages.hash /npmdata/packages.hash.new; then

--- a/charts/n8n/unittests/deployment_test.yaml
+++ b/charts/n8n/unittests/deployment_test.yaml
@@ -2003,7 +2003,7 @@ tests:
             export NON_COMMUNITY_PACKAGES=""
             echo "$PACKAGES" | sha256sum > /npmdata/packages.hash.new
             if [ ! -f /npmdata/packages.hash ] || ! cmp /npmdata/packages.hash /npmdata/packages.hash.new; then
-              if [ -n "$NON_COMMUNITY_PACK  AGES" ]; then
+              if [ -n "$NON_COMMUNITY_PACKAGES" ]; then
                 npm install --loglevel info --no-save --ignore-scripts $NON_COMMUNITY_PACKAGES --prefix /npmdata
               fi
               if [ -n "$COMMUNITY_PACKAGES" ]; then


### PR DESCRIPTION
<!--
Thank you for contributing to community-charts/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in community-charts/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:
Instead of checking the full package name (including scopes) for the n8n-nodes-Prefix, strip possible scopes and do the check on only the package name.

#### Which issue this PR fixes
- Community nodes can't be installed using the nodes.external-Value, if they live within a scope, because the check classifies them as non-community-packages and installs them at the wrong place.
- fix #241

#### Special notes for your reviewer:
Mention @burakince as chart maintainer

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Chart Version bumped
- [X] Chart `artifacthub.io/changes` field updated (if exists)
- [X] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [ ] `values.yaml` file fields documented
- [x] `README.md` file updated
