### PR TITLE
[n8n] Update n8n chart to 2.26.9

### DIFF
--- a/charts/n8n/Chart.lock
+++ b/charts/n8n/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 27.0.10
+  version: 27.0.12
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 18.7.6
+  version: 18.7.7
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:1fb3665164ebb0e8af5900e05c8ac35ea9e3b70c5eba66a00d71e522344a780a
-generated: "2026-06-19T02:48:32.259807229Z"
+digest: sha256:a71b230760da474c5a088ab8ea4e3a729ca9540321105a4f90900339dd258588
+generated: "2026-06-23T02:45:54.069234248Z"

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.23.1
+version: 1.23.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.26.8"
+appVersion: "2.26.9"
 kubeVersion: ">=1.23.0-0"
 home: https://n8n.io
 maintainers:
@@ -51,20 +51,28 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update n8nio/n8n image version to 2.26.8
+      description: Update n8nio/n8n image version to 2.26.9
       links:
         - name: Upstream Project
           url: https://github.com/n8n-io/n8n
-    - kind: fixed
-      description: Fix broken screenshot URL(s) in n8n chart
+    - kind: changed
+      description: Update dependency redis from 27.0.10 to 27.0.12
+      links:
+        - name: ArtifactHub
+          url: https://artifacthub.io/packages/helm/bitnami/redis
+    - kind: changed
+      description: Update dependency postgresql from 18.7.6 to 18.7.7
+      links:
+        - name: ArtifactHub
+          url: https://artifacthub.io/packages/helm/bitnami/postgresql
   artifacthub.io/images: |
     - name: n8n
-      image: n8nio/n8n:2.26.8
+      image: n8nio/n8n:2.26.9
       platforms:
         - linux/amd64
         - linux/arm64
     - name: n8n-runners
-      image: n8nio/runners:2.26.8
+      image: n8nio/runners:2.26.9
       platforms:
         - linux/amd64
         - linux/arm64
@@ -90,11 +98,11 @@ annotations:
     url: https://keybase.io/communitycharts/pgp_keys.asc
 dependencies:
   - name: redis
-    version: 27.0.10
+    version: 27.0.12
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: postgresql
-    version: 18.7.6
+    version: 18.7.7
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: minio

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.23.1](https://img.shields.io/badge/Version-1.23.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.26.8](https://img.shields.io/badge/AppVersion-2.26.8-informational?style=flat-square)
+![Version: 1.23.2](https://img.shields.io/badge/Version-1.23.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.26.9](https://img.shields.io/badge/AppVersion-2.26.9-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -1348,8 +1348,8 @@ Kubernetes: `>=1.23.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 18.7.6 |
-| https://charts.bitnami.com/bitnami | redis | 27.0.10 |
+| https://charts.bitnami.com/bitnami | postgresql | 18.7.7 |
+| https://charts.bitnami.com/bitnami | redis | 27.0.12 |
 | https://charts.min.io/ | minio | 5.4.0 |
 
 ## Uninstall Helm Chart


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the n8n chart to use the latest image version 2.26.9 from n8nio/n8n. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated