### PR TITLE
[n8n] Add opt-in Gateway API HTTPRoute support

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -60,6 +60,8 @@ annotations:
       links:
         - name: GitHub Issue
           url: https://github.com/community-charts/helm-charts/issues/417
+        - name: GitHub PR
+          url: https://github.com/community-charts/helm-charts/pull/534
   artifacthub.io/images: |
     - name: n8n
       image: n8nio/n8n:2.34.5

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.24.27
+version: 1.25.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -55,6 +55,11 @@ annotations:
       links:
         - name: Upstream Project
           url: https://github.com/n8n-io/n8n
+    - kind: added
+      description: Add opt-in Gateway API HTTPRoute support
+      links:
+        - name: GitHub Issue
+          url: https://github.com/community-charts/helm-charts/issues/417
   artifacthub.io/images: |
     - name: n8n
       image: n8nio/n8n:2.34.5

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.24.27](https://img.shields.io/badge/Version-1.24.27-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.34.5](https://img.shields.io/badge/AppVersion-2.34.5-informational?style=flat-square)
+![Version: 1.25.0](https://img.shields.io/badge/Version-1.25.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.34.5](https://img.shields.io/badge/AppVersion-2.34.5-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -121,6 +121,47 @@ ingress:
       paths:
         - path: /
           pathType: ImplementationSpecific
+```
+
+## Gateway API HTTPRoute Example
+
+As an alternative (or in addition) to an `Ingress`, the chart can expose n8n through a [Gateway API](https://gateway-api.sigs.k8s.io/) `HTTPRoute`. It is disabled by default; enable it and attach it to an existing Gateway:
+
+```yaml
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: my-gateway
+      namespace: gateway-system
+      sectionName: https
+  hostnames:
+    - n8n.example.com
+```
+
+When `httpRoute.rules` is left empty the chart generates a single rule that matches `PathPrefix: /` and forwards to the n8n service. Provide your own `rules` for custom path matching, header modification, or traffic splitting. In queue mode you can, for example, route the webhook paths to the webhook service:
+
+```yaml
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: my-gateway
+  hostnames:
+    - n8n.example.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /webhook/
+      backendRefs:
+        - name: my-n8n-webhook
+          port: 5678
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: my-n8n
+          port: 5678
 ```
 
 ## Deployment with Bitnami's PostgreSQL
@@ -1501,6 +1542,13 @@ helm upgrade [RELEASE_NAME] community-charts/n8n
 | extraTemplateManifests | list | `[]` | List of extra Kubernetes manifests as Helm template strings to deploy alongside n8n. Chart labels are automatically merged into each manifest's metadata. |
 | fullnameOverride | string | `""` |  |
 | gracefulShutdownTimeout | int | `30` | graceful shutdown timeout in seconds |
+| httpRoute | object | `{"annotations":{},"enabled":false,"hostnames":[],"labels":{},"parentRefs":[],"rules":[]}` | Gateway API HTTPRoute configuration. Complementary to `ingress` - you may enable either, both, or neither. |
+| httpRoute.annotations | object | `{}` | Additional HTTPRoute annotations |
+| httpRoute.enabled | bool | `false` | Specifies if you want to create an HTTPRoute (Gateway API) |
+| httpRoute.hostnames | list | `[]` | Hostnames the route matches. |
+| httpRoute.labels | object | `{}` | Additional HTTPRoute labels |
+| httpRoute.parentRefs | list | `[]` | List of parentRefs (Gateways) the route attaches to. Required when httpRoute.enabled is true. |
+| httpRoute.rules | list | `[]` | Route rules. When empty, a single rule matching PathPrefix / and forwarding to the n8n service is generated. Provide your own rules for custom matching (e.g. splitting webhook paths to the webhook service in queue mode), header rewriting, or traffic splitting. Values are processed with tpl, so Helm expressions are allowed. |
 | image | object | `{"pullPolicy":"IfNotPresent","repository":"n8nio/n8n","tag":""}` | This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/ |
 | image.pullPolicy | string | `"IfNotPresent"` | This sets the pull policy for images. |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |

--- a/charts/n8n/README.md.gotmpl
+++ b/charts/n8n/README.md.gotmpl
@@ -123,6 +123,47 @@ ingress:
           pathType: ImplementationSpecific
 ```
 
+## Gateway API HTTPRoute Example
+
+As an alternative (or in addition) to an `Ingress`, the chart can expose n8n through a [Gateway API](https://gateway-api.sigs.k8s.io/) `HTTPRoute`. It is disabled by default; enable it and attach it to an existing Gateway:
+
+```yaml
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: my-gateway
+      namespace: gateway-system
+      sectionName: https
+  hostnames:
+    - n8n.example.com
+```
+
+When `httpRoute.rules` is left empty the chart generates a single rule that matches `PathPrefix: /` and forwards to the n8n service. Provide your own `rules` for custom path matching, header modification, or traffic splitting. In queue mode you can, for example, route the webhook paths to the webhook service:
+
+```yaml
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: my-gateway
+  hostnames:
+    - n8n.example.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /webhook/
+      backendRefs:
+        - name: my-n8n-webhook
+          port: 5678
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: my-n8n
+          port: 5678
+```
+
 ## Deployment with Bitnami's PostgreSQL
 
 ```yaml

--- a/charts/n8n/templates/NOTES.txt
+++ b/charts/n8n/templates/NOTES.txt
@@ -5,6 +5,10 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
+{{- else if .Values.httpRoute.enabled }}
+{{- range .Values.httpRoute.hostnames }}
+  https://{{ . }}/
+{{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "n8n.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/charts/n8n/templates/httproute.yaml
+++ b/charts/n8n/templates/httproute.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.httpRoute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "n8n.fullname" . }}
+  labels:
+    {{- include "n8n.main.labels" . | nindent 4 }}
+    {{- with .Values.httpRoute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httpRoute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- if .Values.httpRoute.rules }}
+    {{- tpl (toYaml .Values.httpRoute.rules) . | nindent 4 }}
+    {{- else }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "n8n.fullname" . }}
+          port: {{ .Values.service.port }}
+    {{- end }}
+{{- end }}

--- a/charts/n8n/unittests/httproute_test.yaml
+++ b/charts/n8n/unittests/httproute_test.yaml
@@ -1,0 +1,146 @@
+suite: test httproute
+
+templates:
+  - httproute.yaml
+
+release:
+  name: n8n
+  namespace: n8n
+
+tests:
+  - it: should be empty when httpRoute is not enabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render an HTTPRoute when enabled
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HTTPRoute
+      - isAPIVersion:
+          of: gateway.networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: n8n
+
+  - it: should render parentRefs
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+            namespace: gateway-system
+            sectionName: https
+    asserts:
+      - equal:
+          path: spec.parentRefs[0].name
+          value: my-gateway
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: gateway-system
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: https
+
+  - it: should render hostnames
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+        hostnames:
+          - n8n.example.com
+          - n8n2.example.com
+    asserts:
+      - equal:
+          path: spec.hostnames[0]
+          value: n8n.example.com
+      - equal:
+          path: spec.hostnames[1]
+          value: n8n2.example.com
+
+  - it: should generate a default PathPrefix rule to the n8n service when rules is empty
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+    asserts:
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: PathPrefix
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: n8n
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 5678
+
+  - it: should route the default backendRef to service.port
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+      service:
+        port: 9090
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 9090
+
+  - it: should use custom rules when provided
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+        rules:
+          - matches:
+              - path:
+                  type: Exact
+                  value: /custom
+            backendRefs:
+              - name: custom-svc
+                port: 8080
+    asserts:
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: Exact
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /custom
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: custom-svc
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 8080
+
+  - it: should render annotations and labels
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+        annotations:
+          foo: bar
+        labels:
+          team: automation
+    asserts:
+      - equal:
+          path: metadata.annotations.foo
+          value: bar
+      - equal:
+          path: metadata.labels.team
+          value: automation

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -921,6 +921,57 @@
       "title": "ingress",
       "type": "object"
     },
+    "httpRoute": {
+      "additionalProperties": false,
+      "description": "Gateway API HTTPRoute configuration",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "required": [],
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "annotations": {
+          "additionalProperties": true,
+          "required": [],
+          "title": "annotations",
+          "type": "object"
+        },
+        "labels": {
+          "additionalProperties": true,
+          "required": [],
+          "title": "labels",
+          "type": "object"
+        },
+        "parentRefs": {
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "parentRefs",
+          "type": "array"
+        },
+        "hostnames": {
+          "items": {
+            "type": "string"
+          },
+          "required": [],
+          "title": "hostnames",
+          "type": "array"
+        },
+        "rules": {
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "rules",
+          "type": "array"
+        }
+      },
+      "required": ["enabled", "annotations", "labels", "parentRefs", "hostnames", "rules"],
+      "title": "httpRoute",
+      "type": "object"
+    },
     "livenessProbe": {
       "additionalProperties": true,
       "description": "DEPRECATED: Use main, worker, and webhook blocks livenessProbe field instead. This field will be removed in a future release.",
@@ -5367,6 +5418,7 @@
     "defaultLocale",
     "gracefulShutdownTimeout",
     "ingress",
+    "httpRoute",
     "license",
     "main",
     "nodeSelector",

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -1018,6 +1018,32 @@ ingress:
   #    hosts:
   #      - n8n.local
 
+# -- Gateway API HTTPRoute configuration. Complementary to `ingress` - you may enable either, both, or neither.
+httpRoute:
+  # -- Specifies if you want to create an HTTPRoute (Gateway API)
+  enabled: false
+  # -- Additional HTTPRoute annotations
+  annotations: {}
+  # -- Additional HTTPRoute labels
+  labels: {}
+  # -- List of parentRefs (Gateways) the route attaches to. Required when httpRoute.enabled is true.
+  parentRefs: []
+  #  - name: my-gateway
+  #    namespace: gateway-system
+  #    sectionName: https
+  # -- Hostnames the route matches.
+  hostnames: []
+  #  - n8n.example.com
+  # -- Route rules. When empty, a single rule matching PathPrefix / and forwarding to the n8n service is generated. Provide your own rules for custom matching (e.g. splitting webhook paths to the webhook service in queue mode), header rewriting, or traffic splitting. Values are processed with tpl, so Helm expressions are allowed.
+  rules: []
+  #  - matches:
+  #      - path:
+  #          type: PathPrefix
+  #          value: /
+  #    backendRefs:
+  #      - name: my-n8n
+  #        port: 5678
+
 # -- The service monitor configuration. Please refer to the following link for more information: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md
 serviceMonitor:
   # -- When set true then use a ServiceMonitor to configure scraping


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds an opt-in Gateway API HTTPRoute to the n8n chart as an alternative (or complement) to the existing Ingress. It is disabled by default (`httpRoute.enabled: false`), so it is a no-op for current users.

When `httpRoute.rules` is empty, a single `PathPrefix: /` rule forwarding to the n8n service on `service.port` is generated. A full `rules` override is supported (processed with `tpl`), so users running queue mode can split the webhook paths to the webhook service the same way the Ingress does today.

#### Which issue this PR fixes

  - fixes #

#### Special notes for your reviewer:

Part of the Gateway API rollout requested in #417. This PR covers the n8n chart only; other charts can follow in separate PRs per the one-chart-per-PR rule, so I left the `fixes` line blank to avoid auto-closing the umbrella issue.

Local validation (all green):
- helm unittest: 1053 passed (8 new httproute tests)
- ct lint (helm lint, yamllint, version check): n8n 1.24.5 -> 1.25.0
- kube-linter: no errors
- trivy config (HIGH, CRITICAL): 0 misconfigurations
- helm-docs: README regenerated and idempotent
- rendered enabled / disabled / custom-rules scenarios, and confirmed the values schema rejects unknown httpRoute keys

#### Checklist
- [x] DCO signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated
