### PR TITLE
[n8n] Update n8n chart to 2.31.7

### DIFF
--- a/charts/n8n/Chart.lock
+++ b/charts/n8n/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 27.0.17
+  version: 27.0.18
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 18.8.0
+  version: 18.8.1
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:180223c2594dae3ce1c1555c2810af4a09c8eea015dbcfee298fb6259930c540
-generated: "2026-07-25T02:54:16.772062503Z"
+digest: sha256:a6b4160a220a305253665570a572f70a618e0eaa1dabaa88654b88bb6f647b72
+generated: "2026-07-28T02:54:17.982471825Z"

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.24.18
+version: 1.24.19
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.31.6"
+appVersion: "2.31.7"
 kubeVersion: ">=1.23.0-0"
 home: https://n8n.io
 maintainers:
@@ -51,23 +51,28 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update n8nio/n8n image version to 2.31.6
+      description: Update n8nio/n8n image version to 2.31.7
       links:
         - name: Upstream Project
           url: https://github.com/n8n-io/n8n
     - kind: changed
-      description: Update dependency redis from 27.0.15 to 27.0.17
+      description: Update dependency redis from 27.0.17 to 27.0.18
       links:
         - name: ArtifactHub
           url: https://artifacthub.io/packages/helm/bitnami/redis
+    - kind: changed
+      description: Update dependency postgresql from 18.8.0 to 18.8.1
+      links:
+        - name: ArtifactHub
+          url: https://artifacthub.io/packages/helm/bitnami/postgresql
   artifacthub.io/images: |
     - name: n8n
-      image: n8nio/n8n:2.31.6
+      image: n8nio/n8n:2.31.7
       platforms:
         - linux/amd64
         - linux/arm64
     - name: n8n-runners
-      image: n8nio/runners:2.31.6
+      image: n8nio/runners:2.31.7
       platforms:
         - linux/amd64
         - linux/arm64
@@ -84,11 +89,11 @@ annotations:
     url: https://keybase.io/communitycharts/pgp_keys.asc
 dependencies:
   - name: redis
-    version: 27.0.17
+    version: 27.0.18
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: postgresql
-    version: 18.8.0
+    version: 18.8.1
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: minio

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.24.18](https://img.shields.io/badge/Version-1.24.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.31.6](https://img.shields.io/badge/AppVersion-2.31.6-informational?style=flat-square)
+![Version: 1.24.19](https://img.shields.io/badge/Version-1.24.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.31.7](https://img.shields.io/badge/AppVersion-2.31.7-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -1396,8 +1396,8 @@ Kubernetes: `>=1.23.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 18.8.0 |
-| https://charts.bitnami.com/bitnami | redis | 27.0.17 |
+| https://charts.bitnami.com/bitnami | postgresql | 18.8.1 |
+| https://charts.bitnami.com/bitnami | redis | 27.0.18 |
 | https://charts.min.io/ | minio | 5.4.0 |
 
 ## Uninstall Helm Chart


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the n8n chart to use the latest image version 2.31.7 from n8nio/n8n. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated