### PR TITLE
[n8n] Update n8n chart to 2.27.5

### DIFF
--- a/charts/n8n/Chart.lock
+++ b/charts/n8n/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 27.0.12
+  version: 27.0.13
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 18.7.8
+  version: 18.7.9
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:adc10c621359d4e0c33c7bfe080ab5f6e074ad94b08a29492c424bcd0a49a82a
-generated: "2026-06-24T02:45:27.623382351Z"
+digest: sha256:4c1c3e64bd9c662a68d36d0589c8f0861d963d807163bdb8150cfdc984bd364e
+generated: "2026-06-30T02:52:18.028853551Z"

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.24.0
+version: 1.24.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.27.4"
+appVersion: "2.27.5"
 kubeVersion: ">=1.23.0-0"
 home: https://n8n.io
 maintainers:
@@ -50,26 +50,29 @@ annotations:
       url: https://docs.n8n.io/
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
-    - kind: added
-      description: Add log.format option to control N8N_LOG_FORMAT (text or json, default text)
-    - kind: fixed
-      description: Change log.file.location default to absolute path /home/node/.n8n/logs/n8n.log so file logging works with readOnlyRootFilesystem enabled
+    - kind: changed
+      description: Update n8nio/n8n image version to 2.27.5
       links:
-        - name: GitHub Issue
-          url: https://github.com/community-charts/helm-charts/issues/521
-    - kind: fixed
-      description: Mount emptyDir at /home/node/.npm so npm can write temp files and logs when readOnlyRootFilesystem is enabled
+        - name: Upstream Project
+          url: https://github.com/n8n-io/n8n
+    - kind: changed
+      description: Update dependency redis from 27.0.12 to 27.0.13
       links:
-        - name: GitHub Issue
-          url: https://github.com/community-charts/helm-charts/issues/521
+        - name: ArtifactHub
+          url: https://artifacthub.io/packages/helm/bitnami/redis
+    - kind: changed
+      description: Update dependency postgresql from 18.7.8 to 18.7.9
+      links:
+        - name: ArtifactHub
+          url: https://artifacthub.io/packages/helm/bitnami/postgresql
   artifacthub.io/images: |
     - name: n8n
-      image: n8nio/n8n:2.27.4
+      image: n8nio/n8n:2.27.5
       platforms:
         - linux/amd64
         - linux/arm64
     - name: n8n-runners
-      image: n8nio/runners:2.27.4
+      image: n8nio/runners:2.27.5
       platforms:
         - linux/amd64
         - linux/arm64
@@ -86,11 +89,11 @@ annotations:
     url: https://keybase.io/communitycharts/pgp_keys.asc
 dependencies:
   - name: redis
-    version: 27.0.12
+    version: 27.0.13
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: postgresql
-    version: 18.7.8
+    version: 18.7.9
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: minio

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.24.0](https://img.shields.io/badge/Version-1.24.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.27.4](https://img.shields.io/badge/AppVersion-2.27.4-informational?style=flat-square)
+![Version: 1.24.1](https://img.shields.io/badge/Version-1.24.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.27.5](https://img.shields.io/badge/AppVersion-2.27.5-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -1396,8 +1396,8 @@ Kubernetes: `>=1.23.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 18.7.8 |
-| https://charts.bitnami.com/bitnami | redis | 27.0.12 |
+| https://charts.bitnami.com/bitnami | postgresql | 18.7.9 |
+| https://charts.bitnami.com/bitnami | redis | 27.0.13 |
 | https://charts.min.io/ | minio | 5.4.0 |
 
 ## Uninstall Helm Chart


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the n8n chart to use the latest image version 2.27.5 from n8nio/n8n. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated