### PR TITLE
[mlflow] Add opt-in Gateway API HTTPRoute support

### DIFF
--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.11.4
+version: 1.12.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -61,6 +61,11 @@ annotations:
       links:
         - name: ArtifactHub
           url: https://artifacthub.io/packages/helm/bitnami/postgresql
+    - kind: added
+      description: Add opt-in Gateway API HTTPRoute support, with route hostnames automatically merged into MLFLOW_SERVER_ALLOWED_HOSTS and CORS origins for the server security middleware
+      links:
+        - name: GitHub Issue
+          url: https://github.com/community-charts/helm-charts/issues/417
   artifacthub.io/images: |-
     - name: mlflow
       image: burakince/mlflow:3.15.1

--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -66,6 +66,8 @@ annotations:
       links:
         - name: GitHub Issue
           url: https://github.com/community-charts/helm-charts/issues/417
+        - name: GitHub PR
+          url: https://github.com/community-charts/helm-charts/pull/533
   artifacthub.io/images: |-
     - name: mlflow
       image: burakince/mlflow:3.15.1

--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -66,6 +66,8 @@ annotations:
       links:
         - name: GitHub Issue
           url: https://github.com/community-charts/helm-charts/issues/417
+        - name: GitHub PR
+          url: https://github.com/community-charts/helm-charts/pull/533
   artifacthub.io/images: |-
     - name: mlflow
       image: burakince/mlflow:3.16.0

--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.11.7
+version: 1.12.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -61,6 +61,11 @@ annotations:
       links:
         - name: ArtifactHub
           url: https://artifacthub.io/packages/helm/bitnami/postgresql
+    - kind: added
+      description: Add opt-in Gateway API HTTPRoute support, with route hostnames automatically merged into MLFLOW_SERVER_ALLOWED_HOSTS and CORS origins for the server security middleware
+      links:
+        - name: GitHub Issue
+          url: https://github.com/community-charts/helm-charts/issues/417
   artifacthub.io/images: |-
     - name: mlflow
       image: burakince/mlflow:3.16.0

--- a/charts/mlflow/README.md
+++ b/charts/mlflow/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for Mlflow open source platform for the machine learning lifecycle
 
-![Version: 1.11.4](https://img.shields.io/badge/Version-1.11.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.15.1](https://img.shields.io/badge/AppVersion-3.15.1-informational?style=flat-square)
+![Version: 1.12.0](https://img.shields.io/badge/Version-1.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.15.1](https://img.shields.io/badge/AppVersion-3.15.1-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -676,16 +676,35 @@ oauth2Proxy:
     redirectURL: "https://mlflow.example.com/oauth2/callback"
 ```
 
+## Gateway API HTTPRoute Example
+
+As an alternative (or in addition) to an `Ingress`, the chart can expose MLflow through a [Gateway API](https://gateway-api.sigs.k8s.io/) `HTTPRoute`. It is disabled by default; enable it and attach it to an existing Gateway:
+
+```yaml
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: my-gateway
+      namespace: gateway-system
+      sectionName: https
+  hostnames:
+    - mlflow.example.com
+```
+
+When `httpRoute.rules` is left empty the chart generates a single rule that matches `PathPrefix: /` and forwards to the MLflow service (honouring the oauth2-proxy sidecar port when enabled). Provide your own `rules` for custom path matching, header modification, or traffic splitting.
+
+`httpRoute.hostnames` are also merged into the server security middleware env vars (see below), so Gateway traffic is not rejected as an unrecognised host.
+
 ## Security Middleware Example
 
-MLflow 3.x runs on uvicorn and includes security middleware that protects against DNS rebinding, CORS, and clickjacking attacks. The chart automatically configures `MLFLOW_SERVER_ALLOWED_HOSTS` and `MLFLOW_SERVER_CORS_ALLOWED_ORIGINS` from your ingress hosts so the middleware does not block legitimate requests.
+MLflow 3.x runs on uvicorn and includes security middleware that protects against DNS rebinding, CORS, and clickjacking attacks. The chart automatically configures `MLFLOW_SERVER_ALLOWED_HOSTS` and `MLFLOW_SERVER_CORS_ALLOWED_ORIGINS` from your ingress hosts and httpRoute hostnames so the middleware does not block legitimate requests.
 
-### Auto-detection from Ingress
+### Auto-detection from Ingress and HTTPRoute
 
-When `ingress.enabled` is `true` and hosts are configured the chart derives both env vars automatically:
+When `ingress.enabled` is `true` and hosts are configured, or `httpRoute.enabled` is `true` and hostnames are configured, the chart derives both env vars automatically:
 
 - `MLFLOW_SERVER_ALLOWED_HOSTS` is set to the bare hostnames (e.g. `mlflow.example.com`)
-- `MLFLOW_SERVER_CORS_ALLOWED_ORIGINS` is set to `https://hostname` when `ingress.tls` is configured, or `http://hostname` otherwise
+- `MLFLOW_SERVER_CORS_ALLOWED_ORIGINS` is set to `https://hostname` when `ingress.tls` is configured, or `http://hostname` otherwise; `httpRoute` hostnames are always added as `https://hostname` origins
 
 ```yaml
 ingress:
@@ -1081,6 +1100,13 @@ helm upgrade [RELEASE_NAME] community-charts/mlflow
 | extraVolumes | list | `[]` | Extra Volumes for the pod |
 | flaskServerSecretKey | string | `""` | Mlflow Flask Server Secret Key. Default: Will be auto generated. |
 | fullnameOverride | string | `""` | String to override the default generated fullname |
+| httpRoute | object | `{"annotations":{},"enabled":false,"hostnames":[],"labels":{},"parentRefs":[],"rules":[]}` | Gateway API HTTPRoute configuration. Complementary to `ingress` - you may enable either, both, or neither. |
+| httpRoute.annotations | object | `{}` | Additional HTTPRoute annotations |
+| httpRoute.enabled | bool | `false` | Specifies if you want to create an HTTPRoute (Gateway API) |
+| httpRoute.hostnames | list | `[]` | Hostnames the route matches. Also merged into MLFLOW_SERVER_ALLOWED_HOSTS and (as https origins) MLFLOW_SERVER_CORS_ALLOWED_ORIGINS so the server security middleware does not reject Gateway traffic. |
+| httpRoute.labels | object | `{}` | Additional HTTPRoute labels |
+| httpRoute.parentRefs | list | `[]` | List of parentRefs (Gateways) the route attaches to. Required when httpRoute.enabled is true. |
+| httpRoute.rules | list | `[]` | Route rules. When empty, a single rule matching PathPrefix / and forwarding to the MLflow service is generated. Provide your own rules for custom matching, header rewriting, or traffic splitting. Values are processed with tpl, so Helm expressions are allowed. |
 | image | object | `{"digest":"","pullPolicy":"IfNotPresent","repository":"burakince/mlflow","tag":""}` | Image of mlflow |
 | image.digest | string | `""` | Image digest in the format sha256:<hex>. When set, overrides the tag for immutable pulls. |
 | image.pullPolicy | string | `"IfNotPresent"` | The docker image pull policy |

--- a/charts/mlflow/README.md
+++ b/charts/mlflow/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for Mlflow open source platform for the machine learning lifecycle
 
-![Version: 1.11.7](https://img.shields.io/badge/Version-1.11.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.16.0](https://img.shields.io/badge/AppVersion-3.16.0-informational?style=flat-square)
+![Version: 1.12.0](https://img.shields.io/badge/Version-1.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.16.0](https://img.shields.io/badge/AppVersion-3.16.0-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -676,16 +676,35 @@ oauth2Proxy:
     redirectURL: "https://mlflow.example.com/oauth2/callback"
 ```
 
+## Gateway API HTTPRoute Example
+
+As an alternative (or in addition) to an `Ingress`, the chart can expose MLflow through a [Gateway API](https://gateway-api.sigs.k8s.io/) `HTTPRoute`. It is disabled by default; enable it and attach it to an existing Gateway:
+
+```yaml
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: my-gateway
+      namespace: gateway-system
+      sectionName: https
+  hostnames:
+    - mlflow.example.com
+```
+
+When `httpRoute.rules` is left empty the chart generates a single rule that matches `PathPrefix: /` and forwards to the MLflow service (honouring the oauth2-proxy sidecar port when enabled). Provide your own `rules` for custom path matching, header modification, or traffic splitting.
+
+`httpRoute.hostnames` are also merged into the server security middleware env vars (see below), so Gateway traffic is not rejected as an unrecognised host.
+
 ## Security Middleware Example
 
-MLflow 3.x runs on uvicorn and includes security middleware that protects against DNS rebinding, CORS, and clickjacking attacks. The chart automatically configures `MLFLOW_SERVER_ALLOWED_HOSTS` and `MLFLOW_SERVER_CORS_ALLOWED_ORIGINS` from your ingress hosts so the middleware does not block legitimate requests.
+MLflow 3.x runs on uvicorn and includes security middleware that protects against DNS rebinding, CORS, and clickjacking attacks. The chart automatically configures `MLFLOW_SERVER_ALLOWED_HOSTS` and `MLFLOW_SERVER_CORS_ALLOWED_ORIGINS` from your ingress hosts and httpRoute hostnames so the middleware does not block legitimate requests.
 
-### Auto-detection from Ingress
+### Auto-detection from Ingress and HTTPRoute
 
-When `ingress.enabled` is `true` and hosts are configured the chart derives both env vars automatically:
+When `ingress.enabled` is `true` and hosts are configured, or `httpRoute.enabled` is `true` and hostnames are configured, the chart derives both env vars automatically:
 
 - `MLFLOW_SERVER_ALLOWED_HOSTS` is set to the bare hostnames (e.g. `mlflow.example.com`)
-- `MLFLOW_SERVER_CORS_ALLOWED_ORIGINS` is set to `https://hostname` when `ingress.tls` is configured, or `http://hostname` otherwise
+- `MLFLOW_SERVER_CORS_ALLOWED_ORIGINS` is set to `https://hostname` when `ingress.tls` is configured, or `http://hostname` otherwise; `httpRoute` hostnames are always added as `https://hostname` origins
 
 ```yaml
 ingress:
@@ -1081,6 +1100,13 @@ helm upgrade [RELEASE_NAME] community-charts/mlflow
 | extraVolumes | list | `[]` | Extra Volumes for the pod |
 | flaskServerSecretKey | string | `""` | Mlflow Flask Server Secret Key. Default: Will be auto generated. |
 | fullnameOverride | string | `""` | String to override the default generated fullname |
+| httpRoute | object | `{"annotations":{},"enabled":false,"hostnames":[],"labels":{},"parentRefs":[],"rules":[]}` | Gateway API HTTPRoute configuration. Complementary to `ingress` - you may enable either, both, or neither. |
+| httpRoute.annotations | object | `{}` | Additional HTTPRoute annotations |
+| httpRoute.enabled | bool | `false` | Specifies if you want to create an HTTPRoute (Gateway API) |
+| httpRoute.hostnames | list | `[]` | Hostnames the route matches. Also merged into MLFLOW_SERVER_ALLOWED_HOSTS and (as https origins) MLFLOW_SERVER_CORS_ALLOWED_ORIGINS so the server security middleware does not reject Gateway traffic. |
+| httpRoute.labels | object | `{}` | Additional HTTPRoute labels |
+| httpRoute.parentRefs | list | `[]` | List of parentRefs (Gateways) the route attaches to. Required when httpRoute.enabled is true. |
+| httpRoute.rules | list | `[]` | Route rules. When empty, a single rule matching PathPrefix / and forwarding to the MLflow service is generated. Provide your own rules for custom matching, header rewriting, or traffic splitting. Values are processed with tpl, so Helm expressions are allowed. |
 | image | object | `{"digest":"","pullPolicy":"IfNotPresent","repository":"burakince/mlflow","tag":""}` | Image of mlflow |
 | image.digest | string | `""` | Image digest in the format sha256:<hex>. When set, overrides the tag for immutable pulls. |
 | image.pullPolicy | string | `"IfNotPresent"` | The docker image pull policy |

--- a/charts/mlflow/README.md.gotmpl
+++ b/charts/mlflow/README.md.gotmpl
@@ -676,16 +676,35 @@ oauth2Proxy:
     redirectURL: "https://mlflow.example.com/oauth2/callback"
 ```
 
+## Gateway API HTTPRoute Example
+
+As an alternative (or in addition) to an `Ingress`, the chart can expose MLflow through a [Gateway API](https://gateway-api.sigs.k8s.io/) `HTTPRoute`. It is disabled by default; enable it and attach it to an existing Gateway:
+
+```yaml
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: my-gateway
+      namespace: gateway-system
+      sectionName: https
+  hostnames:
+    - mlflow.example.com
+```
+
+When `httpRoute.rules` is left empty the chart generates a single rule that matches `PathPrefix: /` and forwards to the MLflow service (honouring the oauth2-proxy sidecar port when enabled). Provide your own `rules` for custom path matching, header modification, or traffic splitting.
+
+`httpRoute.hostnames` are also merged into the server security middleware env vars (see below), so Gateway traffic is not rejected as an unrecognised host.
+
 ## Security Middleware Example
 
-MLflow 3.x runs on uvicorn and includes security middleware that protects against DNS rebinding, CORS, and clickjacking attacks. The chart automatically configures `MLFLOW_SERVER_ALLOWED_HOSTS` and `MLFLOW_SERVER_CORS_ALLOWED_ORIGINS` from your ingress hosts so the middleware does not block legitimate requests.
+MLflow 3.x runs on uvicorn and includes security middleware that protects against DNS rebinding, CORS, and clickjacking attacks. The chart automatically configures `MLFLOW_SERVER_ALLOWED_HOSTS` and `MLFLOW_SERVER_CORS_ALLOWED_ORIGINS` from your ingress hosts and httpRoute hostnames so the middleware does not block legitimate requests.
 
-### Auto-detection from Ingress
+### Auto-detection from Ingress and HTTPRoute
 
-When `ingress.enabled` is `true` and hosts are configured the chart derives both env vars automatically:
+When `ingress.enabled` is `true` and hosts are configured, or `httpRoute.enabled` is `true` and hostnames are configured, the chart derives both env vars automatically:
 
 - `MLFLOW_SERVER_ALLOWED_HOSTS` is set to the bare hostnames (e.g. `mlflow.example.com`)
-- `MLFLOW_SERVER_CORS_ALLOWED_ORIGINS` is set to `https://hostname` when `ingress.tls` is configured, or `http://hostname` otherwise
+- `MLFLOW_SERVER_CORS_ALLOWED_ORIGINS` is set to `https://hostname` when `ingress.tls` is configured, or `http://hostname` otherwise; `httpRoute` hostnames are always added as `https://hostname` origins
 
 ```yaml
 ingress:

--- a/charts/mlflow/templates/NOTES.txt
+++ b/charts/mlflow/templates/NOTES.txt
@@ -5,6 +5,10 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
+{{- else if .Values.httpRoute.enabled }}
+{{- range .Values.httpRoute.hostnames }}
+  https://{{ . }}/
+{{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "mlflow.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/charts/mlflow/templates/_helpers.tpl
+++ b/charts/mlflow/templates/_helpers.tpl
@@ -143,7 +143,7 @@ Usage: {{ include "mlflow.normalizeList" $list }}
 
 {{/*
 Build the MLFLOW_SERVER_ALLOWED_HOSTS value.
-Auto-detects ingress hostnames then appends serverAllowedHosts.
+Auto-detects ingress and httpRoute hostnames then appends serverAllowedHosts.
 Delegates dedup and wildcard collapsing to mlflow.normalizeList.
 Usage: {{ include "mlflow.serverAllowedHosts" . }}
 */}}
@@ -154,13 +154,17 @@ Usage: {{ include "mlflow.serverAllowedHosts" . }}
     {{- if .host -}}{{- $hosts = append $hosts .host -}}{{- end -}}
   {{- end -}}
 {{- end -}}
+{{- if and .Values.httpRoute.enabled .Values.httpRoute.hostnames -}}
+  {{- range .Values.httpRoute.hostnames -}}{{- $hosts = append $hosts . -}}{{- end -}}
+{{- end -}}
 {{- range .Values.serverAllowedHosts -}}{{- $hosts = append $hosts . -}}{{- end -}}
 {{- include "mlflow.normalizeList" $hosts -}}
 {{- end }}
 
 {{/*
 Build the MLFLOW_SERVER_CORS_ALLOWED_ORIGINS value.
-Auto-detects ingress origins (https when TLS configured, http otherwise) then appends corsAllowedOrigins.
+Auto-detects ingress origins (https when TLS configured, http otherwise) and httpRoute
+origins (always https) then appends corsAllowedOrigins.
 Delegates dedup and wildcard collapsing to mlflow.normalizeList.
 Usage: {{ include "mlflow.corsAllowedOrigins" . }}
 */}}
@@ -173,13 +177,16 @@ Usage: {{ include "mlflow.corsAllowedOrigins" . }}
     {{- if .host -}}{{- $origins = append $origins (printf "%s://%s" $scheme .host) -}}{{- end -}}
   {{- end -}}
 {{- end -}}
+{{- if and .Values.httpRoute.enabled .Values.httpRoute.hostnames -}}
+  {{- range .Values.httpRoute.hostnames -}}{{- $origins = append $origins (printf "https://%s" .) -}}{{- end -}}
+{{- end -}}
 {{- range .Values.corsAllowedOrigins -}}{{- $origins = append $origins . -}}{{- end -}}
 {{- include "mlflow.normalizeList" $origins -}}
 {{- end }}
 
 {{/*
-Return the port number the Ingress should target. If oauth2-proxy sidecar is enabled
-use its listenPort, otherwise use the service.port value.
+Return the port number the Ingress or HTTPRoute should target. If oauth2-proxy sidecar
+is enabled use its listenPort, otherwise use the service.port value.
 Usage: {{ include "mlflow.servicePort" . }}
 */}}
 {{- define "mlflow.servicePort" -}}

--- a/charts/mlflow/templates/httproute.yaml
+++ b/charts/mlflow/templates/httproute.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.httpRoute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "mlflow.fullname" . }}
+  labels:
+    {{- include "mlflow.labels" . | nindent 4 }}
+    {{- with .Values.httpRoute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httpRoute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- if .Values.httpRoute.rules }}
+    {{- tpl (toYaml .Values.httpRoute.rules) . | nindent 4 }}
+    {{- else }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "mlflow.fullname" . }}
+          port: {{ include "mlflow.servicePort" . }}
+    {{- end }}
+{{- end }}

--- a/charts/mlflow/unittests/configmap_test.yaml
+++ b/charts/mlflow/unittests/configmap_test.yaml
@@ -542,6 +542,75 @@ tests:
           path: data.MLFLOW_SERVER_CORS_ALLOWED_ORIGINS
           value: "*"
 
+  - it: should inject MLFLOW_SERVER_ALLOWED_HOSTS from httpRoute hostnames
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+        hostnames:
+          - mlflow.example.com
+    documentSelector:
+      path: metadata.name
+      value: mlflow-env-configmap
+    asserts:
+      - equal:
+          path: data.MLFLOW_SERVER_ALLOWED_HOSTS
+          value: "mlflow.example.com"
+
+  - it: should inject https CORS origins from httpRoute hostnames
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+        hostnames:
+          - mlflow.example.com
+    documentSelector:
+      path: metadata.name
+      value: mlflow-env-configmap
+    asserts:
+      - equal:
+          path: data.MLFLOW_SERVER_CORS_ALLOWED_ORIGINS
+          value: "https://mlflow.example.com"
+
+  - it: should merge and deduplicate ingress and httpRoute hostnames for allowed hosts
+    set:
+      ingress:
+        enabled: true
+        hosts:
+          - host: mlflow.example.com
+            paths:
+              - path: /
+                pathType: ImplementationSpecific
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+        hostnames:
+          - mlflow.example.com
+          - gw.example.com
+    documentSelector:
+      path: metadata.name
+      value: mlflow-env-configmap
+    asserts:
+      - equal:
+          path: data.MLFLOW_SERVER_ALLOWED_HOSTS
+          value: "mlflow.example.com,gw.example.com"
+
+  - it: should not inject httpRoute hostnames when httpRoute is disabled
+    set:
+      httpRoute:
+        enabled: false
+        hostnames:
+          - mlflow.example.com
+    documentSelector:
+      path: metadata.name
+      value: mlflow-env-configmap
+    asserts:
+      - notExists:
+          path: data.MLFLOW_SERVER_ALLOWED_HOSTS
+
   - it: should match snapshot of default values
     release:
       name: mlflow

--- a/charts/mlflow/unittests/httproute_test.yaml
+++ b/charts/mlflow/unittests/httproute_test.yaml
@@ -1,0 +1,160 @@
+suite: test httproute
+
+templates:
+  - httproute.yaml
+
+release:
+  name: mlflow
+  namespace: mlflow
+
+tests:
+  - it: should be empty when httpRoute is not enabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render an HTTPRoute when enabled
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HTTPRoute
+      - isAPIVersion:
+          of: gateway.networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: mlflow
+
+  - it: should render parentRefs
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+            namespace: gateway-system
+            sectionName: https
+    asserts:
+      - equal:
+          path: spec.parentRefs[0].name
+          value: my-gateway
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: gateway-system
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: https
+
+  - it: should render hostnames
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+        hostnames:
+          - mlflow.example.com
+          - mlflow2.example.com
+    asserts:
+      - equal:
+          path: spec.hostnames[0]
+          value: mlflow.example.com
+      - equal:
+          path: spec.hostnames[1]
+          value: mlflow2.example.com
+
+  - it: should generate a default PathPrefix rule to the mlflow service when rules is empty
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+    asserts:
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: PathPrefix
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: mlflow
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 80
+
+  - it: should route the default backendRef to oauth2Proxy.listenPort when oauth2Proxy is enabled
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+      oauth2Proxy:
+        enabled: true
+        listenPort: 4180
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 4180
+
+  - it: should route the default backendRef to service.port when oauth2Proxy is disabled
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+      service:
+        port: 9090
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 9090
+
+  - it: should use custom rules when provided
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+        rules:
+          - matches:
+              - path:
+                  type: Exact
+                  value: /custom
+            backendRefs:
+              - name: custom-svc
+                port: 8080
+    asserts:
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: Exact
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /custom
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: custom-svc
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 8080
+
+  - it: should render annotations and labels
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+        annotations:
+          foo: bar
+        labels:
+          team: ml
+    asserts:
+      - equal:
+          path: metadata.annotations.foo
+          value: bar
+      - equal:
+          path: metadata.labels.team
+          value: ml

--- a/charts/mlflow/values.schema.json
+++ b/charts/mlflow/values.schema.json
@@ -1210,6 +1210,70 @@
       "title": "ingress",
       "type": "object"
     },
+    "httpRoute": {
+      "additionalProperties": false,
+      "description": "Gateway API HTTPRoute configuration",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "Specifies if you want to create an HTTPRoute (Gateway API)",
+          "required": [],
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "annotations": {
+          "additionalProperties": true,
+          "description": "Additional HTTPRoute annotations",
+          "required": [],
+          "title": "annotations",
+          "type": "object"
+        },
+        "labels": {
+          "additionalProperties": true,
+          "description": "Additional HTTPRoute labels",
+          "required": [],
+          "title": "labels",
+          "type": "object"
+        },
+        "parentRefs": {
+          "description": "List of parentRefs (Gateways) the route attaches to",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "parentRefs",
+          "type": "array"
+        },
+        "hostnames": {
+          "description": "Hostnames the route matches",
+          "items": {
+            "type": "string"
+          },
+          "required": [],
+          "title": "hostnames",
+          "type": "array"
+        },
+        "rules": {
+          "description": "Route rules; when empty a default PathPrefix / rule to the MLflow service is generated",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "rules",
+          "type": "array"
+        }
+      },
+      "required": [
+        "enabled",
+        "annotations",
+        "labels",
+        "parentRefs",
+        "hostnames",
+        "rules"
+      ],
+      "title": "httpRoute",
+      "type": "object"
+    },
     "corsAllowedOrigins": {
       "default": [],
       "description": "List of CORS allowed origins (MLFLOW_SERVER_CORS_ALLOWED_ORIGINS). Auto-derived from ingress hosts when ingress is enabled.",
@@ -3251,6 +3315,7 @@
     "extraEnvVars",
     "extraSecretNamesForEnvFrom",
     "ingress",
+    "httpRoute",
     "resources",
     "serviceMonitor",
     "nodeSelector",

--- a/charts/mlflow/values.yaml
+++ b/charts/mlflow/values.yaml
@@ -463,6 +463,31 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+# -- Gateway API HTTPRoute configuration. Complementary to `ingress` - you may enable either, both, or neither.
+httpRoute:
+  # -- Specifies if you want to create an HTTPRoute (Gateway API)
+  enabled: false
+  # -- Additional HTTPRoute annotations
+  annotations: {}
+  # -- Additional HTTPRoute labels
+  labels: {}
+  # -- List of parentRefs (Gateways) the route attaches to. Required when httpRoute.enabled is true.
+  parentRefs: []
+  #  - name: my-gateway
+  #    namespace: gateway-system
+  #    sectionName: https
+  # -- Hostnames the route matches. Also merged into MLFLOW_SERVER_ALLOWED_HOSTS and (as https origins) MLFLOW_SERVER_CORS_ALLOWED_ORIGINS so the server security middleware does not reject Gateway traffic.
+  hostnames: []
+  #  - mlflow.example.com
+  # -- Route rules. When empty, a single rule matching PathPrefix / and forwarding to the MLflow service is generated. Provide your own rules for custom matching, header rewriting, or traffic splitting. Values are processed with tpl, so Helm expressions are allowed.
+  rules: []
+  #  - matches:
+  #      - path:
+  #          type: PathPrefix
+  #          value: /
+  #    backendRefs:
+  #      - name: my-mlflow
+  #        port: 80
 # -- List of allowed CORS origins for the MLflow server security middleware (env: MLFLOW_SERVER_CORS_ALLOWED_ORIGINS).
 # When ingress is enabled, origins are automatically derived from ingress hosts: https:// if ingress.tls is configured, http:// otherwise.
 # Set explicitly to override auto-detection (e.g. ["*"] for dev, or origins behind a load balancer with TLS termination before ingress).


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds an opt-in Gateway API HTTPRoute to the mlflow chart as an alternative (or complement) to the existing Ingress. It is disabled by default (`httpRoute.enabled: false`), so it is a no-op for current users.

The chart's security middleware derives `MLFLOW_SERVER_ALLOWED_HOSTS` / `MLFLOW_SERVER_CORS_ALLOWED_ORIGINS` from ingress hosts to avoid MLflow 3.x DNS-rebinding rejections. This PR extends that auto-detection to `httpRoute.hostnames`, so MLflow served through a Gateway is not rejected as an unrecognised host. The backendRef port reuses the existing `mlflow.servicePort` helper, so oauth2-proxy sidecar routing works the same as it does for Ingress. When `httpRoute.rules` is empty, a single `PathPrefix: /` rule to the MLflow service is generated; a full `rules` override is supported.

#### Which issue this PR fixes

  - fixes #

#### Special notes for your reviewer:

Part of the Gateway API rollout requested in #417. This PR covers the mlflow chart only; other charts can follow in separate PRs per the one-chart-per-PR rule, so I left the `fixes` line blank to avoid auto-closing the umbrella issue.

Local validation (all green):
- helm unittest: 281 passed (10 new httproute tests plus 4 allowed-hosts/CORS integration cases)
- ct lint (helm lint, yamllint, version check): mlflow 1.11.2 -> 1.12.0
- kube-linter: no errors
- trivy config (HIGH, CRITICAL): 0 misconfigurations
- helm-docs: README regenerated and idempotent
- rendered enabled / disabled / oauth2-proxy / custom-rules scenarios

#### Checklist
- [x] DCO signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated
