### PR TITLE
[actualbudget] Add persistence labels

### DIFF
--- a/charts/actualbudget/Chart.yaml
+++ b/charts/actualbudget/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.1
+version: 1.9.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -48,12 +48,9 @@ annotations:
     - name: Upstream Project
       url: https://github.com/actualbudget/actual
   artifacthub.io/containsSecurityUpdates: "false"
-  artifacthub.io/changes: |-
-    - kind: changed
-      description: Update actualbudget/actual-server image version to 26.7.0
-      links:
-        - name: Upstream Project
-          url: https://hub.docker.com/r/actualbudget/actual-server
+  artifacthub.io/changes: |
+    - kind: added
+      description: Support setting custom labels on the persistence pvc
   artifacthub.io/images: |
     - name: actualbudget
       image: actualbudget/actual-server:26.7.0

--- a/charts/actualbudget/README.md
+++ b/charts/actualbudget/README.md
@@ -4,7 +4,7 @@
 
 A local-first personal finance app
 
-![Version: 1.9.1](https://img.shields.io/badge/Version-1.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.7.0](https://img.shields.io/badge/AppVersion-26.7.0-informational?style=flat-square)
+![Version: 1.9.2](https://img.shields.io/badge/Version-1.9.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 26.7.0](https://img.shields.io/badge/AppVersion-26.7.0-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -187,11 +187,12 @@ helm upgrade [RELEASE_NAME] community-charts/actualbudget
 | login.skipSSLVerification | bool | `false` | This is for skipping the SSL verification for the login. |
 | nameOverride | string | `""` | This is to override the chart name. |
 | nodeSelector | object | `{}` | For more information checkout: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
-| persistence | object | `{"accessModes":["ReadWriteOnce"],"annotations":{},"enabled":false,"existingClaim":"","size":"10Gi","storageClass":"","subPath":"","volumeMode":""}` | This is to setup the persistence for the pod more information can be found here: https://kubernetes.io/docs/concepts/storage/persistent-volumes/ |
+| persistence | object | `{"accessModes":["ReadWriteOnce"],"annotations":{},"enabled":false,"existingClaim":"","labels":{},"size":"10Gi","storageClass":"","subPath":"","volumeMode":""}` | This is to setup the persistence for the pod more information can be found here: https://kubernetes.io/docs/concepts/storage/persistent-volumes/ |
 | persistence.accessModes | list | `["ReadWriteOnce"]` | Actual Budget persistence access mode |
 | persistence.annotations | object | `{}` | Actual Budget persistence annotations |
 | persistence.enabled | bool | `false` | Enable persistence |
 | persistence.existingClaim | string | `""` | Actual Budget persistence existing claim |
+| persistence.labels | object | `{}` | Actual Budget persistence labels |
 | persistence.size | string | `"10Gi"` | Actual Budget persistence size |
 | persistence.storageClass | string | `""` | Actual Budget persistence storage class |
 | persistence.subPath | string | `""` | Actual Budget persistence sub path |

--- a/charts/actualbudget/templates/pvc.yaml
+++ b/charts/actualbudget/templates/pvc.yaml
@@ -8,6 +8,9 @@ metadata:
   {{- end }}
   labels:
     {{- include "actualbudget.labels" . | nindent 4 }}
+    {{- with .Values.persistence.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: {{ template "actualbudget.fullname" . }}-data
   namespace: {{ .Release.Namespace }}
 spec:

--- a/charts/actualbudget/unittests/pvc_test.yaml
+++ b/charts/actualbudget/unittests/pvc_test.yaml
@@ -49,6 +49,20 @@ tests:
           path: spec.resources.requests.storage
           value: 20Gi
 
+  - it: should set labels when persistence is enabled and existingClaim is not set and labels are set
+    set:
+      persistence:
+        enabled: true
+        labels:
+          key: value
+        existingClaim: ""
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.labels.key
+          value: value
+
   - it: should set volumeMode when persistence is enabled and volumeMode is set
     set:
       persistence:

--- a/charts/actualbudget/values.schema.json
+++ b/charts/actualbudget/values.schema.json
@@ -535,6 +535,14 @@
           "title": "existingClaim",
           "type": "string"
         },
+        "labels": {
+          "additionalProperties": true,
+          "default": {},
+          "description": "Actual Budget persistence labels",
+          "required": [],
+          "title": "labels",
+          "type": "object"
+        },
         "size": {
           "default": "10Gi",
           "pattern": "^[0-9]+(Gi|Mi|Ki|G|M|K)$",
@@ -569,6 +577,7 @@
       "required": [
         "enabled",
         "annotations",
+        "labels",
         "existingClaim",
         "storageClass",
         "subPath",

--- a/charts/actualbudget/values.yaml
+++ b/charts/actualbudget/values.yaml
@@ -190,6 +190,9 @@ persistence:
   # -- Actual Budget persistence annotations
   annotations: {}
 
+  # -- Actual Budget persistence labels
+  labels: {}
+
   # -- Actual Budget persistence existing claim
   existingClaim: ""
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a `persistence.labels` value to the actualbudget chart, allowing custom
labels to be set on the generated PVC. This mirrors the existing
`persistence.annotations` support.

Longhorn recurring backup jobs select volumes by label (see
https://longhorn.io/docs/1.10.1/snapshots-and-backups/scheduling-backups-and-snapshots/#with-persistentvolumeclaim-using-the-kubectl-command),
so being able to label the PVC declaratively is required to include the volume
in scheduled backups without patching the claim after install.

#### Which issue this PR fixes

N/A — no tracking issue; small additive enhancement.

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated
