### PR TITLE
[mlflow] Update mlflow chart to 3.15.0

### DIFF
--- a/charts/mlflow/Chart.lock
+++ b/charts/mlflow/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 18.7.6
+  version: 18.8.4
 - name: mysql
   repository: https://charts.bitnami.com/bitnami
   version: 14.0.3
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:db65b471991f0d2a3f78ea85d4b2e3042cafaa1335efb155c625d57226255f24
-generated: "2026-06-21T18:44:35.052434931Z"
+digest: sha256:e0948c87da24554e8b6db9e9949f516ba9530c73162975eec9e076190e401178
+generated: "2026-08-01T02:51:22.317345629Z"

--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.11.2
+version: 1.11.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.14.0"
+appVersion: "3.15.0"
 kubeVersion: ">=1.16.0-0"
 home: https://mlflow.org
 maintainers:
@@ -52,18 +52,18 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update dbchecker image version to 1.38.0
+      description: Update burakince/mlflow image version to 3.15.0
       links:
-        - name: dbchecker
-          url: https://hub.docker.com/r/library/busybox
+        - name: Upstream Project
+          url: https://hub.docker.com/r/burakince/mlflow
     - kind: changed
-      description: Update ini-file-initializer image version to 1.38.0
+      description: Update dependency postgresql from 18.7.6 to 18.8.4
       links:
-        - name: ini-file-initializer
-          url: https://hub.docker.com/r/library/busybox
+        - name: ArtifactHub
+          url: https://artifacthub.io/packages/helm/bitnami/postgresql
   artifacthub.io/images: |-
     - name: mlflow
-      image: burakince/mlflow:3.14.0
+      image: burakince/mlflow:3.15.0
     - name: oauth2-proxy
       image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3
     - name: dbchecker
@@ -100,7 +100,7 @@ annotations:
     url: https://keybase.io/communitycharts/pgp_keys.asc
 dependencies:
   - name: postgresql
-    version: 18.7.6
+    version: 18.8.4
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: mysql

--- a/charts/mlflow/README.md
+++ b/charts/mlflow/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for Mlflow open source platform for the machine learning lifecycle
 
-![Version: 1.11.2](https://img.shields.io/badge/Version-1.11.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.14.0](https://img.shields.io/badge/AppVersion-3.14.0-informational?style=flat-square)
+![Version: 1.11.3](https://img.shields.io/badge/Version-1.11.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.15.0](https://img.shields.io/badge/AppVersion-3.15.0-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -954,7 +954,7 @@ Kubernetes: `>=1.16.0-0`
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.bitnami.com/bitnami | mysql | 14.0.3 |
-| https://charts.bitnami.com/bitnami | postgresql | 18.7.6 |
+| https://charts.bitnami.com/bitnami | postgresql | 18.8.4 |
 | https://charts.min.io/ | minio | 5.4.0 |
 
 ## Uninstall Helm Chart


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the mlflow chart to use the latest image version 3.15.0 from burakince/mlflow. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated