### PR TITLE
[n8n] Update n8n chart to 2.36.7

### DIFF
--- a/charts/n8n/Chart.lock
+++ b/charts/n8n/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 28.0.7
+  version: 28.0.10
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 18.8.12
+  version: 18.8.13
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:fbacce7052969e99eb8bc4a1112b62deda38cf250451dddcff6799a3522b7bd6
-generated: "2026-08-19T02:48:03.501370252Z"
+digest: sha256:60163c9828cb7a40db878ece4a6243048aedf92c88a2fab82938157ee3fc25a2
+generated: "2026-08-26T02:49:37.507075081Z"

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.24.32
+version: 1.24.33
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.35.7"
+appVersion: "2.36.7"
 kubeVersion: ">=1.23.0-0"
 home: https://n8n.io
 maintainers:
@@ -51,18 +51,28 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update n8nio/n8n image version to 2.35.7
+      description: Update n8nio/n8n image version to 2.36.7
       links:
         - name: Upstream Project
           url: https://github.com/n8n-io/n8n
+    - kind: changed
+      description: Update dependency redis from 28.0.7 to 28.0.10
+      links:
+        - name: ArtifactHub
+          url: https://artifacthub.io/packages/helm/bitnami/redis
+    - kind: changed
+      description: Update dependency postgresql from 18.8.12 to 18.8.13
+      links:
+        - name: ArtifactHub
+          url: https://artifacthub.io/packages/helm/bitnami/postgresql
   artifacthub.io/images: |
     - name: n8n
-      image: n8nio/n8n:2.35.7
+      image: n8nio/n8n:2.36.7
       platforms:
         - linux/amd64
         - linux/arm64
     - name: n8n-runners
-      image: n8nio/runners:2.35.7
+      image: n8nio/runners:2.36.7
       platforms:
         - linux/amd64
         - linux/arm64
@@ -79,11 +89,11 @@ annotations:
     url: https://keybase.io/communitycharts/pgp_keys.asc
 dependencies:
   - name: redis
-    version: 28.0.7
+    version: 28.0.10
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: postgresql
-    version: 18.8.12
+    version: 18.8.13
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: minio

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.24.32](https://img.shields.io/badge/Version-1.24.32-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.35.7](https://img.shields.io/badge/AppVersion-2.35.7-informational?style=flat-square)
+![Version: 1.24.33](https://img.shields.io/badge/Version-1.24.33-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.36.7](https://img.shields.io/badge/AppVersion-2.36.7-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -1396,8 +1396,8 @@ Kubernetes: `>=1.23.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 18.8.12 |
-| https://charts.bitnami.com/bitnami | redis | 28.0.7 |
+| https://charts.bitnami.com/bitnami | postgresql | 18.8.13 |
+| https://charts.bitnami.com/bitnami | redis | 28.0.10 |
 | https://charts.min.io/ | minio | 5.4.0 |
 
 ## Uninstall Helm Chart


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the n8n chart to use the latest image version 2.36.7 from n8nio/n8n. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated