### PR TITLE
[n8n] Update n8n chart to 2.30.8

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.24.14
+version: 1.24.15
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.30.7"
+appVersion: "2.30.8"
 kubeVersion: ">=1.23.0-0"
 home: https://n8n.io
 maintainers:
@@ -51,18 +51,18 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update n8nio/n8n image version to 2.30.7
+      description: Update n8nio/n8n image version to 2.30.8
       links:
         - name: Upstream Project
           url: https://github.com/n8n-io/n8n
   artifacthub.io/images: |
     - name: n8n
-      image: n8nio/n8n:2.30.7
+      image: n8nio/n8n:2.30.8
       platforms:
         - linux/amd64
         - linux/arm64
     - name: n8n-runners
-      image: n8nio/runners:2.30.7
+      image: n8nio/runners:2.30.8
       platforms:
         - linux/amd64
         - linux/arm64

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.24.14](https://img.shields.io/badge/Version-1.24.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.30.7](https://img.shields.io/badge/AppVersion-2.30.7-informational?style=flat-square)
+![Version: 1.24.15](https://img.shields.io/badge/Version-1.24.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.30.8](https://img.shields.io/badge/AppVersion-2.30.8-informational?style=flat-square)
 
 ## Official Documentation
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the n8n chart to use the latest image version 2.30.8 from n8nio/n8n. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated