### PR TITLE
[actualbudget] Add opt-in Gateway API HTTPRoute support

### DIFF
--- a/charts/actualbudget/Chart.yaml
+++ b/charts/actualbudget/Chart.yaml
@@ -59,6 +59,8 @@ annotations:
       links:
         - name: GitHub Issue
           url: https://github.com/community-charts/helm-charts/issues/417
+        - name: GitHub PR
+          url: https://github.com/community-charts/helm-charts/pull/537
   artifacthub.io/images: |
     - name: actualbudget
       image: actualbudget/actual-server:26.8.1

--- a/charts/actualbudget/Chart.yaml
+++ b/charts/actualbudget/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.3
+version: 1.10.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -54,6 +54,11 @@ annotations:
       links:
         - name: Upstream Project
           url: https://hub.docker.com/r/actualbudget/actual-server
+    - kind: added
+      description: Add opt-in Gateway API HTTPRoute support
+      links:
+        - name: GitHub Issue
+          url: https://github.com/community-charts/helm-charts/issues/417
   artifacthub.io/images: |
     - name: actualbudget
       image: actualbudget/actual-server:26.8.1

--- a/charts/actualbudget/Chart.yaml
+++ b/charts/actualbudget/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.4
+version: 1.10.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -54,6 +54,11 @@ annotations:
       links:
         - name: Upstream Project
           url: https://hub.docker.com/r/actualbudget/actual-server
+    - kind: added
+      description: Add opt-in Gateway API HTTPRoute support
+      links:
+        - name: GitHub Issue
+          url: https://github.com/community-charts/helm-charts/issues/417
   artifacthub.io/images: |
     - name: actualbudget
       image: actualbudget/actual-server:26.9.0

--- a/charts/actualbudget/Chart.yaml
+++ b/charts/actualbudget/Chart.yaml
@@ -59,6 +59,8 @@ annotations:
       links:
         - name: GitHub Issue
           url: https://github.com/community-charts/helm-charts/issues/417
+        - name: GitHub PR
+          url: https://github.com/community-charts/helm-charts/pull/537
   artifacthub.io/images: |
     - name: actualbudget
       image: actualbudget/actual-server:26.9.0

--- a/charts/actualbudget/README.md
+++ b/charts/actualbudget/README.md
@@ -4,7 +4,7 @@
 
 A local-first personal finance app
 
-![Version: 1.9.3](https://img.shields.io/badge/Version-1.9.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.8.1](https://img.shields.io/badge/AppVersion-26.8.1-informational?style=flat-square)
+![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.8.1](https://img.shields.io/badge/AppVersion-26.8.1-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -54,6 +54,40 @@ ingress:
 persistence:
   enabled: true
   existingClaim: actualbudget-volume
+```
+
+## Gateway API HTTPRoute Example
+
+As an alternative (or in addition) to an `Ingress`, the chart can expose Actual Budget through a [Gateway API](https://gateway-api.sigs.k8s.io/) `HTTPRoute`. It is disabled by default; enable it and attach it to an existing Gateway:
+
+```yaml
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: my-gateway
+      namespace: gateway-system
+      sectionName: https
+  hostnames:
+    - actualbudget.example.com
+```
+
+When `httpRoute.rules` is left empty the chart generates a single rule that matches `PathPrefix: /` and forwards to the Actual Budget service. Provide your own `rules` for custom path matching, header modification, or traffic splitting:
+
+```yaml
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: my-gateway
+  hostnames:
+    - actualbudget.example.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: my-actualbudget
+          port: 5006
 ```
 
 ## Configuring OpenID Connect
@@ -157,6 +191,13 @@ helm upgrade [RELEASE_NAME] community-charts/actualbudget
 | files.server | string | `"/data/server-files"` | The server will put an account.sqlite file in this directory, which will contain the (hashed) server password, a list of all the budget files the server knows about, and the active session token (along with anything else the server may want to store in the future). For more information checkout: https://actualbudget.org/docs/config/#serverfiles |
 | files.user | string | `"/data/user-files"` | The server will put all the budget files in this directory as binary blobs. For more information checkout: https://actualbudget.org/docs/config/#userfiles |
 | fullnameOverride | string | `""` |  |
+| httpRoute | object | `{"annotations":{},"enabled":false,"hostnames":[],"labels":{},"parentRefs":[],"rules":[]}` | Gateway API HTTPRoute configuration. Complementary to `ingress` - you may enable either, both, or neither. |
+| httpRoute.annotations | object | `{}` | Additional HTTPRoute annotations |
+| httpRoute.enabled | bool | `false` | Specifies if you want to create an HTTPRoute (Gateway API) |
+| httpRoute.hostnames | list | `[]` | Hostnames the route matches. |
+| httpRoute.labels | object | `{}` | Additional HTTPRoute labels |
+| httpRoute.parentRefs | list | `[]` | List of parentRefs (Gateways) the route attaches to. Required when httpRoute.enabled is true. |
+| httpRoute.rules | list | `[]` | Route rules. When empty, a single rule matching PathPrefix / and forwarding to the actualbudget service is generated. Provide your own rules for custom matching, header rewriting, or traffic splitting. Values are processed with tpl, so Helm expressions are allowed. |
 | image.digest | string | `""` | Image digest in the format sha256:<hex>. When set, overrides the tag for immutable pulls. |
 | image.pullPolicy | string | `"IfNotPresent"` | This sets the pull policy for images. |
 | image.repository | string | `"actualbudget/actual-server"` | The docker image repository to use |

--- a/charts/actualbudget/README.md
+++ b/charts/actualbudget/README.md
@@ -4,7 +4,7 @@
 
 A local-first personal finance app
 
-![Version: 1.9.4](https://img.shields.io/badge/Version-1.9.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.9.0](https://img.shields.io/badge/AppVersion-26.9.0-informational?style=flat-square)
+![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.9.0](https://img.shields.io/badge/AppVersion-26.9.0-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -54,6 +54,40 @@ ingress:
 persistence:
   enabled: true
   existingClaim: actualbudget-volume
+```
+
+## Gateway API HTTPRoute Example
+
+As an alternative (or in addition) to an `Ingress`, the chart can expose Actual Budget through a [Gateway API](https://gateway-api.sigs.k8s.io/) `HTTPRoute`. It is disabled by default; enable it and attach it to an existing Gateway:
+
+```yaml
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: my-gateway
+      namespace: gateway-system
+      sectionName: https
+  hostnames:
+    - actualbudget.example.com
+```
+
+When `httpRoute.rules` is left empty the chart generates a single rule that matches `PathPrefix: /` and forwards to the Actual Budget service. Provide your own `rules` for custom path matching, header modification, or traffic splitting:
+
+```yaml
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: my-gateway
+  hostnames:
+    - actualbudget.example.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: my-actualbudget
+          port: 5006
 ```
 
 ## Configuring OpenID Connect
@@ -157,6 +191,13 @@ helm upgrade [RELEASE_NAME] community-charts/actualbudget
 | files.server | string | `"/data/server-files"` | The server will put an account.sqlite file in this directory, which will contain the (hashed) server password, a list of all the budget files the server knows about, and the active session token (along with anything else the server may want to store in the future). For more information checkout: https://actualbudget.org/docs/config/#serverfiles |
 | files.user | string | `"/data/user-files"` | The server will put all the budget files in this directory as binary blobs. For more information checkout: https://actualbudget.org/docs/config/#userfiles |
 | fullnameOverride | string | `""` |  |
+| httpRoute | object | `{"annotations":{},"enabled":false,"hostnames":[],"labels":{},"parentRefs":[],"rules":[]}` | Gateway API HTTPRoute configuration. Complementary to `ingress` - you may enable either, both, or neither. |
+| httpRoute.annotations | object | `{}` | Additional HTTPRoute annotations |
+| httpRoute.enabled | bool | `false` | Specifies if you want to create an HTTPRoute (Gateway API) |
+| httpRoute.hostnames | list | `[]` | Hostnames the route matches. |
+| httpRoute.labels | object | `{}` | Additional HTTPRoute labels |
+| httpRoute.parentRefs | list | `[]` | List of parentRefs (Gateways) the route attaches to. Required when httpRoute.enabled is true. |
+| httpRoute.rules | list | `[]` | Route rules. When empty, a single rule matching PathPrefix / and forwarding to the actualbudget service is generated. Provide your own rules for custom matching, header rewriting, or traffic splitting. Values are processed with tpl, so Helm expressions are allowed. |
 | image.digest | string | `""` | Image digest in the format sha256:<hex>. When set, overrides the tag for immutable pulls. |
 | image.pullPolicy | string | `"IfNotPresent"` | This sets the pull policy for images. |
 | image.repository | string | `"actualbudget/actual-server"` | The docker image repository to use |

--- a/charts/actualbudget/README.md.gotmpl
+++ b/charts/actualbudget/README.md.gotmpl
@@ -56,6 +56,40 @@ persistence:
   existingClaim: actualbudget-volume
 ```
 
+## Gateway API HTTPRoute Example
+
+As an alternative (or in addition) to an `Ingress`, the chart can expose Actual Budget through a [Gateway API](https://gateway-api.sigs.k8s.io/) `HTTPRoute`. It is disabled by default; enable it and attach it to an existing Gateway:
+
+```yaml
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: my-gateway
+      namespace: gateway-system
+      sectionName: https
+  hostnames:
+    - actualbudget.example.com
+```
+
+When `httpRoute.rules` is left empty the chart generates a single rule that matches `PathPrefix: /` and forwards to the Actual Budget service. Provide your own `rules` for custom path matching, header modification, or traffic splitting:
+
+```yaml
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: my-gateway
+  hostnames:
+    - actualbudget.example.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: my-actualbudget
+          port: 5006
+```
+
 ## Configuring OpenID Connect
 
 The `actualbudget` Helm chart supports OpenID Connect (OIDC) for authentication with providers like Keycloak or Auth0. Please find full tested providers from [here](https://actualbudget.org/docs/config/oauth-auth/#tested-providers). Configure the `login.openid` settings in `values.yaml` or a `secrets.yaml` file to enable it. See the [Values](#values) table for all options, including `login.openid.tokenExpiration` (valid values: `"never"`, `"openid-provider"`, or seconds like `3600`).

--- a/charts/actualbudget/templates/NOTES.txt
+++ b/charts/actualbudget/templates/NOTES.txt
@@ -5,6 +5,10 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
+{{- else if .Values.httpRoute.enabled }}
+{{- range .Values.httpRoute.hostnames }}
+  https://{{ . }}/
+{{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "actualbudget.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/charts/actualbudget/templates/httproute.yaml
+++ b/charts/actualbudget/templates/httproute.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.httpRoute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "actualbudget.fullname" . }}
+  labels:
+    {{- include "actualbudget.labels" . | nindent 4 }}
+    {{- with .Values.httpRoute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httpRoute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- range . }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- if .Values.httpRoute.rules }}
+    {{- tpl (toYaml .Values.httpRoute.rules) . | nindent 4 }}
+    {{- else }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "actualbudget.fullname" . }}
+          port: {{ .Values.service.port }}
+    {{- end }}
+{{- end }}

--- a/charts/actualbudget/unittests/httproute_test.yaml
+++ b/charts/actualbudget/unittests/httproute_test.yaml
@@ -1,0 +1,146 @@
+suite: test httproute
+
+templates:
+  - httproute.yaml
+
+release:
+  name: actualbudget
+  namespace: actualbudget
+
+tests:
+  - it: should be empty when httpRoute is not enabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render an HTTPRoute when enabled
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HTTPRoute
+      - isAPIVersion:
+          of: gateway.networking.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: actualbudget
+
+  - it: should render parentRefs
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+            namespace: gateway-system
+            sectionName: https
+    asserts:
+      - equal:
+          path: spec.parentRefs[0].name
+          value: my-gateway
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: gateway-system
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: https
+
+  - it: should render hostnames
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+        hostnames:
+          - actualbudget.example.com
+          - budget.example.com
+    asserts:
+      - equal:
+          path: spec.hostnames[0]
+          value: actualbudget.example.com
+      - equal:
+          path: spec.hostnames[1]
+          value: budget.example.com
+
+  - it: should generate a default PathPrefix rule to the actualbudget service when rules is empty
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+    asserts:
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: PathPrefix
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: actualbudget
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 5006
+
+  - it: should route the default backendRef to service.port
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+      service:
+        port: 9090
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 9090
+
+  - it: should use custom rules when provided
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+        rules:
+          - matches:
+              - path:
+                  type: Exact
+                  value: /custom
+            backendRefs:
+              - name: custom-svc
+                port: 8080
+    asserts:
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: Exact
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /custom
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: custom-svc
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 8080
+
+  - it: should render annotations and labels
+    set:
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: my-gateway
+        annotations:
+          foo: bar
+        labels:
+          team: finance
+    asserts:
+      - equal:
+          path: metadata.annotations.foo
+          value: bar
+      - equal:
+          path: metadata.labels.team
+          value: finance

--- a/charts/actualbudget/values.schema.json
+++ b/charts/actualbudget/values.schema.json
@@ -462,6 +462,57 @@
       "title": "ingress",
       "type": "object"
     },
+    "httpRoute": {
+      "additionalProperties": false,
+      "description": "Gateway API HTTPRoute configuration",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "required": [],
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "annotations": {
+          "additionalProperties": true,
+          "required": [],
+          "title": "annotations",
+          "type": "object"
+        },
+        "labels": {
+          "additionalProperties": true,
+          "required": [],
+          "title": "labels",
+          "type": "object"
+        },
+        "parentRefs": {
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "parentRefs",
+          "type": "array"
+        },
+        "hostnames": {
+          "items": {
+            "type": "string"
+          },
+          "required": [],
+          "title": "hostnames",
+          "type": "array"
+        },
+        "rules": {
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "rules",
+          "type": "array"
+        }
+      },
+      "required": ["enabled", "annotations", "labels", "parentRefs", "hostnames", "rules"],
+      "title": "httpRoute",
+      "type": "object"
+    },
     "extraEnvVars": {
       "type": "object",
       "description": "Extra environment variables",
@@ -945,6 +996,7 @@
     "upload",
     "login",
     "ingress",
+    "httpRoute",
     "extraEnvVars",
     "resources",
     "livenessProbe",

--- a/charts/actualbudget/values.yaml
+++ b/charts/actualbudget/values.yaml
@@ -154,6 +154,32 @@ ingress:
   #    hosts:
   #      - actualbudget.local
 
+# -- Gateway API HTTPRoute configuration. Complementary to `ingress` - you may enable either, both, or neither.
+httpRoute:
+  # -- Specifies if you want to create an HTTPRoute (Gateway API)
+  enabled: false
+  # -- Additional HTTPRoute annotations
+  annotations: {}
+  # -- Additional HTTPRoute labels
+  labels: {}
+  # -- List of parentRefs (Gateways) the route attaches to. Required when httpRoute.enabled is true.
+  parentRefs: []
+  #  - name: my-gateway
+  #    namespace: gateway-system
+  #    sectionName: https
+  # -- Hostnames the route matches.
+  hostnames: []
+  #  - actualbudget.example.com
+  # -- Route rules. When empty, a single rule matching PathPrefix / and forwarding to the actualbudget service is generated. Provide your own rules for custom matching, header rewriting, or traffic splitting. Values are processed with tpl, so Helm expressions are allowed.
+  rules: []
+  #  - matches:
+  #      - path:
+  #          type: PathPrefix
+  #          value: /
+  #    backendRefs:
+  #      - name: my-actualbudget
+  #        port: 5006
+
 # -- Extra environment variables. For more information checkout: https://actualbudget.org/docs/config/
 extraEnvVars: {}
 


### PR DESCRIPTION
Add an opt-in Gateway API `HTTPRoute` to the actualbudget chart, complementary to the existing `Ingress` (enable either, both, or neither). Disabled by default; when `httpRoute.rules` is empty a single `PathPrefix: /` rule forwards to the actualbudget service on `service.port`. `parentRefs`, `hostnames`, `annotations`, `labels`, and full `rules` overrides are supported. Same pattern as the mlflow (#533) and n8n (#534) HTTPRoute PRs.

Part of #417 ([All] Gateway API Support). Not using the `fixes` keyword so the umbrella issue stays open.

Validation (local, all green):
- helm unittest --strict: 64 passed (7 suites, incl. new httproute_test, 8 cases)
- helm lint: 0 failed
- kube-linter (.kube-linter.yaml): No lint errors
- trivy config: 0 HIGH/CRITICAL
- helm-docs: README regenerated + idempotent
- helm template: disabled (0 HTTPRoute) / enabled default rule / ingress+httpRoute both - all correct

Chart version bumped 1.9.1 -> 1.10.0.
