### PR TITLE
[n8n] Update n8n chart to 2.30.5

### DIFF
--- a/charts/n8n/Chart.lock
+++ b/charts/n8n/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 27.0.15
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 18.7.13
+  version: 18.8.0
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:0d0f8432a53958bb02ca199711e5f8e3da9613d71cfcfae5c8d68d706bef7f4c
-generated: "2026-07-11T02:50:39.563497828Z"
+digest: sha256:2eb2547d70b6fd339db1234d11dc883b87493c097c898d35577c633ccbf82d68
+generated: "2026-07-16T02:51:31.710845821Z"

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.24.11
+version: 1.24.12
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.30.4"
+appVersion: "2.30.5"
 kubeVersion: ">=1.23.0-0"
 home: https://n8n.io
 maintainers:
@@ -51,18 +51,23 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update n8nio/n8n image version to 2.30.4
+      description: Update n8nio/n8n image version to 2.30.5
       links:
         - name: Upstream Project
           url: https://github.com/n8n-io/n8n
+    - kind: changed
+      description: Update dependency postgresql from 18.7.13 to 18.8.0
+      links:
+        - name: ArtifactHub
+          url: https://artifacthub.io/packages/helm/bitnami/postgresql
   artifacthub.io/images: |
     - name: n8n
-      image: n8nio/n8n:2.30.4
+      image: n8nio/n8n:2.30.5
       platforms:
         - linux/amd64
         - linux/arm64
     - name: n8n-runners
-      image: n8nio/runners:2.30.4
+      image: n8nio/runners:2.30.5
       platforms:
         - linux/amd64
         - linux/arm64
@@ -83,7 +88,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: postgresql
-    version: 18.7.13
+    version: 18.8.0
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: minio

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.24.11](https://img.shields.io/badge/Version-1.24.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.30.4](https://img.shields.io/badge/AppVersion-2.30.4-informational?style=flat-square)
+![Version: 1.24.12](https://img.shields.io/badge/Version-1.24.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.30.5](https://img.shields.io/badge/AppVersion-2.30.5-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -1396,7 +1396,7 @@ Kubernetes: `>=1.23.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 18.7.13 |
+| https://charts.bitnami.com/bitnami | postgresql | 18.8.0 |
 | https://charts.bitnami.com/bitnami | redis | 27.0.15 |
 | https://charts.min.io/ | minio | 5.4.0 |
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the n8n chart to use the latest image version 2.30.5 from n8nio/n8n. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated