### PR TITLE
[outline] Add image digest support and harden security context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a community Helm chart repository hosting production-grade Kubernetes charts for: `actualbudget`, `cloudflared`, `drone`, `kserve`, `mlflow`, `n8n`, `outline`, and `pypiserver`. Charts are published to GitHub Pages via the `chart-releaser` action.
 
-Chart-specific guidance (architecture, external docs, non-obvious patterns) lives in `charts/<name>/CLAUDE.md`. Read that file when working on a specific chart. Charts that currently have one: `actualbudget` (`charts/actualbudget/CLAUDE.md`), `mlflow` (`charts/mlflow/CLAUDE.md`), `n8n` (`charts/n8n/CLAUDE.md`).
+Chart-specific guidance (architecture, external docs, non-obvious patterns) lives in `charts/<name>/CLAUDE.md`. Read that file when working on a specific chart. Charts that currently have one: `actualbudget` (`charts/actualbudget/CLAUDE.md`), `mlflow` (`charts/mlflow/CLAUDE.md`), `n8n` (`charts/n8n/CLAUDE.md`), `outline` (`charts/outline/CLAUDE.md`).
 
 ## Common Commands
 

--- a/charts/outline/.helmignore
+++ b/charts/outline/.helmignore
@@ -26,3 +26,4 @@ unittests/
 
 README.md.gotmpl
 values-kind.yaml
+CLAUDE.md

--- a/charts/outline/CLAUDE.md
+++ b/charts/outline/CLAUDE.md
@@ -1,0 +1,102 @@
+# Outline Chart — Architecture Notes
+
+Official hosting documentation: https://docs.getoutline.com/s/hosting/
+
+## Runtime Environment
+
+- Image: `outlinewiki/outline`, runs as user `nodejs` (UID 1001), workdir `/opt/outline`
+- Entry point: `node build/server/index.js`
+- `readOnlyRootFilesystem: true` — only `/tmp` needs a writable emptyDir volume. File uploads go to `/var/lib/outline/data` only when `fileStorage.mode: local` with persistence enabled, so the `data` PVC mount is conditional on that path.
+
+## Redis URL Duality
+
+Outline accepts two Redis URL formats:
+
+- **Plain:** `redis://host:port` — used when the built-in redis subchart has auth disabled (`redis.enabled=true` AND `redis.auth.enabled=false`). The chart sets `REDIS_URL` directly in the env block.
+- **Advanced:** `ioredis://<base64-JSON>` — required when auth is enabled or when using an external Redis with credentials. `files/entrypoint.sh` constructs this from `REDIS_HOST`, `REDIS_PORT`, `REDIS_USERNAME`, `REDIS_PASSWORD` environment variables and exports `REDIS_URL` before starting the server.
+
+The deployment command is conditionally overridden to `["/bin/bash", "/entrypoint.sh"]` for any case that is NOT (built-in redis + auth disabled). See `templates/deployment.yaml:60-62`.
+
+## OIDC Auth Provider Mutual Exclusivity
+
+Outline uses a single set of `OIDC_*` env vars regardless of which OIDC-compatible provider is chosen. The chart maps these providers through the same variables:
+
+- **gitea** → `OIDC_*` with gitea-specific endpoints
+- **gitlab** → `OIDC_*` with gitlab-specific endpoints
+- **auth0** → `OIDC_*` with auth0-specific endpoints
+- **keycloak** → `OIDC_*` with keycloak realm endpoints (also adds `OIDC_LOGOUT_URI`)
+- **oidc** → `OIDC_*` with manually specified endpoints
+
+These five are implemented as `if / else if / else if / else if / else if` in `templates/secret.yaml:135-192` — enabling more than one will silently use whichever comes first in the chain. Only **one** may be enabled per deployment.
+
+The other auth providers (slack, google, azure, github, discord, saml) are independent and may be combined freely.
+
+## Auto-Generated SECRET_KEY and UTILS_SECRET
+
+`templates/secret.yaml:32-56` uses `helm.sh/hook: pre-install` combined with a `lookup` call to prevent regeneration on `helm upgrade`:
+
+```yaml
+{{- if not (lookup "v1" "Secret" .Release.Namespace $secretName) }}
+```
+
+The secret is only created if it does not already exist. This means:
+- First install: random 64-char hex values are generated and stored.
+- Subsequent upgrades: the existing secret is left untouched.
+- Override: set `secretKey` / `utilsSecret` in values or point to an external secret via `secretKeyExternalSecret` / `utilsSecretExternalSecret`.
+
+## URL Resolution
+
+The `URL` env var is resolved in priority order (`templates/deployment.yaml:96-107`):
+
+1. `values.url` if explicitly set
+2. First ingress host (HTTP or HTTPS based on TLS presence) when `ingress.enabled=true`
+3. Fallback: `http://<fullname>:<port>` using the internal service name
+
+## File Storage
+
+Two modes controlled by `fileStorage.mode`:
+
+- **`local`** (default): Files stored in `FILE_STORAGE_LOCAL_ROOT_DIR` (default `/var/lib/outline/data`). A PVC is mounted at that path only when `fileStorage.local.persistence.enabled=true`. Without persistence, local storage is ephemeral — acceptable for dev but data is lost on pod restart.
+- **`s3`**: Files stored in an S3-compatible bucket. Credentials sourced from the built-in MinIO subchart (when enabled) or from `fileStorage.s3.*` values. When MinIO is enabled with no users configured (`minio.users: []`), the chart auto-creates an `<fullname>-minio` secret and reads `rootUser`/`rootPassword` from it.
+
+## Subcharts
+
+Three optional subcharts: `redis` (Bitnami), `postgresql` (Bitnami), `minio` (MinIO). All three are stored as `.tgz` archives in `charts/`, which causes Trivy's Helm renderer to fail with 0 detections — this is expected behavior and does not indicate the chart is insecure.
+
+## Secret Architecture
+
+`templates/secret.yaml` creates up to 7 Kubernetes Secrets:
+
+| Secret | Condition | Contents |
+|---|---|---|
+| `<fullname>-postgresql` | `!postgresql.enabled && !externalPostgresql.existingSecret` | `postgres-password` |
+| `<fullname>-redis` | `!redis.enabled && !externalRedis.existingSecret` | `redis-username`, `redis-password` |
+| `<fullname>-auto-generated-secret` | `secretKeyExternalSecret.name == "" && utilsSecretExternalSecret.name == ""` | `secret-key`, `utils-secret` |
+| `<fullname>-s3-secret` | `fileStorage.mode == s3 && !fileStorage.s3.existingSecret` | S3 credentials |
+| `<fullname>-auth-secret` | Always | Auth provider env vars (`SLACK_*`, `GOOGLE_*`, `OIDC_*`, etc.) |
+| `<fullname>-smtp-secret` | Always | `SMTP_HOST`, `SMTP_PORT`, `SMTP_FROM_EMAIL`, `SMTP_REPLY_EMAIL`, etc. |
+| `<fullname>-integrations-secret` | Always | Integration env vars (iframely, openAI, gotenberg, sentry, slack, dropbox, linear, notion) |
+
+The auth, smtp, and integrations secrets are always created (even when empty) because the deployment unconditionally references them via `envFrom`.
+
+## KubeLinter Annotation
+
+The deployment carries a `read-secret-from-env-var` suppression at the object level:
+
+```yaml
+metadata:
+  annotations:
+    ignore-check.kube-linter.io/read-secret-from-env-var: "Outline reads secrets via environment variables; the application does not support file-based secret loading"
+```
+
+This is intentional — Outline does not support reading secrets from mounted files.
+
+## Database Connection
+
+PostgreSQL connection is constructed from individual `PG*` env vars then assembled into `DATABASE_URL`:
+
+```
+postgres://$(PGUSER):$(PGPASSWORD)@$(PGHOST):$(PGPORT)/$(PGDATABASE)
+```
+
+This allows Kubernetes to resolve `secretKeyRef` for `PGPASSWORD` before the composite value is expanded at runtime.

--- a/charts/outline/Chart.yaml
+++ b/charts/outline/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1
+version: 0.9.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -52,6 +52,10 @@ annotations:
       url: https://docs.getoutline.com/s/hosting/
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
+    - kind: added
+      description: Add optional image digest support for immutable image pulls
+    - kind: fixed
+      description: Enable readOnlyRootFilesystem and add built-in tmp emptyDir volume
     - kind: changed
       description: Update outlinewiki/outline image version to 1.8.1
       links:

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for the fastest knowledge base for growing teams. Beautiful, realtime collaborative, feature packed, and markdown compatible.
 
-![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.1](https://img.shields.io/badge/AppVersion-1.8.1-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.1](https://img.shields.io/badge/AppVersion-1.8.1-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -711,7 +711,8 @@ helm upgrade [RELEASE_NAME] community-charts/outline
 | fileStorage.workspaceImportMaxSize | string | `""` | This is for setting up the file storage workspace import max size. |
 | fullnameOverride | string | `""` | This is to override the full name of the chart. |
 | hostAliases | list | `[]` | Host aliases for the pod. For more information checkout: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/#adding-additional-entries-with-hostaliases |
-| image | object | `{"pullPolicy":"IfNotPresent","repository":"outlinewiki/outline","tag":""}` | This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/ |
+| image | object | `{"digest":"","pullPolicy":"IfNotPresent","repository":"outlinewiki/outline","tag":""}` | This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/ |
+| image.digest | string | `""` | Image digest in the format sha256:<hex>. When set, overrides the tag for immutable pulls. |
 | image.pullPolicy | string | `"IfNotPresent"` | This sets the pull policy for images. |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
@@ -865,7 +866,7 @@ helm upgrade [RELEASE_NAME] community-charts/outline
 | secretKeyExternalSecret | object | `{"key":"secret-key","name":""}` | This is for setting up the secret key external secret. |
 | secretKeyExternalSecret.key | string | `"secret-key"` | This is for setting up the secret key external secret key. |
 | secretKeyExternalSecret.name | string | `""` | This is for setting up the secret key external secret name. |
-| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":false,"runAsGroup":1001,"runAsNonRoot":true,"runAsUser":1001}` | This is for setting Security Context to a Container. For more information checkout: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true,"runAsGroup":1001,"runAsNonRoot":true,"runAsUser":1001}` | This is for setting Security Context to a Container. For more information checkout: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
 | service | object | `{"annotations":{},"enabled":true,"name":"http","port":3000,"type":"ClusterIP"}` | This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/ |
 | service.annotations | object | `{}` | Additional service annotations |
 | service.enabled | bool | `true` | This sets the service enabled. |

--- a/charts/outline/templates/_helpers.tpl
+++ b/charts/outline/templates/_helpers.tpl
@@ -149,6 +149,18 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Build the full container image reference, appending digest when set.
+*/}}
+{{- define "outline.containerImage" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s:%s@%s" .Values.image.repository $tag .Values.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Generate random hex similar to `openssl rand -hex 32` command.
 Usage: {{ include "outline.generateRandomHex" 64 }}
 */}}

--- a/charts/outline/templates/deployment.yaml
+++ b/charts/outline/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "outline.containerImage" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
           {{- if not (and .Values.redis.enabled (not .Values.redis.auth.enabled)) }}
           command: ["/bin/bash", "/entrypoint.sh"]
@@ -408,6 +408,8 @@ spec:
                 name: {{ . }}
           {{- end }}
           volumeMounts:
+            - name: tmp
+              mountPath: /tmp
             - name: entrypoint-volume
               mountPath: /entrypoint.sh
               subPath: entrypoint.sh
@@ -422,6 +424,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        - name: tmp
+          emptyDir: {}
         - name: entrypoint-volume
           configMap:
             name: {{ template "outline.fullname" . }}-entrypoint

--- a/charts/outline/unittests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/outline/unittests/__snapshot__/deployment_test.yaml.snap
@@ -180,11 +180,13 @@ should match snapshot of default values:
                   drop:
                     - ALL
                 privileged: false
-                readOnlyRootFilesystem: false
+                readOnlyRootFilesystem: true
                 runAsGroup: 1001
                 runAsNonRoot: true
                 runAsUser: 1001
               volumeMounts:
+                - mountPath: /tmp
+                  name: tmp
                 - mountPath: /entrypoint.sh
                   name: entrypoint-volume
                   subPath: entrypoint.sh
@@ -193,6 +195,8 @@ should match snapshot of default values:
             fsGroupChangePolicy: OnRootMismatch
           serviceAccountName: outline
           volumes:
+            - emptyDir: {}
+              name: tmp
             - configMap:
                 defaultMode: 493
                 name: outline-entrypoint

--- a/charts/outline/unittests/deployment_test.yaml
+++ b/charts/outline/unittests/deployment_test.yaml
@@ -144,6 +144,33 @@ tests:
           value: fake-image-repository/fake-image:fake-tag
         template: deployment.yaml
 
+  - it: should add digest to image tag when digest is set
+    set:
+      image:
+        digest: "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+    chart:
+      appVersion: 1.8.1
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "outline")].image
+          value: "outlinewiki/outline:1.8.1@sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+        template: deployment.yaml
+
+  - it: should always have a tmp emptyDir volume and mount
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tmp
+            emptyDir: {}
+        template: deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "outline")].volumeMounts
+          content:
+            name: tmp
+            mountPath: /tmp
+        template: deployment.yaml
+
   - it: should use default image and chart app version as image tag when tag is not set
     set:
       image:

--- a/charts/outline/values.schema.json
+++ b/charts/outline/values.schema.json
@@ -41,12 +41,21 @@
           "required": [],
           "title": "tag",
           "type": "string"
+        },
+        "digest": {
+          "default": "",
+          "description": "Image digest in the format sha256:<hex>. When set, overrides the tag for immutable pulls.",
+          "pattern": "^(sha256:[a-f0-9]{64})?$",
+          "required": [],
+          "title": "digest",
+          "type": "string"
         }
       },
       "required": [
         "repository",
         "pullPolicy",
-        "tag"
+        "tag",
+        "digest"
       ],
       "title": "image",
       "type": "object"

--- a/charts/outline/values.yaml
+++ b/charts/outline/values.yaml
@@ -13,6 +13,8 @@ image:
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.
   tag: ""
+  # -- Image digest in the format sha256:<hex>. When set, overrides the tag for immutable pulls.
+  digest: ""
 
 # -- This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
@@ -65,7 +67,7 @@ securityContext:
   capabilities:
     drop:
       - ALL
-  readOnlyRootFilesystem: false
+  readOnlyRootFilesystem: true
   runAsNonRoot: true
   privileged: false
   runAsUser: 1001


### PR DESCRIPTION
#### What this PR does / why we need it:

- Adds optional `image.digest` field (pattern: `sha256:[a-f0-9]{64}`) so the image can be pinned to an immutable digest for production deployments.
- Enables `readOnlyRootFilesystem: true` in the default security context and adds a built-in `tmp` emptyDir volume/mount for `/tmp`.
- Adds `charts/outline/CLAUDE.md` with architecture notes covering the Redis URL duality, OIDC auth mutual exclusivity, auto-generated secret lifecycle, and more.
- Adds `CLAUDE.md` to `charts/outline/.helmignore` so it is excluded from packaged tarballs.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

- `readOnlyRootFilesystem: true` was verified by running the chart against a colima cluster — outline starts cleanly, runs migrations, and listens on port 3000 with no EROFS errors.
- The outline Docker image (`outlinewiki/outline`) only writes to `/tmp` at startup. The `/var/lib/outline/data` path is only written when `fileStorage.mode: local` with persistence enabled, so the `data` mount remains conditional on that path rather than always using an emptyDir.
- Subcharts are stored as `.tgz` archives, which causes Trivy's Helm renderer to return 0 findings — this is existing, expected behaviour and does not indicate a regression.

#### Checklist
- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[outline]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated