### PR TITLE
feat(n8n): add taskRunners.external.existingSecret for external task runner tokens

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.24.27
+version: 1.25.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -50,11 +50,11 @@ annotations:
       url: https://docs.n8n.io/
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
-    - kind: changed
-      description: Update n8nio/n8n image version to 2.34.5
+    - kind: added
+      description: Add taskRunners.external.existingSecret to source external task runner auth tokens from a pre-existing Secret instead of chart-generated random tokens
       links:
-        - name: Upstream Project
-          url: https://github.com/n8n-io/n8n
+        - name: GitHub PR
+          url: https://github.com/community-charts/helm-charts/pull/525
   artifacthub.io/images: |
     - name: n8n
       image: n8nio/n8n:2.34.5

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.24.37
+version: 1.25.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -50,21 +50,11 @@ annotations:
       url: https://docs.n8n.io/
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
-    - kind: changed
-      description: Update n8nio/n8n image version to 2.37.9
+    - kind: added
+      description: Add taskRunners.external.existingSecret to source external task runner auth tokens from a pre-existing Secret instead of chart-generated random tokens
       links:
-        - name: Upstream Project
-          url: https://github.com/n8n-io/n8n
-    - kind: changed
-      description: Update dependency redis from 28.0.12 to 28.0.15
-      links:
-        - name: ArtifactHub
-          url: https://artifacthub.io/packages/helm/bitnami/redis
-    - kind: changed
-      description: Update dependency postgresql from 18.8.14 to 18.8.17
-      links:
-        - name: ArtifactHub
-          url: https://artifacthub.io/packages/helm/bitnami/postgresql
+        - name: GitHub PR
+          url: https://github.com/community-charts/helm-charts/pull/525
   artifacthub.io/images: |
     - name: n8n
       image: n8nio/n8n:2.37.9

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.24.27](https://img.shields.io/badge/Version-1.24.27-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.34.5](https://img.shields.io/badge/AppVersion-2.34.5-informational?style=flat-square)
+![Version: 1.25.0](https://img.shields.io/badge/Version-1.25.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.34.5](https://img.shields.io/badge/AppVersion-2.34.5-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -1717,17 +1717,20 @@ helm upgrade [RELEASE_NAME] community-charts/n8n
 | serviceMonitor.targetLabels | list | `[]` | Set of labels to transfer on the Kubernetes Service onto the target. |
 | serviceMonitor.timeout | string | `"10s"` | Set timeout for scrape |
 | strategy | object | `{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"}` | This will set the deployment strategy more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |
-| taskRunners | object | `{"broker":{"address":"127.0.0.1","port":5679},"external":{"autoShutdownTimeout":15,"image":{"pullPolicy":"IfNotPresent","repository":"n8nio/runners","tag":""},"mainNodeAuthToken":"","nodeOptions":["--max-semi-space-size=16","--max-old-space-size=300"],"port":5680,"resources":{"limits":{"cpu":"2000m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"32Mi"}},"workerNodeAuthToken":""},"maxConcurrency":5,"mode":"internal","taskHeartbeatInterval":30,"taskTimeout":60}` | Task runners mode. Please follow the documentation for more information: https://docs.n8n.io/hosting/configuration/task-runners/ |
+| taskRunners | object | `{"broker":{"address":"127.0.0.1","port":5679},"external":{"autoShutdownTimeout":15,"existingSecret":"","existingSecretAuthTokenKey":"auth-token","existingSecretWorkerAuthTokenKey":"worker-auth-token","image":{"pullPolicy":"IfNotPresent","repository":"n8nio/runners","tag":""},"mainNodeAuthToken":"","nodeOptions":["--max-semi-space-size=16","--max-old-space-size=300"],"port":5680,"resources":{"limits":{"cpu":"2000m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"32Mi"}},"workerNodeAuthToken":""},"maxConcurrency":5,"mode":"internal","taskHeartbeatInterval":30,"taskTimeout":60}` | Task runners mode. Please follow the documentation for more information: https://docs.n8n.io/hosting/configuration/task-runners/ |
 | taskRunners.broker | object | `{"address":"127.0.0.1","port":5679}` | The address for the broker of the external task runner |
 | taskRunners.broker.address | string | `"127.0.0.1"` | The address for the broker of the external task runner |
 | taskRunners.broker.port | int | `5679` | The port for the broker of the external task runner |
-| taskRunners.external | object | `{"autoShutdownTimeout":15,"image":{"pullPolicy":"IfNotPresent","repository":"n8nio/runners","tag":""},"mainNodeAuthToken":"","nodeOptions":["--max-semi-space-size=16","--max-old-space-size=300"],"port":5680,"resources":{"limits":{"cpu":"2000m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"32Mi"}},"workerNodeAuthToken":""}` | The configuration for the external task runner |
+| taskRunners.external | object | `{"autoShutdownTimeout":15,"existingSecret":"","existingSecretAuthTokenKey":"auth-token","existingSecretWorkerAuthTokenKey":"worker-auth-token","image":{"pullPolicy":"IfNotPresent","repository":"n8nio/runners","tag":""},"mainNodeAuthToken":"","nodeOptions":["--max-semi-space-size=16","--max-old-space-size=300"],"port":5680,"resources":{"limits":{"cpu":"2000m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"32Mi"}},"workerNodeAuthToken":""}` | The configuration for the external task runner |
 | taskRunners.external.autoShutdownTimeout | int | `15` | The auto shutdown timeout for the external task runner in seconds |
+| taskRunners.external.existingSecret | string | `""` | The name of an existing Secret holding the task runner auth tokens. When set, the chart does not create its own task runner Secret and `mainNodeAuthToken`/`workerNodeAuthToken` are ignored. Useful to manage the tokens out-of-band (e.g. a secrets manager) and avoid the chart regenerating them on every render. |
+| taskRunners.external.existingSecretAuthTokenKey | string | `"auth-token"` | The key in `existingSecret` that stores the main node auth token. |
+| taskRunners.external.existingSecretWorkerAuthTokenKey | string | `"worker-auth-token"` | The key in `existingSecret` that stores the worker node auth token. |
 | taskRunners.external.image | object | `{"pullPolicy":"IfNotPresent","repository":"n8nio/runners","tag":""}` | The image for the external task runner sidecar. Tag must match the n8n appVersion. |
 | taskRunners.external.image.pullPolicy | string | `"IfNotPresent"` | This sets the pull policy for images. |
 | taskRunners.external.image.repository | string | `"n8nio/runners"` | The repository for the external task runner image |
 | taskRunners.external.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
-| taskRunners.external.mainNodeAuthToken | string | `""` | The auth token for the main node |
+| taskRunners.external.mainNodeAuthToken | string | `""` | The auth token for the main node. Ignored when `existingSecret` is set. |
 | taskRunners.external.nodeOptions | list | `["--max-semi-space-size=16","--max-old-space-size=300"]` | The node options for the external task runner |
 | taskRunners.external.port | int | `5680` | The port for the external task runner |
 | taskRunners.external.resources | object | `{"limits":{"cpu":"2000m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"32Mi"}}` | The resources for the external task runner |
@@ -1737,7 +1740,7 @@ helm upgrade [RELEASE_NAME] community-charts/n8n
 | taskRunners.external.resources.requests | object | `{"cpu":"100m","memory":"32Mi"}` | The resources requests for the external task runner |
 | taskRunners.external.resources.requests.cpu | string | `"100m"` | The CPU request for the external task runner |
 | taskRunners.external.resources.requests.memory | string | `"32Mi"` | The memory request for the external task runner |
-| taskRunners.external.workerNodeAuthToken | string | `""` | The auth token for the worker node |
+| taskRunners.external.workerNodeAuthToken | string | `""` | The auth token for the worker node. Ignored when `existingSecret` is set. |
 | taskRunners.maxConcurrency | int | `5` | The maximum concurrency for the task |
 | taskRunners.mode | string | `"internal"` | Use `internal` to use internal task runner, or use `external` to have external sidecar task runner. For more information please follow the documentation: https://docs.n8n.io/hosting/configuration/task-runners/#task-runner-modes |
 | taskRunners.taskHeartbeatInterval | int | `30` | The heartbeat interval for the task in seconds |

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.24.37](https://img.shields.io/badge/Version-1.24.37-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.37.9](https://img.shields.io/badge/AppVersion-2.37.9-informational?style=flat-square)
+![Version: 1.25.0](https://img.shields.io/badge/Version-1.25.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.37.9](https://img.shields.io/badge/AppVersion-2.37.9-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -1717,17 +1717,20 @@ helm upgrade [RELEASE_NAME] community-charts/n8n
 | serviceMonitor.targetLabels | list | `[]` | Set of labels to transfer on the Kubernetes Service onto the target. |
 | serviceMonitor.timeout | string | `"10s"` | Set timeout for scrape |
 | strategy | object | `{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"}` | This will set the deployment strategy more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |
-| taskRunners | object | `{"broker":{"address":"127.0.0.1","port":5679},"external":{"autoShutdownTimeout":15,"image":{"pullPolicy":"IfNotPresent","repository":"n8nio/runners","tag":""},"mainNodeAuthToken":"","nodeOptions":["--max-semi-space-size=16","--max-old-space-size=300"],"port":5680,"resources":{"limits":{"cpu":"2000m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"32Mi"}},"workerNodeAuthToken":""},"maxConcurrency":5,"mode":"internal","taskHeartbeatInterval":30,"taskTimeout":60}` | Task runners mode. Please follow the documentation for more information: https://docs.n8n.io/hosting/configuration/task-runners/ |
+| taskRunners | object | `{"broker":{"address":"127.0.0.1","port":5679},"external":{"autoShutdownTimeout":15,"existingSecret":"","existingSecretAuthTokenKey":"auth-token","existingSecretWorkerAuthTokenKey":"worker-auth-token","image":{"pullPolicy":"IfNotPresent","repository":"n8nio/runners","tag":""},"mainNodeAuthToken":"","nodeOptions":["--max-semi-space-size=16","--max-old-space-size=300"],"port":5680,"resources":{"limits":{"cpu":"2000m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"32Mi"}},"workerNodeAuthToken":""},"maxConcurrency":5,"mode":"internal","taskHeartbeatInterval":30,"taskTimeout":60}` | Task runners mode. Please follow the documentation for more information: https://docs.n8n.io/hosting/configuration/task-runners/ |
 | taskRunners.broker | object | `{"address":"127.0.0.1","port":5679}` | The address for the broker of the external task runner |
 | taskRunners.broker.address | string | `"127.0.0.1"` | The address for the broker of the external task runner |
 | taskRunners.broker.port | int | `5679` | The port for the broker of the external task runner |
-| taskRunners.external | object | `{"autoShutdownTimeout":15,"image":{"pullPolicy":"IfNotPresent","repository":"n8nio/runners","tag":""},"mainNodeAuthToken":"","nodeOptions":["--max-semi-space-size=16","--max-old-space-size=300"],"port":5680,"resources":{"limits":{"cpu":"2000m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"32Mi"}},"workerNodeAuthToken":""}` | The configuration for the external task runner |
+| taskRunners.external | object | `{"autoShutdownTimeout":15,"existingSecret":"","existingSecretAuthTokenKey":"auth-token","existingSecretWorkerAuthTokenKey":"worker-auth-token","image":{"pullPolicy":"IfNotPresent","repository":"n8nio/runners","tag":""},"mainNodeAuthToken":"","nodeOptions":["--max-semi-space-size=16","--max-old-space-size=300"],"port":5680,"resources":{"limits":{"cpu":"2000m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"32Mi"}},"workerNodeAuthToken":""}` | The configuration for the external task runner |
 | taskRunners.external.autoShutdownTimeout | int | `15` | The auto shutdown timeout for the external task runner in seconds |
+| taskRunners.external.existingSecret | string | `""` | The name of an existing Secret holding the task runner auth tokens. When set, the chart does not create its own task runner Secret and `mainNodeAuthToken`/`workerNodeAuthToken` are ignored. Useful to manage the tokens out-of-band (e.g. a secrets manager) and avoid the chart regenerating them on every render. |
+| taskRunners.external.existingSecretAuthTokenKey | string | `"auth-token"` | The key in `existingSecret` that stores the main node auth token. |
+| taskRunners.external.existingSecretWorkerAuthTokenKey | string | `"worker-auth-token"` | The key in `existingSecret` that stores the worker node auth token. |
 | taskRunners.external.image | object | `{"pullPolicy":"IfNotPresent","repository":"n8nio/runners","tag":""}` | The image for the external task runner sidecar. Tag must match the n8n appVersion. |
 | taskRunners.external.image.pullPolicy | string | `"IfNotPresent"` | This sets the pull policy for images. |
 | taskRunners.external.image.repository | string | `"n8nio/runners"` | The repository for the external task runner image |
 | taskRunners.external.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
-| taskRunners.external.mainNodeAuthToken | string | `""` | The auth token for the main node |
+| taskRunners.external.mainNodeAuthToken | string | `""` | The auth token for the main node. Ignored when `existingSecret` is set. |
 | taskRunners.external.nodeOptions | list | `["--max-semi-space-size=16","--max-old-space-size=300"]` | The node options for the external task runner |
 | taskRunners.external.port | int | `5680` | The port for the external task runner |
 | taskRunners.external.resources | object | `{"limits":{"cpu":"2000m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"32Mi"}}` | The resources for the external task runner |
@@ -1737,7 +1740,7 @@ helm upgrade [RELEASE_NAME] community-charts/n8n
 | taskRunners.external.resources.requests | object | `{"cpu":"100m","memory":"32Mi"}` | The resources requests for the external task runner |
 | taskRunners.external.resources.requests.cpu | string | `"100m"` | The CPU request for the external task runner |
 | taskRunners.external.resources.requests.memory | string | `"32Mi"` | The memory request for the external task runner |
-| taskRunners.external.workerNodeAuthToken | string | `""` | The auth token for the worker node |
+| taskRunners.external.workerNodeAuthToken | string | `""` | The auth token for the worker node. Ignored when `existingSecret` is set. |
 | taskRunners.maxConcurrency | int | `5` | The maximum concurrency for the task |
 | taskRunners.mode | string | `"internal"` | Use `internal` to use internal task runner, or use `external` to have external sidecar task runner. For more information please follow the documentation: https://docs.n8n.io/hosting/configuration/task-runners/#task-runner-modes |
 | taskRunners.taskHeartbeatInterval | int | `30` | The heartbeat interval for the task in seconds |

--- a/charts/n8n/templates/deployment-worker.yaml
+++ b/charts/n8n/templates/deployment-worker.yaml
@@ -216,8 +216,8 @@ spec:
             - name: N8N_RUNNERS_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "n8n.taskRunners.fullname" . }}-secret
-                  key: worker-auth-token
+                  name: {{ default (printf "%s-secret" (include "n8n.taskRunners.fullname" .)) .Values.taskRunners.external.existingSecret }}
+                  key: {{ .Values.taskRunners.external.existingSecretWorkerAuthTokenKey }}
           {{- end }}
           {{- if has "s3" .Values.binaryData.availableModes }}
             - name: N8N_EXTERNAL_STORAGE_S3_ACCESS_KEY
@@ -375,8 +375,8 @@ spec:
             - name: N8N_RUNNERS_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "n8n.taskRunners.fullname" . }}-secret
-                  key: worker-auth-token
+                  name: {{ default (printf "%s-secret" (include "n8n.taskRunners.fullname" .)) .Values.taskRunners.external.existingSecret }}
+                  key: {{ .Values.taskRunners.external.existingSecretWorkerAuthTokenKey }}
           {{- if .Values.nodes.builtin.enabled }}
             - name: NODE_FUNCTION_ALLOW_BUILTIN
               value: {{ if .Values.nodes.builtin.modules }}{{ join "," .Values.nodes.builtin.modules }}{{ else }}"*"{{ end }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -190,8 +190,8 @@ spec:
             - name: N8N_RUNNERS_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "n8n.taskRunners.fullname" . }}-secret
-                  key: auth-token
+                  name: {{ default (printf "%s-secret" (include "n8n.taskRunners.fullname" .)) .Values.taskRunners.external.existingSecret }}
+                  key: {{ .Values.taskRunners.external.existingSecretAuthTokenKey }}
           {{- end }}
           {{- if gt (int .Values.main.count) 1 }}
             - name: N8N_MULTI_MAIN_SETUP_ENABLED
@@ -359,8 +359,8 @@ spec:
             - name: N8N_RUNNERS_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "n8n.taskRunners.fullname" . }}-secret
-                  key: auth-token
+                  name: {{ default (printf "%s-secret" (include "n8n.taskRunners.fullname" .)) .Values.taskRunners.external.existingSecret }}
+                  key: {{ .Values.taskRunners.external.existingSecretAuthTokenKey }}
           {{- if .Values.nodes.builtin.enabled }}
             - name: NODE_FUNCTION_ALLOW_BUILTIN
               value: {{ if .Values.nodes.builtin.modules }}{{ join "," .Values.nodes.builtin.modules }}{{ else }}"*"{{ end }}

--- a/charts/n8n/templates/secret.yaml
+++ b/charts/n8n/templates/secret.yaml
@@ -61,7 +61,7 @@ data:
   redis-username: {{ .Values.externalRedis.username | default "default" | b64enc | quote }}
   redis-password: {{ .Values.externalRedis.password | b64enc | quote }}
 {{- end }}
-{{- if eq .Values.taskRunners.mode "external" }}
+{{- if and (eq .Values.taskRunners.mode "external") (not .Values.taskRunners.external.existingSecret) }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/n8n/templates/statefulset-worker.yaml
+++ b/charts/n8n/templates/statefulset-worker.yaml
@@ -200,8 +200,8 @@ spec:
             - name: N8N_RUNNERS_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "n8n.taskRunners.fullname" . }}-secret
-                  key: worker-auth-token
+                  name: {{ default (printf "%s-secret" (include "n8n.taskRunners.fullname" .)) .Values.taskRunners.external.existingSecret }}
+                  key: {{ .Values.taskRunners.external.existingSecretWorkerAuthTokenKey }}
           {{- end }}
           {{- if has "s3" .Values.binaryData.availableModes }}
             - name: N8N_EXTERNAL_STORAGE_S3_ACCESS_KEY
@@ -359,8 +359,8 @@ spec:
             - name: N8N_RUNNERS_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "n8n.taskRunners.fullname" . }}-secret
-                  key: worker-auth-token
+                  name: {{ default (printf "%s-secret" (include "n8n.taskRunners.fullname" .)) .Values.taskRunners.external.existingSecret }}
+                  key: {{ .Values.taskRunners.external.existingSecretWorkerAuthTokenKey }}
           {{- if .Values.nodes.builtin.enabled }}
             - name: NODE_FUNCTION_ALLOW_BUILTIN
               value: {{ if .Values.nodes.builtin.modules }}{{ join "," .Values.nodes.builtin.modules }}{{ else }}"*"{{ end }}

--- a/charts/n8n/templates/statefulset.yaml
+++ b/charts/n8n/templates/statefulset.yaml
@@ -178,8 +178,8 @@ spec:
             - name: N8N_RUNNERS_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "n8n.taskRunners.fullname" . }}-secret
-                  key: auth-token
+                  name: {{ default (printf "%s-secret" (include "n8n.taskRunners.fullname" .)) .Values.taskRunners.external.existingSecret }}
+                  key: {{ .Values.taskRunners.external.existingSecretAuthTokenKey }}
           {{- end }}
           {{- if gt (int .Values.main.count) 1 }}
             - name: N8N_MULTI_MAIN_SETUP_ENABLED
@@ -347,8 +347,8 @@ spec:
             - name: N8N_RUNNERS_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "n8n.taskRunners.fullname" . }}-secret
-                  key: auth-token
+                  name: {{ default (printf "%s-secret" (include "n8n.taskRunners.fullname" .)) .Values.taskRunners.external.existingSecret }}
+                  key: {{ .Values.taskRunners.external.existingSecretAuthTokenKey }}
           {{- if .Values.nodes.builtin.enabled }}
             - name: NODE_FUNCTION_ALLOW_BUILTIN
               value: {{ if .Values.nodes.builtin.modules }}{{ join "," .Values.nodes.builtin.modules }}{{ else }}"*"{{ end }}

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -4500,6 +4500,27 @@
         "external": {
           "additionalProperties": false,
           "properties": {
+            "existingSecret": {
+              "default": "",
+              "description": "The name of an existing Secret holding the task runner auth tokens. When set, the chart does not create its own task runner Secret and mainNodeAuthToken/workerNodeAuthToken are ignored",
+              "required": [],
+              "title": "existingSecret",
+              "type": "string"
+            },
+            "existingSecretAuthTokenKey": {
+              "default": "auth-token",
+              "description": "The key in existingSecret that stores the main node auth token",
+              "required": [],
+              "title": "existingSecretAuthTokenKey",
+              "type": "string"
+            },
+            "existingSecretWorkerAuthTokenKey": {
+              "default": "worker-auth-token",
+              "description": "The key in existingSecret that stores the worker node auth token",
+              "required": [],
+              "title": "existingSecretWorkerAuthTokenKey",
+              "type": "string"
+            },
             "mainNodeAuthToken": {
               "default": "",
               "description": "This sets the auth token for the n8n main node of the external task runner",

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -942,9 +942,15 @@ taskRunners:
 
   # -- The configuration for the external task runner
   external:
-    # -- The auth token for the main node
+    # -- The name of an existing Secret holding the task runner auth tokens. When set, the chart does not create its own task runner Secret and `mainNodeAuthToken`/`workerNodeAuthToken` are ignored. Useful to manage the tokens out-of-band (e.g. a secrets manager) and avoid the chart regenerating them on every render.
+    existingSecret: ""
+    # -- The key in `existingSecret` that stores the main node auth token.
+    existingSecretAuthTokenKey: "auth-token"
+    # -- The key in `existingSecret` that stores the worker node auth token.
+    existingSecretWorkerAuthTokenKey: "worker-auth-token"
+    # -- The auth token for the main node. Ignored when `existingSecret` is set.
     mainNodeAuthToken: ""
-    # -- The auth token for the worker node
+    # -- The auth token for the worker node. Ignored when `existingSecret` is set.
     workerNodeAuthToken: ""
     # -- The auto shutdown timeout for the external task runner in seconds
     autoShutdownTimeout: 15


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a `taskRunners.external.existingSecret` option so the external task runner auth tokens can be sourced from a pre-existing Secret instead of being generated by the chart.

Today, when `taskRunners.mode=external` and `mainNodeAuthToken`/`workerNodeAuthToken` are left empty, the chart generates the `auth-token`/`worker-auth-token` values with `generateRandomHex` on **every render** (there is no `lookup`-based retention, unlike the encryption-key Secret in the same template). Under GitOps tooling (Argo CD, Flux) this produces a permanent diff on the task runner Secret — every sync rewrites the tokens and restarts the runner sidecars.

This mirrors the existing `externalRedis.existingSecret` / `externalPostgresql.existingSecret` pattern already in the chart:

- When `existingSecret` is set, `secret.yaml` no longer renders the chart-managed task runner Secret, and the main/worker workloads reference the provided Secret via `secretKeyRef`.
- `existingSecretAuthTokenKey` / `existingSecretWorkerAuthTokenKey` default to the current `auth-token` / `worker-auth-token` keys, so default behavior is unchanged.

#### Which issue this PR fixes
  - fixes #

#### Special notes for your reviewer:

- Default behavior is fully backward compatible — with `existingSecret` unset, the chart still generates the Secret and the consumers reference the same name/keys as before.
- Updated `values.yaml`, `values.schema.json`, regenerated `README.md` (helm-docs), and bumped the chart `version` + `artifacthub.io/changes`.
- Verified with `helm template` across: default external mode, `existingSecret` set, custom key overrides, and the worker queue path (postgres + queue) — all consumers (main deployment/statefulset, worker deployment/statefulset, runner sidecars) correctly switch to the provided Secret and the chart-managed Secret is suppressed.

#### Checklist
- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
