### PR TITLE
[n8n] Add workloadAnnotations for Deployment/StatefulSet/DaemonSet metadata annotations

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.24.8
+version: 1.25.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -50,11 +50,8 @@ annotations:
       url: https://docs.n8n.io/
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
-    - kind: changed
-      description: Update n8nio/n8n image version to 2.29.8
-      links:
-        - name: Upstream Project
-          url: https://github.com/n8n-io/n8n
+    - kind: added
+      description: New workloadAnnotations value to set annotations on the workload objects (Deployment/StatefulSet/DaemonSet metadata), e.g. for Stakater Reloader
   artifacthub.io/images: |
     - name: n8n
       image: n8nio/n8n:2.29.8

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.24.8](https://img.shields.io/badge/Version-1.24.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.29.8](https://img.shields.io/badge/AppVersion-2.29.8-informational?style=flat-square)
+![Version: 1.25.0](https://img.shields.io/badge/Version-1.25.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.29.8](https://img.shields.io/badge/AppVersion-2.29.8-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -1850,6 +1850,7 @@ helm upgrade [RELEASE_NAME] community-charts/n8n
 | workflowHistory | object | `{"enabled":true,"pruneTime":336}` | The workflow history configuration |
 | workflowHistory.enabled | bool | `true` | Whether to save workflow history versions |
 | workflowHistory.pruneTime | int | `336` | Time (in hours) to keep workflow history versions for. To disable it, use -1 as a value |
+| workloadAnnotations | object | `{}` | Annotations to add to the workload objects (Deployment/StatefulSet/DaemonSet metadata), e.g. for Stakater Reloader. For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
 
 **Homepage:** <https://n8n.io>
 

--- a/charts/n8n/templates/deployment-mcp-webhook.yaml
+++ b/charts/n8n/templates/deployment-mcp-webhook.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "n8n.mcp-webhook.fullname" . }}
   labels:
     {{- include "n8n.mcp-webhook.labels" . | nindent 4 }}
+  {{- with .Values.workloadAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not (kindIs "invalid" .Values.revisionHistoryLimit) }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}

--- a/charts/n8n/templates/deployment-webhook.yaml
+++ b/charts/n8n/templates/deployment-webhook.yaml
@@ -9,6 +9,10 @@ metadata:
   name: {{ include "n8n.webhook.fullname" . }}
   labels:
     {{- include "n8n.webhook.labels" . | nindent 4 }}
+  {{- with .Values.workloadAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not (kindIs "invalid" .Values.revisionHistoryLimit) }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}

--- a/charts/n8n/templates/deployment-worker.yaml
+++ b/charts/n8n/templates/deployment-worker.yaml
@@ -10,6 +10,10 @@ metadata:
   name: {{ include "n8n.worker.fullname" . }}
   labels:
     {{- include "n8n.worker.labels" . | nindent 4 }}
+  {{- with .Values.workloadAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not (kindIs "invalid" .Values.revisionHistoryLimit) }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "n8n.fullname" . }}
   labels:
     {{- include "n8n.main.labels" . | nindent 4 }}
+  {{- with .Values.workloadAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not (kindIs "invalid" .Values.revisionHistoryLimit) }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}

--- a/charts/n8n/templates/statefulset-worker.yaml
+++ b/charts/n8n/templates/statefulset-worker.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "n8n.worker.fullname" . }}
   labels:
     {{- include "n8n.worker.labels" . | nindent 4 }}
+  {{- with .Values.workloadAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not (kindIs "invalid" .Values.revisionHistoryLimit) }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}

--- a/charts/n8n/templates/statefulset.yaml
+++ b/charts/n8n/templates/statefulset.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "n8n.fullname" . }}
   labels:
     {{- include "n8n.main.labels" . | nindent 4 }}
+  {{- with .Values.workloadAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not (kindIs "invalid" .Values.revisionHistoryLimit) }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}

--- a/charts/n8n/unittests/deployment-mcp-webhook_test.yaml
+++ b/charts/n8n/unittests/deployment-mcp-webhook_test.yaml
@@ -89,6 +89,22 @@ tests:
           value: test
         template: deployment-mcp-webhook.yaml
 
+  - it: should set workload annotations when workloadAnnotations are set
+    set:
+      workloadAnnotations:
+        test: test
+    asserts:
+      - equal:
+          path: metadata.annotations.test
+          value: test
+        template: deployment-mcp-webhook.yaml
+
+  - it: should not have workload annotations by default
+    asserts:
+      - notExists:
+          path: metadata.annotations
+        template: deployment-mcp-webhook.yaml
+
   - it: should set pod labels when podLabels are set
     set:
       podLabels:

--- a/charts/n8n/unittests/deployment-webhook_test.yaml
+++ b/charts/n8n/unittests/deployment-webhook_test.yaml
@@ -88,6 +88,22 @@ tests:
           value: test
         template: deployment-webhook.yaml
 
+  - it: should set workload annotations when workloadAnnotations are set
+    set:
+      workloadAnnotations:
+        test: test
+    asserts:
+      - equal:
+          path: metadata.annotations.test
+          value: test
+        template: deployment-webhook.yaml
+
+  - it: should not have workload annotations by default
+    asserts:
+      - notExists:
+          path: metadata.annotations
+        template: deployment-webhook.yaml
+
   - it: should set pod labels when podLabels are set
     set:
       podLabels:

--- a/charts/n8n/unittests/deployment-worker_test.yaml
+++ b/charts/n8n/unittests/deployment-worker_test.yaml
@@ -90,6 +90,22 @@ tests:
           value: test
         template: deployment-worker.yaml
 
+  - it: should set workload annotations when workloadAnnotations are set
+    set:
+      workloadAnnotations:
+        test: test
+    asserts:
+      - equal:
+          path: metadata.annotations.test
+          value: test
+        template: deployment-worker.yaml
+
+  - it: should not have workload annotations by default
+    asserts:
+      - notExists:
+          path: metadata.annotations
+        template: deployment-worker.yaml
+
   - it: should set pod labels when podLabels are set
     set:
       podLabels:

--- a/charts/n8n/unittests/deployment_test.yaml
+++ b/charts/n8n/unittests/deployment_test.yaml
@@ -66,6 +66,22 @@ tests:
           value: test
         template: deployment.yaml
 
+  - it: should set workload annotations when workloadAnnotations are set
+    set:
+      workloadAnnotations:
+        test: test
+    asserts:
+      - equal:
+          path: metadata.annotations.test
+          value: test
+        template: deployment.yaml
+
+  - it: should not have workload annotations by default
+    asserts:
+      - notExists:
+          path: metadata.annotations
+        template: deployment.yaml
+
   - it: should set pod labels when podLabels are set
     set:
       podLabels:

--- a/charts/n8n/unittests/statefulset-worker_test.yaml
+++ b/charts/n8n/unittests/statefulset-worker_test.yaml
@@ -61,6 +61,22 @@ tests:
           value: test
         template: statefulset-worker.yaml
 
+  - it: should set workload annotations when workloadAnnotations are set
+    set:
+      workloadAnnotations:
+        test: test
+    asserts:
+      - equal:
+          path: metadata.annotations.test
+          value: test
+        template: statefulset-worker.yaml
+
+  - it: should not have workload annotations by default
+    asserts:
+      - notExists:
+          path: metadata.annotations
+        template: statefulset-worker.yaml
+
   - it: should set pod labels when podLabels are set
     set:
       podLabels:

--- a/charts/n8n/unittests/statefulset_test.yaml
+++ b/charts/n8n/unittests/statefulset_test.yaml
@@ -41,6 +41,22 @@ tests:
           value: test
         template: statefulset.yaml
 
+  - it: should set workload annotations when workloadAnnotations are set
+    set:
+      workloadAnnotations:
+        test: test
+    asserts:
+      - equal:
+          path: metadata.annotations.test
+          value: test
+        template: statefulset.yaml
+
+  - it: should not have workload annotations by default
+    asserts:
+      - notExists:
+          path: metadata.annotations
+        template: statefulset.yaml
+
   - it: should set pod labels when podLabels are set
     set:
       podLabels:

--- a/charts/n8n/values.schema.json
+++ b/charts/n8n/values.schema.json
@@ -1974,6 +1974,13 @@
       "title": "podLabels",
       "type": "object"
     },
+    "workloadAnnotations": {
+      "additionalProperties": true,
+      "description": "Annotations to add to the workload objects (Deployment/StatefulSet/DaemonSet metadata), e.g. for Stakater Reloader. For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/",
+      "required": [],
+      "title": "workloadAnnotations",
+      "type": "object"
+    },
     "podSecurityContext": {
       "additionalProperties": true,
       "description": "This is for setting Security Context to a Pod. For more information checkout: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
@@ -5344,6 +5351,7 @@
     "serviceAccount",
     "podAnnotations",
     "podLabels",
+    "workloadAnnotations",
     "podSecurityContext",
     "securityContext",
     "service",

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -43,6 +43,9 @@ podAnnotations: {}
 # -- This is for setting Kubernetes Labels to a Pod. For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 podLabels: {}
 
+# -- Annotations to add to the workload objects (Deployment/StatefulSet/DaemonSet metadata), e.g. for Stakater Reloader. For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+workloadAnnotations: {}
+
 # -- This is for setting Security Context to a Pod. For more information checkout: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 podSecurityContext:
   fsGroup: 1000


### PR DESCRIPTION
#### What this PR does / why we need it:

The chart can currently only inject user-supplied annotations onto the **pod template** (`spec.template.metadata.annotations`) via the global `podAnnotations` value. There is no way to set annotations on the top-level `metadata.annotations` of the generated Deployment / StatefulSet / DaemonSet objects.

This PR adds a global `workloadAnnotations` value (map, default `{}`), mirroring the existing `podAnnotations` design, and renders it onto the workload-level `metadata.annotations` of all six workload templates (`deployment.yaml`, `statefulset.yaml`, `deployment-worker.yaml`, `statefulset-worker.yaml`, `deployment-webhook.yaml`, `deployment-mcp-webhook.yaml`).

Motivating use case: [Stakater Reloader](https://github.com/stakater/Reloader) reads its trigger annotations (e.g. `reloader.stakater.com/auto: "true"`) **only** from the workload's own `metadata.annotations` — annotations on the pod template are invisible to it. Today, Reloader cannot be wired to n8n through Helm values at all; users are forced into a kustomize post-render wrapper or the cluster-wide `--auto-reload-all` flag. CI/CD tooling, cost-allocation, and policy controllers also commonly key off workload-level annotations.

The change is fully backward compatible: the default is `{}`, and with `{{- with .Values.workloadAnnotations }}` the `annotations:` block only renders when a non-empty map is supplied, so existing releases produce byte-identical manifests.

Verification:

```console
$ helm template n8n charts/n8n --set 'workloadAnnotations.reloader\.stakater\.com/auto=true' \
    --set worker.mode=queue --set webhook.mode=queue --set webhook.mcp.enabled=true \
    --set webhook.count=2 --set db.type=postgresdb \
  | awk '/^kind: (Deployment|StatefulSet|DaemonSet)/{k=$2} /^  name:/{n=$2} /reloader.stakater.com/{print k, n, $0}'
Deployment n8n-mcp-webhook     reloader.stakater.com/auto: true
Deployment n8n-webhook     reloader.stakater.com/auto: true
Deployment n8n-worker     reloader.stakater.com/auto: true
Deployment n8n     reloader.stakater.com/auto: true

# StatefulSet paths (main.count=2 + persistence, worker.count=2 + persistence):
StatefulSet n8n-worker     reloader.stakater.com/auto: true
StatefulSet n8n     reloader.stakater.com/auto: true

# Default render is unchanged (no stray empty annotations: block):
$ helm template n8n charts/n8n | grep -c 'reloader'
0

$ helm unittest --strict --file 'unittests/**/*.yaml' charts/n8n
Test Suites: 17 passed, 17 total
Tests:       1057 passed, 1057 total

$ ct lint / helm lint / kube-linter — all green
```

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

cc @burakince


- Unit tests added to all six workload test suites: annotation lands on workload `metadata.annotations` when set, and no `annotations` block is rendered by default.
- `values.schema.json` updated (`workloadAnnotations` property + `required` entry).
- Chart version bumped `1.24.8` → `1.25.0` (new backward-compatible feature), `artifacthub.io/changes` updated. `appVersion` untouched.
- README regenerated with helm-docs.

#### Checklist
- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated

