### PR TITLE
[mlflow] Update mlflow chart values images

### DIFF
--- a/charts/mlflow/Chart.lock
+++ b/charts/mlflow/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 18.8.6
+  version: 18.8.12
 - name: mysql
   repository: https://charts.bitnami.com/bitnami
   version: 14.0.3
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:fc0552304203d24324cb16d0724941f2262ef4c8ed6605622c87a1a7c8d21a4f
-generated: "2026-08-07T02:45:15.290661942Z"
+digest: sha256:b05b0e9a907ede07586b5f50a855d3c7116a963fe3670fbd59b42002a7c0ed37
+generated: "2026-08-21T02:48:01.256741157Z"

--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.11.4
+version: 1.11.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -52,12 +52,12 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update burakince/mlflow image version to 3.15.1
+      description: Update oauth2-proxy image version to v7.15.4
       links:
-        - name: Upstream Project
-          url: https://hub.docker.com/r/burakince/mlflow
+        - name: oauth2-proxy
+          url: https://quay.io/repository/oauth2-proxy/oauth2-proxy
     - kind: changed
-      description: Update dependency postgresql from 18.8.4 to 18.8.6
+      description: Update dependency postgresql from 18.8.6 to 18.8.12
       links:
         - name: ArtifactHub
           url: https://artifacthub.io/packages/helm/bitnami/postgresql
@@ -65,7 +65,7 @@ annotations:
     - name: mlflow
       image: burakince/mlflow:3.15.1
     - name: oauth2-proxy
-      image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3
+      image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.4
     - name: dbchecker
       image: library/busybox:1.38.0
     - name: ini-file-initializer
@@ -100,7 +100,7 @@ annotations:
     url: https://keybase.io/communitycharts/pgp_keys.asc
 dependencies:
   - name: postgresql
-    version: 18.8.6
+    version: 18.8.12
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: mysql

--- a/charts/mlflow/README.md
+++ b/charts/mlflow/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for Mlflow open source platform for the machine learning lifecycle
 
-![Version: 1.11.4](https://img.shields.io/badge/Version-1.11.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.15.1](https://img.shields.io/badge/AppVersion-3.15.1-informational?style=flat-square)
+![Version: 1.11.5](https://img.shields.io/badge/Version-1.11.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.15.1](https://img.shields.io/badge/AppVersion-3.15.1-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -954,7 +954,7 @@ Kubernetes: `>=1.16.0-0`
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.bitnami.com/bitnami | mysql | 14.0.3 |
-| https://charts.bitnami.com/bitnami | postgresql | 18.8.6 |
+| https://charts.bitnami.com/bitnami | postgresql | 18.8.12 |
 | https://charts.min.io/ | minio | 5.4.0 |
 
 ## Uninstall Helm Chart
@@ -1156,7 +1156,7 @@ helm upgrade [RELEASE_NAME] community-charts/mlflow
 | mysql.image.repository | string | `"bitnamilegacy/mysql"` | This is temporary workaround because of bitnami's deprecation until to completely replace it with our solution. |
 | nameOverride | string | `""` | String to override the default generated name |
 | nodeSelector | object | `{}` | For more information checkout: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
-| oauth2Proxy | object | `{"cookieSecret":"","createSecret":false,"enabled":false,"existingSecret":{"clientIDKey":"client-id","clientSecretKey":"client-secret","cookieSecretKey":"cookie-secret","name":""},"extraArgs":["--cookie-secure=true","--cookie-samesite=lax"],"extraEnv":{},"image":{"pullPolicy":"IfNotPresent","repository":"quay.io/oauth2-proxy/oauth2-proxy","tag":"v7.15.3"},"listenPort":4180,"provider":{"clientID":"","clientSecret":"","issuerURL":"","name":"keycloak","redirectURL":""},"resources":{}}` | oauth2-proxy sidecar configuration |
+| oauth2Proxy | object | `{"cookieSecret":"","createSecret":false,"enabled":false,"existingSecret":{"clientIDKey":"client-id","clientSecretKey":"client-secret","cookieSecretKey":"cookie-secret","name":""},"extraArgs":["--cookie-secure=true","--cookie-samesite=lax"],"extraEnv":{},"image":{"pullPolicy":"IfNotPresent","repository":"quay.io/oauth2-proxy/oauth2-proxy","tag":"v7.15.4"},"listenPort":4180,"provider":{"clientID":"","clientSecret":"","issuerURL":"","name":"keycloak","redirectURL":""},"resources":{}}` | oauth2-proxy sidecar configuration |
 | oauth2Proxy.cookieSecret | string | `""` | Cookie secret plaintext value — only used when createSecret is true |
 | oauth2Proxy.createSecret | bool | `false` | If true the chart will create a Kubernetes secret with the oauth client id/secret |
 | oauth2Proxy.enabled | bool | `false` | Enable deploying oauth2-proxy as a sidecar to the mlflow pod |
@@ -1167,10 +1167,10 @@ helm upgrade [RELEASE_NAME] community-charts/mlflow
 | oauth2Proxy.existingSecret.name | string | `""` | Name of the pre-existing secret; if empty the chart creates one when createSecret is true |
 | oauth2Proxy.extraArgs | list | `["--cookie-secure=true","--cookie-samesite=lax"]` | Extra args to pass to oauth2-proxy as flags |
 | oauth2Proxy.extraEnv | object | `{}` | Extra environment variables for oauth2-proxy |
-| oauth2Proxy.image | object | `{"pullPolicy":"IfNotPresent","repository":"quay.io/oauth2-proxy/oauth2-proxy","tag":"v7.15.3"}` | OAuth2 Proxy image |
+| oauth2Proxy.image | object | `{"pullPolicy":"IfNotPresent","repository":"quay.io/oauth2-proxy/oauth2-proxy","tag":"v7.15.4"}` | OAuth2 Proxy image |
 | oauth2Proxy.image.pullPolicy | string | `"IfNotPresent"` | OAuth2 Proxy image pull policy |
 | oauth2Proxy.image.repository | string | `"quay.io/oauth2-proxy/oauth2-proxy"` | OAuth2 Proxy image repository |
-| oauth2Proxy.image.tag | string | `"v7.15.3"` | OAuth2 Proxy image tag |
+| oauth2Proxy.image.tag | string | `"v7.15.4"` | OAuth2 Proxy image tag |
 | oauth2Proxy.listenPort | int | `4180` | Port oauth2-proxy listens on inside the pod |
 | oauth2Proxy.provider | object | `{"clientID":"","clientSecret":"","issuerURL":"","name":"keycloak","redirectURL":""}` | Provider specific settings (example: keycloak) |
 | oauth2Proxy.provider.clientID | string | `""` | OAuth2 client ID |

--- a/charts/mlflow/values.yaml
+++ b/charts/mlflow/values.yaml
@@ -583,7 +583,7 @@ oauth2Proxy:
     # -- OAuth2 Proxy image repository
     repository: quay.io/oauth2-proxy/oauth2-proxy
     # -- OAuth2 Proxy image tag
-    tag: v7.15.3
+    tag: v7.15.4
     # -- OAuth2 Proxy image pull policy
     pullPolicy: IfNotPresent
   # Upstream is constructed from the mlflow service container port;


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the mlflow chart to use the latest image version 3.15.1 from burakince/mlflow. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated