### PR TITLE
[mlflow] Add optional garbage collection CronJob

### DIFF
--- a/charts/mlflow/CLAUDE.md
+++ b/charts/mlflow/CLAUDE.md
@@ -11,6 +11,7 @@ A single MLflow tracking-server `Deployment` (image: `burakince/mlflow`, **not**
 - **Artifact storage** pointing at S3, Azure Blob Storage, or GCS
 - **Basic auth** (`auth.enabled`) or **LDAP auth** (`ldapAuth.enabled`) or **OIDC auth** (`oidcAuth.enabled`) — all mutually exclusive, never more than one
 - **OAuth2-proxy sidecar** (`oauth2Proxy.enabled`) — mutually exclusive with `oidcAuth`; cannot be combined with each other
+- **Garbage collection CronJob** (`garbageCollection.enabled`) for periodic `mlflow gc`
 - **Prometheus ServiceMonitor** when the `monitoring.coreos.com/v1` CRD is available
 - **HPA** under strict conditions (see below)
 
@@ -221,6 +222,14 @@ Test cases for all paths exist in `unittests/deployment_test.yaml`.
 
 When `artifactRoot.proxiedArtifactStorage: true`, the CLI flag switches from `--default-artifact-root` to `--artifacts-destination` and `--serve-artifacts` is also appended. The destination value comes from `artifactRoot.defaultArtifactsDestination`, not `artifactRoot.defaultArtifactRoot`. Cloud storage flags override the destination URI, but `--serve-artifacts` is still injected.
 
+### Garbage Collection CronJob
+
+`garbageCollection.enabled` creates `templates/gc-cronjob.yaml`, which periodically runs `mlflow gc` in the same image as the tracking server. It passes `--backend-store-uri` directly. When `artifactRoot.proxiedArtifactStorage` is enabled, it also injects a default `MLFLOW_TRACKING_URI` pointing at the in-cluster MLflow Service unless the user provides `extraEnvVars.MLFLOW_TRACKING_URI`.
+
+The CronJob reuses the same backend-store URI helper, DB credential env helper, artifact-store env helper, and `envFrom` sources as the main container. This is important for S3 existing secrets, bundled MinIO credentials, Azure/GCS credentials from `-env-secret`, and user-provided `extraEnvVars` / `extraSecretNamesForEnvFrom`.
+
+The template fails when enabled with the default in-memory SQLite backend (`backendStore.defaultSqlitePath: ":memory:"`) because each pod has an ephemeral database and garbage collection would silently do nothing useful. It does not hard-fail local artifact storage: users can mount persistent local storage with `garbageCollection.extraVolumes` / `extraVolumeMounts`, but remote artifact stores (S3/Azure/GCS) are the normal production path.
+
 ### LDAP CA Certificate
 
 LDAP with a self-signed CA uses one of two paths (mutually exclusive):
@@ -241,6 +250,10 @@ Both mount to `/certs/ca.crt` and set `LDAP_CA=/certs/ca.crt` in the main contai
 | `mlflow.oauth2ProxySecretName` | `<release>-oauth2-proxy` or `oauth2Proxy.existingSecret.name` |
 | `mlflow.oidcAuthSecretName` | `<release>-oidc-auth-secret` or `oidcAuth.existingSecret.name` |
 | `mlflow.oidcAuthDbSecretName` | `<release>-oidc-auth-db-secret` or `oidcAuth.database.postgres.existingSecret.name` |
+| `mlflow.backendStoreUriArg` | Builds the `--backend-store-uri=...` argument shared by server and GC containers |
+| `mlflow.backendStoreCredentialEnv` | Renders direct DB credential env entries for subcharts / existing database secrets |
+| `mlflow.artifactStoreEnv` | Renders artifact-store credential env entries plus `extraEnvVars` |
+| `mlflow.runtimeEnvFrom` | Renders common envFrom sources for configmap, env secret, Flask secret, and extra secrets |
 | `mlflow.normalizeList` | Deduplicates a list and joins with `,`; collapses to `*` when wildcard present |
 | `mlflow.serverAllowedHosts` | Builds `MLFLOW_SERVER_ALLOWED_HOSTS` value from ingress + `serverAllowedHosts` |
 | `mlflow.corsAllowedOrigins` | Builds `MLFLOW_SERVER_CORS_ALLOWED_ORIGINS` value from ingress + `corsAllowedOrigins` |
@@ -335,6 +348,8 @@ Test files are in `unittests/`. Each focuses on one configuration axis:
 | `servicemonitor_test.yaml` | Prometheus ServiceMonitor rendering |
 | `trusted_ca_cert_secret_test.yaml` | LDAP CA certificate secret |
 | `extra_deploy_test.yaml` | `extraDeploy` rendering: empty list, single object, multiple objects, and `tpl` expression evaluation |
+| `gc_cronjob_test.yaml` | Garbage collection CronJob rendering, backend URI variants, env inheritance, pod parity, volumes, resources |
+| `gc_cronjob_fail_test.yaml` | Garbage collection `failedTemplate` guard for default in-memory SQLite |
 
 Use `matchRegex` (not `equal`) when asserting a substring within a rendered multi-line arg or command string — the full strings include unrelated boilerplate that would make `equal` brittle.
 
@@ -348,4 +363,5 @@ Used exclusively by `ct install` in CI — do not rely on it for production-like
 - Bitnami PostgreSQL subchart (`postgresql.enabled: true`) with persistence disabled
 - `backendStore.databaseMigration: true` — exercises the `mlflow-db-migration` init container
 - `backendStore.databaseConnectionCheck: true` — exercises the `dbchecker` init container
+- `garbageCollection.enabled: true` — exercises the garbage collection CronJob
 - MinIO subchart (`minio.enabled: true`) with persistence disabled, plus `artifactRoot.s3.enabled: true` — exercises S3 artifact storage via the bundled MinIO instance

--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.11.2
+version: 1.12.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -51,16 +51,8 @@ annotations:
       url: https://github.com/burakince/mlflow
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
-    - kind: changed
-      description: Update dbchecker image version to 1.38.0
-      links:
-        - name: dbchecker
-          url: https://hub.docker.com/r/library/busybox
-    - kind: changed
-      description: Update ini-file-initializer image version to 1.38.0
-      links:
-        - name: ini-file-initializer
-          url: https://hub.docker.com/r/library/busybox
+    - kind: added
+      description: Add optional garbageCollection CronJob to periodically run `mlflow gc`
   artifacthub.io/images: |-
     - name: mlflow
       image: burakince/mlflow:3.14.0

--- a/charts/mlflow/README.md
+++ b/charts/mlflow/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for Mlflow open source platform for the machine learning lifecycle
 
-![Version: 1.11.2](https://img.shields.io/badge/Version-1.11.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.14.0](https://img.shields.io/badge/AppVersion-3.14.0-informational?style=flat-square)
+![Version: 1.12.0](https://img.shields.io/badge/Version-1.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.14.0](https://img.shields.io/badge/AppVersion-3.14.0-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -1081,6 +1081,18 @@ helm upgrade [RELEASE_NAME] community-charts/mlflow
 | extraVolumes | list | `[]` | Extra Volumes for the pod |
 | flaskServerSecretKey | string | `""` | Mlflow Flask Server Secret Key. Default: Will be auto generated. |
 | fullnameOverride | string | `""` | String to override the default generated fullname |
+| garbageCollection | object | `{"allWorkspaces":false,"backoffLimit":1,"concurrencyPolicy":"Forbid","enabled":false,"extraVolumeMounts":[],"extraVolumes":[],"failedJobsHistoryLimit":3,"olderThan":"","resources":{},"schedule":"0 2 * * 0","successfulJobsHistoryLimit":3}` | Periodic garbage collection of soft-deleted MLflow runs/experiments/models via `mlflow gc`. Requires a persistent backend store for useful operation. When proxied artifact storage is enabled, the CronJob sets a default `MLFLOW_TRACKING_URI` pointing at the in-cluster MLflow Service unless `extraEnvVars.MLFLOW_TRACKING_URI` is provided. |
+| garbageCollection.allWorkspaces | bool | `false` | Pass --all-workspaces to `mlflow gc` to collect garbage across all workspaces instead of only the default one |
+| garbageCollection.backoffLimit | int | `1` | backoffLimit for the underlying Job |
+| garbageCollection.concurrencyPolicy | string | `"Forbid"` | concurrencyPolicy for the CronJob |
+| garbageCollection.enabled | bool | `false` | Specifies if you want to create the garbage collection CronJob |
+| garbageCollection.extraVolumeMounts | list | `[]` | Extra volume mounts for the garbage collection container |
+| garbageCollection.extraVolumes | list | `[]` | Extra volumes for the garbage collection pod, e.g. mounting a custom CA bundle or persistent local artifact storage |
+| garbageCollection.failedJobsHistoryLimit | int | `3` | Number of failed finished jobs to retain |
+| garbageCollection.olderThan | string | `""` | Only delete resources that have been soft-deleted for at least this duration, e.g. "30d". Leave empty to delete all soft-deleted resources regardless of age. |
+| garbageCollection.resources | object | `{}` | Resource requests/limits for the garbage collection container |
+| garbageCollection.schedule | string | `"0 2 * * 0"` | Cron schedule expression for the garbage collection job |
+| garbageCollection.successfulJobsHistoryLimit | int | `3` | Number of successful finished jobs to retain |
 | image | object | `{"digest":"","pullPolicy":"IfNotPresent","repository":"burakince/mlflow","tag":""}` | Image of mlflow |
 | image.digest | string | `""` | Image digest in the format sha256:<hex>. When set, overrides the tag for immutable pulls. |
 | image.pullPolicy | string | `"IfNotPresent"` | The docker image pull policy |

--- a/charts/mlflow/README.md
+++ b/charts/mlflow/README.md
@@ -1082,7 +1082,6 @@ helm upgrade [RELEASE_NAME] community-charts/mlflow
 | flaskServerSecretKey | string | `""` | Mlflow Flask Server Secret Key. Default: Will be auto generated. |
 | fullnameOverride | string | `""` | String to override the default generated fullname |
 | garbageCollection | object | `{"allWorkspaces":false,"backoffLimit":1,"concurrencyPolicy":"Forbid","enabled":false,"extraVolumeMounts":[],"extraVolumes":[],"failedJobsHistoryLimit":3,"olderThan":"","resources":{},"schedule":"0 2 * * 0","successfulJobsHistoryLimit":3}` | Periodic garbage collection of soft-deleted MLflow runs/experiments/models via `mlflow gc`. Requires a persistent backend store for useful operation. When proxied artifact storage is enabled, the CronJob sets a default `MLFLOW_TRACKING_URI` pointing at the in-cluster MLflow Service unless `extraEnvVars.MLFLOW_TRACKING_URI` is provided. |
-| garbageCollection.allWorkspaces | bool | `false` | Pass --all-workspaces to `mlflow gc` to collect garbage across all workspaces instead of only the default one |
 | garbageCollection.backoffLimit | int | `1` | backoffLimit for the underlying Job |
 | garbageCollection.concurrencyPolicy | string | `"Forbid"` | concurrencyPolicy for the CronJob |
 | garbageCollection.enabled | bool | `false` | Specifies if you want to create the garbage collection CronJob |

--- a/charts/mlflow/templates/_helpers.tpl
+++ b/charts/mlflow/templates/_helpers.tpl
@@ -131,6 +131,168 @@ Build the full container image reference, appending digest when set.
 {{- end }}
 
 {{/*
+Build the SQLAlchemy backend-store URI argument shared by the server and garbage collector.
+*/}}
+{{- define "mlflow.backendStoreUriArg" -}}
+{{- $dbConnectionDriver := "" -}}
+{{- if and (or .Values.backendStore.postgres.enabled .Values.postgresql.enabled) .Values.backendStore.postgres.driver -}}
+  {{- $dbConnectionDriver = printf "+%s" .Values.backendStore.postgres.driver -}}
+{{- else if and (or .Values.backendStore.mysql.enabled .Values.mysql.enabled) .Values.backendStore.mysql.driver -}}
+  {{- $dbConnectionDriver = printf "+%s" .Values.backendStore.mysql.driver -}}
+{{- else if and .Values.backendStore.mssql.enabled .Values.backendStore.mssql.driver -}}
+  {{- $dbConnectionDriver = printf "+%s" .Values.backendStore.mssql.driver -}}
+{{- end -}}
+{{- if or .Values.backendStore.postgres.enabled .Values.postgresql.enabled -}}
+{{- printf "--backend-store-uri=postgresql%s://" $dbConnectionDriver -}}
+{{- else if or .Values.backendStore.mysql.enabled .Values.mysql.enabled -}}
+{{- printf "--backend-store-uri=mysql%s://$(MYSQL_USERNAME):$(MYSQL_PWD)@$(MYSQL_HOST):$(MYSQL_TCP_PORT)/$(MYSQL_DATABASE)" $dbConnectionDriver -}}
+{{- else if .Values.backendStore.mssql.enabled -}}
+  {{- if .Values.backendStore.mssql.existingConnectionUrlSecret.name -}}
+--backend-store-uri=$(MSSQL_CONNECTION_URL)
+  {{- else if .Values.backendStore.mssql.connectionUrl -}}
+{{- printf "--backend-store-uri=%s" .Values.backendStore.mssql.connectionUrl -}}
+  {{- else -}}
+{{- printf "--backend-store-uri=mssql%s://$(MSSQL_USERNAME):$(MSSQL_PWD)@$(MSSQL_HOST):$(MSSQL_TCP_PORT)/$(MSSQL_DATABASE)" $dbConnectionDriver -}}
+  {{- end -}}
+{{- else -}}
+{{- printf "--backend-store-uri=sqlite:///%s" .Values.backendStore.defaultSqlitePath | quote -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Render direct DB credential env entries for subcharts or existing database secrets.
+The chart-managed env-secret is still consumed through envFrom.
+*/}}
+{{- define "mlflow.backendStoreCredentialEnv" -}}
+{{- if .Values.postgresql.enabled }}
+- name: PGPASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "mlflow.postgresql.fullname" . }}
+  {{- if .Values.postgresql.auth.username }}
+      key: password
+  {{- else }}
+      key: postgres-password
+  {{- end }}
+      optional: true
+{{- end }}
+{{- if .Values.mysql.enabled }}
+- name: MYSQL_PWD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "mlflow.mysql.fullname" . }}
+  {{- if .Values.mysql.auth.username }}
+      key: password
+  {{- else }}
+      key: mysql-root-password
+  {{- end }}
+      optional: true
+{{- end }}
+{{- if .Values.backendStore.existingDatabaseSecret.name }}
+  {{- if .Values.backendStore.postgres.enabled }}
+- name: PGPASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.backendStore.existingDatabaseSecret.name }}
+      key: {{ .Values.backendStore.existingDatabaseSecret.passwordKey }}
+- name: PGUSER
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.backendStore.existingDatabaseSecret.name }}
+      key: {{ .Values.backendStore.existingDatabaseSecret.usernameKey }}
+  {{- end }}
+  {{- if .Values.backendStore.mysql.enabled }}
+- name: MYSQL_PWD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.backendStore.existingDatabaseSecret.name }}
+      key: {{ .Values.backendStore.existingDatabaseSecret.passwordKey }}
+- name: MYSQL_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.backendStore.existingDatabaseSecret.name }}
+      key: {{ .Values.backendStore.existingDatabaseSecret.usernameKey }}
+  {{- end }}
+  {{- if .Values.backendStore.mssql.enabled }}
+- name: MSSQL_PWD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.backendStore.existingDatabaseSecret.name }}
+      key: {{ .Values.backendStore.existingDatabaseSecret.passwordKey }}
+- name: MSSQL_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.backendStore.existingDatabaseSecret.name }}
+      key: {{ .Values.backendStore.existingDatabaseSecret.usernameKey }}
+  {{- end }}
+{{- end }}
+{{- if and .Values.backendStore.mssql.enabled .Values.backendStore.mssql.existingConnectionUrlSecret.name }}
+- name: MSSQL_CONNECTION_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.backendStore.mssql.existingConnectionUrlSecret.name }}
+      key: {{ .Values.backendStore.mssql.existingConnectionUrlSecret.key }}
+{{- end }}
+{{- end }}
+
+{{/*
+Render artifact-store and user-provided env entries shared by the server and garbage collector.
+*/}}
+{{- define "mlflow.artifactStoreEnv" -}}
+{{- if and .Values.artifactRoot.s3.enabled .Values.artifactRoot.s3.existingSecret.name }}
+  {{- if .Values.artifactRoot.s3.existingSecret.keyOfAccessKeyId }}
+- name: AWS_ACCESS_KEY_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.artifactRoot.s3.existingSecret.name }}
+      key: {{ .Values.artifactRoot.s3.existingSecret.keyOfAccessKeyId }}
+  {{- end }}
+  {{- if .Values.artifactRoot.s3.existingSecret.keyOfSecretAccessKey }}
+- name: AWS_SECRET_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.artifactRoot.s3.existingSecret.name }}
+      key: {{ .Values.artifactRoot.s3.existingSecret.keyOfSecretAccessKey }}
+  {{- end }}
+{{- else if and .Values.artifactRoot.s3.enabled .Values.minio.enabled }}
+- name: AWS_ACCESS_KEY_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ printf "%s-minio" (include "mlflow.fullname" .) }}
+      key: rootUser
+- name: AWS_SECRET_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ printf "%s-minio" (include "mlflow.fullname" .) }}
+      key: rootPassword
+{{- end }}
+{{- if .Values.minio.enabled }}
+- name: MLFLOW_S3_ENDPOINT_URL
+  value: {{ printf "http://%s-minio:9000" (include "mlflow.fullname" .) }}
+{{- end }}
+{{- range $key, $value := .Values.extraEnvVars }}
+- name: {{ $key }}
+  value: {{ $value | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Render common envFrom entries shared by the server and garbage collector.
+*/}}
+{{- define "mlflow.runtimeEnvFrom" -}}
+- configMapRef:
+    name: {{ include "mlflow.fullname" . }}-env-configmap
+- secretRef:
+    name: {{ include "mlflow.fullname" . }}-env-secret
+- secretRef:
+    name: {{ include "mlflow.fullname" . }}-flask-server-secret-key
+{{- range .Values.extraSecretNamesForEnvFrom }}
+- secretRef:
+    name: {{ . }}
+{{- end }}
+{{- end }}
+
+{{/*
 Deduplicate a string list and return a comma-separated string.
 Collapses the entire list to "*" when the wildcard entry is present.
 Returns empty string when the list is empty.

--- a/charts/mlflow/templates/deployment.yaml
+++ b/charts/mlflow/templates/deployment.yaml
@@ -30,14 +30,6 @@
   {{- $artifactCommand = printf "--%s=gs://%s/%s" $artifactCommandPrefix .Values.artifactRoot.gcs.bucket .Values.artifactRoot.gcs.path }}
 {{- end }}
 
-{{- $dbConnectionDriver := "" }}
-{{- if and (or .Values.backendStore.postgres.enabled .Values.postgresql.enabled) .Values.backendStore.postgres.driver }}
-  {{- $dbConnectionDriver = printf "+%s" .Values.backendStore.postgres.driver }}
-{{- else if and (or .Values.backendStore.mysql.enabled .Values.mysql.enabled) .Values.backendStore.mysql.driver }}
-  {{- $dbConnectionDriver = printf "+%s" .Values.backendStore.mysql.driver }}
-{{- else if and .Values.backendStore.mssql.enabled .Values.backendStore.mssql.driver }}
-  {{- $dbConnectionDriver = printf "+%s" .Values.backendStore.mssql.driver }}
-{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -99,71 +91,10 @@ spec:
           image: "{{ .Values.initImages.dbchecker.repository }}:{{ .Values.initImages.dbchecker.tag }}"
           imagePullPolicy: {{ .Values.initImages.dbchecker.pullPolicy }}
           command: [ "/script/dbchecker.sh" ]
-        {{- if or .Values.postgresql.enabled .Values.mysql.enabled .Values.backendStore.existingDatabaseSecret.name }}
+        {{- with include "mlflow.backendStoreCredentialEnv" . }}
           env:
+            {{- . | nindent 12 }}
         {{- end }}
-          {{- if .Values.postgresql.enabled }}
-            - name: PGPASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ (include "mlflow.postgresql.fullname" .) }}
-              {{- if .Values.postgresql.auth.username }}
-                  key: password
-              {{- else }}
-                  key: postgres-password
-              {{- end }}
-                  optional: true
-          {{- end }}
-          {{- if .Values.mysql.enabled }}
-            - name: MYSQL_PWD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ (include "mlflow.mysql.fullname" .) }}
-              {{- if .Values.mysql.auth.username }}
-                  key: password
-              {{- else }}
-                  key: mysql-root-password
-              {{- end }}
-                  optional: true
-          {{- end }}
-          {{- if .Values.backendStore.existingDatabaseSecret.name }}
-            {{- if .Values.backendStore.postgres.enabled }}
-            - name: PGPASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.backendStore.existingDatabaseSecret.name }}
-                  key: {{ .Values.backendStore.existingDatabaseSecret.passwordKey }}
-            - name: PGUSER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.backendStore.existingDatabaseSecret.name }}
-                  key: {{ .Values.backendStore.existingDatabaseSecret.usernameKey }}
-            {{- end }}
-            {{- if .Values.backendStore.mysql.enabled }}
-            - name: MYSQL_PWD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.backendStore.existingDatabaseSecret.name }}
-                  key: {{ .Values.backendStore.existingDatabaseSecret.passwordKey }}
-            - name: MYSQL_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.backendStore.existingDatabaseSecret.name }}
-                  key: {{ .Values.backendStore.existingDatabaseSecret.usernameKey }}
-            {{- end }}
-            {{- if .Values.backendStore.mssql.enabled }}
-            - name: MSSQL_PWD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.backendStore.existingDatabaseSecret.name }}
-                  key: {{ .Values.backendStore.existingDatabaseSecret.passwordKey }}
-            - name: MSSQL_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.backendStore.existingDatabaseSecret.name }}
-                  key: {{ .Values.backendStore.existingDatabaseSecret.usernameKey }}
-            {{- end }}
-          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "mlflow.fullname" . }}-env-configmap
@@ -184,78 +115,10 @@ spec:
           imagePullPolicy: {{ .Values.initImages.mlflowDbMigration.pullPolicy }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-        {{- if or .Values.postgresql.enabled .Values.mysql.enabled .Values.backendStore.existingDatabaseSecret.name (and .Values.backendStore.mssql.enabled .Values.backendStore.mssql.existingConnectionUrlSecret.name) }}
+        {{- with include "mlflow.backendStoreCredentialEnv" . }}
           env:
+            {{- . | nindent 12 }}
         {{- end }}
-          {{- if .Values.postgresql.enabled }}
-            - name: PGPASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ (include "mlflow.postgresql.fullname" .) }}
-              {{- if .Values.postgresql.auth.username }}
-                  key: password
-              {{- else }}
-                  key: postgres-password
-              {{- end }}
-                  optional: true
-          {{- end }}
-          {{- if .Values.mysql.enabled }}
-            - name: MYSQL_PWD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ (include "mlflow.mysql.fullname" .) }}
-              {{- if .Values.mysql.auth.username }}
-                  key: password
-              {{- else }}
-                  key: mysql-root-password
-              {{- end }}
-                  optional: true
-          {{- end }}
-          {{- if .Values.backendStore.existingDatabaseSecret.name }}
-            {{- if .Values.backendStore.postgres.enabled }}
-            - name: PGPASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.backendStore.existingDatabaseSecret.name }}
-                  key: {{ .Values.backendStore.existingDatabaseSecret.passwordKey }}
-            - name: PGUSER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.backendStore.existingDatabaseSecret.name }}
-                  key: {{ .Values.backendStore.existingDatabaseSecret.usernameKey }}
-            {{- end }}
-            {{- if .Values.backendStore.mysql.enabled }}
-            - name: MYSQL_PWD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.backendStore.existingDatabaseSecret.name }}
-                  key: {{ .Values.backendStore.existingDatabaseSecret.passwordKey }}
-            - name: MYSQL_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.backendStore.existingDatabaseSecret.name }}
-                  key: {{ .Values.backendStore.existingDatabaseSecret.usernameKey }}
-            {{- end }}
-            {{- if .Values.backendStore.mssql.enabled }}
-            - name: MSSQL_PWD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.backendStore.existingDatabaseSecret.name }}
-                  key: {{ .Values.backendStore.existingDatabaseSecret.passwordKey }}
-            - name: MSSQL_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.backendStore.existingDatabaseSecret.name }}
-                  key: {{ .Values.backendStore.existingDatabaseSecret.usernameKey }}
-            {{- end }}
-          {{- end }}
-          {{- if and .Values.backendStore.mssql.enabled .Values.backendStore.mssql.existingConnectionUrlSecret.name }}
-            - name: MSSQL_CONNECTION_URL
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.backendStore.mssql.existingConnectionUrlSecret.name }}
-                  key: {{ .Values.backendStore.mssql.existingConnectionUrlSecret.key }}
-          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "mlflow.fullname" . }}-env-configmap
@@ -352,21 +215,7 @@ spec:
             - server
             - --host={{ .Values.serverHost }}
             - --port={{ .Values.service.containerPort }}
-          {{- if or .Values.backendStore.postgres.enabled .Values.postgresql.enabled }}
-            - --backend-store-uri=postgresql{{ $dbConnectionDriver }}://
-          {{- else if or .Values.backendStore.mysql.enabled .Values.mysql.enabled }}
-            - --backend-store-uri=mysql{{ $dbConnectionDriver }}://$(MYSQL_USERNAME):$(MYSQL_PWD)@$(MYSQL_HOST):$(MYSQL_TCP_PORT)/$(MYSQL_DATABASE)
-          {{- else if or .Values.backendStore.mssql.enabled }}
-            {{- if .Values.backendStore.mssql.existingConnectionUrlSecret.name }}
-            - --backend-store-uri=$(MSSQL_CONNECTION_URL)
-            {{- else if .Values.backendStore.mssql.connectionUrl }}
-            - --backend-store-uri={{ .Values.backendStore.mssql.connectionUrl }}
-            {{- else }}
-            - --backend-store-uri=mssql{{ $dbConnectionDriver }}://$(MSSQL_USERNAME):$(MSSQL_PWD)@$(MSSQL_HOST):$(MSSQL_TCP_PORT)/$(MSSQL_DATABASE)
-            {{- end }}
-          {{- else }}
-            - "--backend-store-uri=sqlite:///{{ .Values.backendStore.defaultSqlitePath }}"
-          {{- end }}
+            - {{ include "mlflow.backendStoreUriArg" . }}
             - {{ $artifactCommand }}
           {{- if .Values.artifactRoot.proxiedArtifactStorage }}
             - --serve-artifacts
@@ -506,121 +355,14 @@ spec:
               value: {{ .Values.oidcAuth.trustedProxies | join "," | quote }}
             {{- end }}
           {{- end }}
-          {{- if .Values.postgresql.enabled }}
-            - name: PGPASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ (include "mlflow.postgresql.fullname" .) }}
-              {{- if .Values.postgresql.auth.username }}
-                  key: password
-              {{- else }}
-                  key: postgres-password
-              {{- end }}
-                  optional: true
+          {{- with include "mlflow.backendStoreCredentialEnv" . }}
+            {{- . | nindent 12 }}
           {{- end }}
-          {{- if .Values.mysql.enabled }}
-            - name: MYSQL_PWD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ (include "mlflow.mysql.fullname" .) }}
-              {{- if .Values.mysql.auth.username }}
-                  key: password
-              {{- else }}
-                  key: mysql-root-password
-              {{- end }}
-                  optional: true
-          {{- end }}
-          {{- if .Values.backendStore.existingDatabaseSecret.name }}
-            {{- if .Values.backendStore.postgres.enabled }}
-            - name: PGPASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.backendStore.existingDatabaseSecret.name }}
-                  key: {{ .Values.backendStore.existingDatabaseSecret.passwordKey }}
-            - name: PGUSER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.backendStore.existingDatabaseSecret.name }}
-                  key: {{ .Values.backendStore.existingDatabaseSecret.usernameKey }}
-            {{- end }}
-            {{- if .Values.backendStore.mysql.enabled }}
-            - name: MYSQL_PWD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.backendStore.existingDatabaseSecret.name }}
-                  key: {{ .Values.backendStore.existingDatabaseSecret.passwordKey }}
-            - name: MYSQL_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.backendStore.existingDatabaseSecret.name }}
-                  key: {{ .Values.backendStore.existingDatabaseSecret.usernameKey }}
-            {{- end }}
-            {{- if .Values.backendStore.mssql.enabled }}
-            - name: MSSQL_PWD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.backendStore.existingDatabaseSecret.name }}
-                  key: {{ .Values.backendStore.existingDatabaseSecret.passwordKey }}
-            - name: MSSQL_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.backendStore.existingDatabaseSecret.name }}
-                  key: {{ .Values.backendStore.existingDatabaseSecret.usernameKey }}
-            {{- end }}
-          {{- end }}
-          {{- if and .Values.backendStore.mssql.enabled .Values.backendStore.mssql.existingConnectionUrlSecret.name }}
-            - name: MSSQL_CONNECTION_URL
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.backendStore.mssql.existingConnectionUrlSecret.name }}
-                  key: {{ .Values.backendStore.mssql.existingConnectionUrlSecret.key }}
-          {{- end }}
-          {{- if and .Values.artifactRoot.s3.enabled .Values.artifactRoot.s3.existingSecret.name }}
-            {{- if .Values.artifactRoot.s3.existingSecret.keyOfAccessKeyId }}
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.artifactRoot.s3.existingSecret.name }}
-                  key: {{ .Values.artifactRoot.s3.existingSecret.keyOfAccessKeyId }}
-            {{- end }}
-            {{- if .Values.artifactRoot.s3.existingSecret.keyOfSecretAccessKey }}
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.artifactRoot.s3.existingSecret.name }}
-                  key: {{ .Values.artifactRoot.s3.existingSecret.keyOfSecretAccessKey }}
-            {{- end }}
-          {{- else if and .Values.artifactRoot.s3.enabled .Values.minio.enabled }}
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: {{ printf "%s-minio" (include "mlflow.fullname" .) }}
-                  key: rootUser
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ printf "%s-minio" (include "mlflow.fullname" .) }}
-                  key: rootPassword
-          {{- end }}
-          {{- if .Values.minio.enabled }}
-            - name: MLFLOW_S3_ENDPOINT_URL
-              value: {{ printf "http://%s-minio:9000" (include "mlflow.fullname" .) }}
-          {{- end }}
-          {{- range $key, $value := .Values.extraEnvVars }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
+          {{- with include "mlflow.artifactStoreEnv" . }}
+            {{- . | nindent 12 }}
           {{- end }}
           envFrom:
-            - configMapRef:
-                name: {{ include "mlflow.fullname" . }}-env-configmap
-            - secretRef:
-                name: {{ include "mlflow.fullname" . }}-env-secret
-            - secretRef:
-                name: {{ include "mlflow.fullname" . }}-flask-server-secret-key
-          {{- range .Values.extraSecretNamesForEnvFrom }}
-            - secretRef:
-                name: {{ . }}
-          {{- end }}
+            {{- include "mlflow.runtimeEnvFrom" . | nindent 12 }}
           volumeMounts:
             - name: tmp
               mountPath: /tmp

--- a/charts/mlflow/templates/gc-cronjob.yaml
+++ b/charts/mlflow/templates/gc-cronjob.yaml
@@ -1,0 +1,110 @@
+{{- if .Values.garbageCollection.enabled }}
+{{- if and (not (or .Values.backendStore.postgres.enabled .Values.backendStore.mysql.enabled .Values.backendStore.mssql.enabled .Values.postgresql.enabled .Values.mysql.enabled)) (eq .Values.backendStore.defaultSqlitePath ":memory:") }}
+  {{- fail "garbageCollection requires a persistent backend store; default in-memory SQLite cannot be garbage collected" }}
+{{- end }}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: batch/v1
+{{- else }}
+apiVersion: batch/v1beta1
+{{- end }}
+kind: CronJob
+metadata:
+  name: {{ include "mlflow.fullname" . }}-gc
+  labels:
+    {{- include "mlflow.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.garbageCollection.schedule | quote }}
+  concurrencyPolicy: {{ .Values.garbageCollection.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.garbageCollection.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.garbageCollection.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.garbageCollection.backoffLimit }}
+      template:
+        metadata:
+          {{- with .Values.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          labels:
+            {{- include "mlflow.selectorLabels" . | nindent 12 }}
+          {{- with .Values.extraPodLabels }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        spec:
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          serviceAccountName: {{ include "mlflow.serviceAccountName" . }}
+          restartPolicy: Never
+          {{- with .Values.podSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          containers:
+            - name: mlflow-gc
+              {{- with .Values.securityContext }}
+              securityContext:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+              image: {{ include "mlflow.containerImage" . }}
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command: ["mlflow"]
+              args:
+                - gc
+                - {{ include "mlflow.backendStoreUriArg" . }}
+                {{- if .Values.garbageCollection.olderThan }}
+                - --older-than={{ .Values.garbageCollection.olderThan }}
+                {{- end }}
+                {{- if .Values.garbageCollection.allWorkspaces }}
+                - --all-workspaces
+                {{- end }}
+              {{- $backendStoreEnv := include "mlflow.backendStoreCredentialEnv" . }}
+              {{- $artifactStoreEnv := include "mlflow.artifactStoreEnv" . }}
+              {{- $defaultTrackingUri := and .Values.artifactRoot.proxiedArtifactStorage (not (hasKey .Values.extraEnvVars "MLFLOW_TRACKING_URI")) }}
+              {{- if or $backendStoreEnv $artifactStoreEnv $defaultTrackingUri }}
+              env:
+                {{- with $backendStoreEnv }}
+                {{- . | nindent 16 }}
+                {{- end }}
+                {{- if $defaultTrackingUri }}
+                - name: MLFLOW_TRACKING_URI
+                  value: {{ printf "http://%s:%v" (include "mlflow.fullname" .) .Values.service.port | quote }}
+                {{- end }}
+                {{- with $artifactStoreEnv }}
+                {{- . | nindent 16 }}
+                {{- end }}
+              {{- end }}
+              envFrom:
+                {{- include "mlflow.runtimeEnvFrom" . | nindent 16 }}
+              resources:
+                {{- toYaml .Values.garbageCollection.resources | nindent 16 }}
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+              {{- with .Values.garbageCollection.extraVolumeMounts }}
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.priorityClassName }}
+          priorityClassName: {{ . }}
+          {{- end }}
+          volumes:
+            - name: tmp
+              emptyDir: {}
+          {{- with .Values.garbageCollection.extraVolumes }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/charts/mlflow/unittests/gc_cronjob_fail_test.yaml
+++ b/charts/mlflow/unittests/gc_cronjob_fail_test.yaml
@@ -1,0 +1,20 @@
+suite: test garbage collection cronjob failures
+
+templates:
+  - gc-cronjob.yaml
+
+release:
+  name: mlflow
+  namespace: mlflow
+
+chart:
+  version: 1.0.0
+  appVersion: 1.0.0
+
+tests:
+  - it: should fail when enabled with default in-memory sqlite
+    set:
+      garbageCollection.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "garbageCollection requires a persistent backend store; default in-memory SQLite cannot be garbage collected"

--- a/charts/mlflow/unittests/gc_cronjob_test.yaml
+++ b/charts/mlflow/unittests/gc_cronjob_test.yaml
@@ -1,0 +1,321 @@
+suite: test garbage collection cronjob
+
+templates:
+  - gc-cronjob.yaml
+
+release:
+  name: mlflow
+  namespace: mlflow
+
+chart:
+  version: 1.0.0
+  appVersion: 1.0.0
+
+tests:
+  - it: should not render when garbage collection is disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render cronjob with default options when enabled with postgres
+    set:
+      garbageCollection.enabled: true
+      backendStore.postgres.enabled: true
+    capabilities:
+      majorVersion: 1
+      minorVersion: 21
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: apiVersion
+          value: batch/v1
+      - equal:
+          path: kind
+          value: CronJob
+      - equal:
+          path: metadata.name
+          value: mlflow-gc
+      - equal:
+          path: spec.schedule
+          value: "0 2 * * 0"
+      - equal:
+          path: spec.concurrencyPolicy
+          value: Forbid
+      - equal:
+          path: spec.successfulJobsHistoryLimit
+          value: 3
+      - equal:
+          path: spec.failedJobsHistoryLimit
+          value: 3
+      - equal:
+          path: spec.jobTemplate.spec.backoffLimit
+          value: 1
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[?(@.name == "mlflow-gc")].args
+          content: gc
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[?(@.name == "mlflow-gc")].args
+          content: --backend-store-uri=postgresql://
+
+  - it: should use batch v1beta1 when kubernetes version is less than 1.21
+    set:
+      garbageCollection.enabled: true
+      backendStore.postgres.enabled: true
+    capabilities:
+      majorVersion: 1
+      minorVersion: 20
+    asserts:
+      - equal:
+          path: apiVersion
+          value: batch/v1beta1
+
+  - it: should render older-than and all-workspaces flags
+    set:
+      garbageCollection:
+        enabled: true
+        olderThan: 30d
+        allWorkspaces: true
+      backendStore.postgres.enabled: true
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[?(@.name == "mlflow-gc")].args
+          content: --older-than=30d
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[?(@.name == "mlflow-gc")].args
+          content: --all-workspaces
+
+  - it: should render mysql backend-store-uri and existing database secret env vars
+    set:
+      garbageCollection.enabled: true
+      backendStore:
+        mysql:
+          enabled: true
+          driver: pymysql
+        existingDatabaseSecret:
+          name: test-secret
+          usernameKey: customUsername
+          passwordKey: customPassword
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[?(@.name == "mlflow-gc")].args
+          content: --backend-store-uri=mysql+pymysql://$(MYSQL_USERNAME):$(MYSQL_PWD)@$(MYSQL_HOST):$(MYSQL_TCP_PORT)/$(MYSQL_DATABASE)
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[?(@.name == "mlflow-gc")].env
+          content:
+            name: MYSQL_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: test-secret
+                key: customUsername
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[?(@.name == "mlflow-gc")].env
+          content:
+            name: MYSQL_PWD
+            valueFrom:
+              secretKeyRef:
+                name: test-secret
+                key: customPassword
+
+  - it: should render mssql connection url from existing secret
+    set:
+      garbageCollection.enabled: true
+      backendStore:
+        mssql:
+          enabled: true
+          existingConnectionUrlSecret:
+            name: mssql-url-secret
+            key: connectionUrl
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[?(@.name == "mlflow-gc")].args
+          content: --backend-store-uri=$(MSSQL_CONNECTION_URL)
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[?(@.name == "mlflow-gc")].env
+          content:
+            name: MSSQL_CONNECTION_URL
+            valueFrom:
+              secretKeyRef:
+                name: mssql-url-secret
+                key: connectionUrl
+
+  - it: should allow sqlite when a non-memory sqlite path is configured
+    set:
+      garbageCollection.enabled: true
+      backendStore.defaultSqlitePath: /mlflow/data/mlflow.db
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[?(@.name == "mlflow-gc")].args
+          content: "--backend-store-uri=sqlite:////mlflow/data/mlflow.db"
+
+  - it: should inherit s3 existing secret env vars and extra envFrom secrets
+    set:
+      garbageCollection.enabled: true
+      backendStore.postgres.enabled: true
+      artifactRoot:
+        s3:
+          enabled: true
+          bucket: test-bucket
+          existingSecret:
+            name: my-aws-existing-secret
+      extraSecretNamesForEnvFrom:
+        - my-extra-secret
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[?(@.name == "mlflow-gc")].env
+          content:
+            name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: my-aws-existing-secret
+                key: AWS_ACCESS_KEY_ID
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[?(@.name == "mlflow-gc")].envFrom
+          content:
+            secretRef:
+              name: my-extra-secret
+
+  - it: should inherit minio env vars
+    set:
+      garbageCollection.enabled: true
+      postgresql.enabled: true
+      artifactRoot.s3.enabled: true
+      minio.enabled: true
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[?(@.name == "mlflow-gc")].env
+          content:
+            name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: mlflow-minio
+                key: rootUser
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[?(@.name == "mlflow-gc")].env
+          content:
+            name: MLFLOW_S3_ENDPOINT_URL
+            value: http://mlflow-minio:9000
+
+  - it: should inherit extraEnvVars
+    set:
+      garbageCollection.enabled: true
+      backendStore.postgres.enabled: true
+      extraEnvVars:
+        MLFLOW_S3_IGNORE_TLS: "true"
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[?(@.name == "mlflow-gc")].env
+          content:
+            name: MLFLOW_S3_IGNORE_TLS
+            value: "true"
+
+  - it: should inject tracking uri when proxied artifact storage is enabled
+    set:
+      garbageCollection.enabled: true
+      backendStore.postgres.enabled: true
+      artifactRoot.proxiedArtifactStorage: true
+      service.port: 8080
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[?(@.name == "mlflow-gc")].env
+          content:
+            name: MLFLOW_TRACKING_URI
+            value: http://mlflow:8080
+
+  - it: should use user-provided tracking uri when proxied artifact storage is enabled
+    set:
+      garbageCollection.enabled: true
+      backendStore.postgres.enabled: true
+      artifactRoot.proxiedArtifactStorage: true
+      extraEnvVars:
+        MLFLOW_TRACKING_URI: http://mlflow.internal:5000
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[?(@.name == "mlflow-gc")].env
+          content:
+            name: MLFLOW_TRACKING_URI
+            value: http://mlflow.internal:5000
+
+  - it: should render pod parity settings
+    set:
+      garbageCollection.enabled: true
+      backendStore.postgres.enabled: true
+      imagePullSecrets:
+        - name: registry-secret
+      priorityClassName: high-priority
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: mlflow
+          effect: NoSchedule
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.imagePullSecrets[0].name
+          value: registry-secret
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.priorityClassName
+          value: high-priority
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.nodeSelector["kubernetes.io/os"]
+          value: linux
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.tolerations[0].key
+          value: dedicated
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
+          value: kubernetes.io/os
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.volumes
+          content:
+            name: tmp
+            emptyDir: {}
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[?(@.name == "mlflow-gc")].volumeMounts
+          content:
+            name: tmp
+            mountPath: /tmp
+
+  - it: should render extra volumes volume mounts and resources
+    set:
+      garbageCollection:
+        enabled: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        extraVolumes:
+          - name: custom-ca
+            configMap:
+              name: custom-ca
+        extraVolumeMounts:
+          - name: custom-ca
+            mountPath: /etc/ssl/custom-ca
+            readOnly: true
+      backendStore.postgres.enabled: true
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[?(@.name == "mlflow-gc")].resources.requests.cpu
+          value: 100m
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.volumes
+          content:
+            name: custom-ca
+            configMap:
+              name: custom-ca
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[?(@.name == "mlflow-gc")].volumeMounts
+          content:
+            name: custom-ca
+            mountPath: /etc/ssl/custom-ca
+            readOnly: true

--- a/charts/mlflow/values-kind.yaml
+++ b/charts/mlflow/values-kind.yaml
@@ -6,6 +6,9 @@ backendStore:
   databaseMigration: true
   databaseConnectionCheck: true
 
+garbageCollection:
+  enabled: true
+
 postgresql:
   enabled: true
 

--- a/charts/mlflow/values.schema.json
+++ b/charts/mlflow/values.schema.json
@@ -3218,6 +3218,132 @@
       "title": "autoscaling",
       "type": "object"
     },
+    "garbageCollection": {
+      "additionalProperties": false,
+      "description": "Periodic garbage collection of soft-deleted MLflow runs/experiments/models via `mlflow gc`. Requires a persistent backend store for useful operation. When proxied artifact storage is enabled, the CronJob sets a default `MLFLOW_TRACKING_URI` pointing at the in-cluster MLflow Service unless `extraEnvVars.MLFLOW_TRACKING_URI` is provided.",
+      "properties": {
+        "enabled": {
+          "default": false,
+          "description": "Specifies if you want to create the garbage collection CronJob",
+          "required": [],
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "schedule": {
+          "default": "0 2 * * 0",
+          "description": "Cron schedule expression for the garbage collection job",
+          "required": [],
+          "title": "schedule",
+          "type": "string"
+        },
+        "olderThan": {
+          "default": "",
+          "description": "Only delete resources that have been soft-deleted for at least this duration, e.g. 30d. Leave empty to delete all soft-deleted resources regardless of age.",
+          "required": [],
+          "title": "olderThan",
+          "type": "string"
+        },
+        "allWorkspaces": {
+          "default": false,
+          "description": "Pass --all-workspaces to `mlflow gc` to collect garbage across all workspaces instead of only the default one",
+          "required": [],
+          "title": "allWorkspaces",
+          "type": "boolean"
+        },
+        "concurrencyPolicy": {
+          "default": "Forbid",
+          "description": "concurrencyPolicy for the CronJob",
+          "enum": [
+            "Allow",
+            "Forbid",
+            "Replace"
+          ],
+          "required": [],
+          "title": "concurrencyPolicy",
+          "type": "string"
+        },
+        "successfulJobsHistoryLimit": {
+          "default": 3,
+          "description": "Number of successful finished jobs to retain",
+          "minimum": 0,
+          "required": [],
+          "title": "successfulJobsHistoryLimit",
+          "type": "integer"
+        },
+        "failedJobsHistoryLimit": {
+          "default": 3,
+          "description": "Number of failed finished jobs to retain",
+          "minimum": 0,
+          "required": [],
+          "title": "failedJobsHistoryLimit",
+          "type": "integer"
+        },
+        "backoffLimit": {
+          "default": 1,
+          "description": "backoffLimit for the underlying Job",
+          "minimum": 0,
+          "required": [],
+          "title": "backoffLimit",
+          "type": "integer"
+        },
+        "extraVolumes": {
+          "description": "Extra volumes for the garbage collection pod, e.g. mounting a custom CA bundle or persistent local artifact storage",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "extraVolumes",
+          "type": "array"
+        },
+        "extraVolumeMounts": {
+          "description": "Extra volume mounts for the garbage collection container",
+          "items": {
+            "required": []
+          },
+          "required": [],
+          "title": "extraVolumeMounts",
+          "type": "array"
+        },
+        "resources": {
+          "additionalProperties": true,
+          "description": "Resource requests/limits for the garbage collection container",
+          "properties": {
+            "limits": {
+              "additionalProperties": true,
+              "properties": {},
+              "required": [],
+              "title": "limits",
+              "type": "object"
+            },
+            "requests": {
+              "additionalProperties": true,
+              "properties": {},
+              "required": [],
+              "title": "requests",
+              "type": "object"
+            }
+          },
+          "required": [],
+          "title": "resources",
+          "type": "object"
+        }
+      },
+      "required": [
+        "enabled",
+        "schedule",
+        "olderThan",
+        "allWorkspaces",
+        "concurrencyPolicy",
+        "successfulJobsHistoryLimit",
+        "failedJobsHistoryLimit",
+        "backoffLimit",
+        "extraVolumes",
+        "extraVolumeMounts",
+        "resources"
+      ],
+      "title": "garbageCollection",
+      "type": "object"
+    },
     "minio": {
       "type": "object",
       "title": "minio",
@@ -3267,7 +3393,8 @@
     "flaskServerSecretKey",
     "auth",
     "ldapAuth",
-    "autoscaling"
+    "autoscaling",
+    "garbageCollection"
   ],
   "allOf": [
     {

--- a/charts/mlflow/values.yaml
+++ b/charts/mlflow/values.yaml
@@ -402,6 +402,30 @@ autoscaling:
   #     value: 4
   #     periodSeconds: 15
   #   selectPolicy: Max
+# -- Periodic garbage collection of soft-deleted MLflow runs/experiments/models via `mlflow gc`. Requires a persistent backend store for useful operation. When proxied artifact storage is enabled, the CronJob sets a default `MLFLOW_TRACKING_URI` pointing at the in-cluster MLflow Service unless `extraEnvVars.MLFLOW_TRACKING_URI` is provided.
+garbageCollection:
+  # -- Specifies if you want to create the garbage collection CronJob
+  enabled: false
+  # -- Cron schedule expression for the garbage collection job
+  schedule: "0 2 * * 0"
+  # -- Only delete resources that have been soft-deleted for at least this duration, e.g. "30d". Leave empty to delete all soft-deleted resources regardless of age.
+  olderThan: ""
+  # -- Pass --all-workspaces to `mlflow gc` to collect garbage across all workspaces instead of only the default one
+  allWorkspaces: false
+  # -- concurrencyPolicy for the CronJob
+  concurrencyPolicy: Forbid
+  # -- Number of successful finished jobs to retain
+  successfulJobsHistoryLimit: 3
+  # -- Number of failed finished jobs to retain
+  failedJobsHistoryLimit: 3
+  # -- backoffLimit for the underlying Job
+  backoffLimit: 1
+  # -- Extra volumes for the garbage collection pod, e.g. mounting a custom CA bundle or persistent local artifact storage
+  extraVolumes: []
+  # -- Extra volume mounts for the garbage collection container
+  extraVolumeMounts: []
+  # -- Resource requests/limits for the garbage collection container
+  resources: {}
 # -- A map of arguments and values to pass to the `mlflow server` command. Keys must be camelcase. Helm will turn them to kebabcase style.
 extraArgs: {}
 # Number of gunicorn worker processes to handle requests (default: 4).


### PR DESCRIPTION
<!--
Thank you for contributing to community-charts/helm-charts.
Before you submit this PR we'd like to make sure you are aware of our technical requirements and best practices:

* https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#technical-requirements
* https://helm.sh/docs/chart_best_practices/

For a quick overview across what we will look at reviewing your PR, please read our review guidelines:

// TODO: add a REVIEW_GUIDELINES.md in community-charts/helm-charts
* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the history.
This will make it easier to identify new changes.
The PR will be squashed anyways when it is merged.
Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
Once pushed, GitHub Actions will run across your changes and do some initial checks and linting.
These checks run very quickly.
Please check the results.
We would like these checks to pass before we even continue reviewing your changes.
-->
#### What this PR does / why we need it:

This PR adds an optional `garbageCollection` CronJob to the mlflow chart for periodically running `mlflow gc` against a persistent backend store.

The change includes:

- Adds `templates/gc-cronjob.yaml` for an opt-in MLflow garbage collection CronJob
- Adds `garbageCollection` values for schedule, history limits, backoff limit, resources, `--older-than`, `--all-workspaces`, extra volumes, and extra volume mounts
- Reuses shared helpers for backend-store URI generation, database credential environment variables, artifact-store environment variables, and common `envFrom` entries
- Adds support for MSSQL full connection URLs via `backendStore.mssql.connectionUrl` and `backendStore.mssql.existingConnectionUrlSecret`
- Prevents enabling garbage collection with the default in-memory SQLite backend, since there is no persistent store to clean up
- Updates `values.schema.json`, `README.md`, and chart documentation
- Bumps the mlflow chart version to `1.12.0`
- Adds unit tests covering CronJob rendering, backend-store variants, artifact env inheritance, pod scheduling/security options, and invalid in-memory SQLite configuration

#### Which issue this PR fixes

N/A

#### Special notes for your reviewer:

The CronJob is disabled by default and only renders when `garbageCollection.enabled=true`.

The implementation shares backend-store and environment rendering between the Deployment and the garbage collection CronJob so both paths use the same database/artifact configuration behavior.

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated