### PR TITLE
[cloudflared] Add support for remotely-managed tunnels (revives #432, with runtime verification)

### DIFF
--- a/charts/cloudflared/Chart.yaml
+++ b/charts/cloudflared/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.16
+version: 2.3.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -52,11 +52,13 @@ annotations:
       url: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
-    - kind: changed
-      description: Update cloudflare/cloudflared image version to 2026.8.2
+    - kind: added
+      description: Add remotely-managed tunnel support via a new tunnelMode value
       links:
-        - name: Upstream Project
-          url: https://hub.docker.com/r/cloudflare/cloudflared
+        - name: Cloudflare Remotely-Managed Tunnels
+          url: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/configure-tunnels/remote-tunnel-permissions/
+    - kind: added
+      description: Support supplying the tunnel token from an existing Kubernetes secret
   artifacthub.io/images: |
     - name: cloudflared
       image: cloudflare/cloudflared:2026.8.2

--- a/charts/cloudflared/README.md
+++ b/charts/cloudflared/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for cloudflare tunnel
 
-![Version: 2.2.16](https://img.shields.io/badge/Version-2.2.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.8.2](https://img.shields.io/badge/AppVersion-2026.8.2-informational?style=flat-square)
+![Version: 2.3.0](https://img.shields.io/badge/Version-2.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.8.2](https://img.shields.io/badge/AppVersion-2026.8.2-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -23,20 +23,64 @@ _See [`helm repo`](https://helm.sh/docs/helm/helm_repo/) for command documentati
 
 > **Tip**: The creation of a Cloudflare account and the setup of a Cloudflared tunnel are prerequisites for using this chart. These steps are not included as part of the chart installation process and must be completed beforehand.
 
+This chart supports two tunnel modes:
+
+- **Remote mode** (`tunnelMode: remote`) — The tunnel is configured entirely from the Cloudflare Zero Trust dashboard. You only need a tunnel token. This is the recommended approach for most users.
+- **Local mode** (`tunnelMode: local`, default) — The tunnel is configured locally via a config file, credentials JSON, and certificate PEM. Ingress rules are defined in your Helm values.
+
 ### Prerequisites
 
 1. **Create a Cloudflare Account**
    If you do not yet have a Cloudflare account, please refer to [Cloudflare's official documentation](https://developers.cloudflare.com/fundamentals/setup/account/create-account/) to create one.
 
-2. **Set Up a Cloudflared Tunnel**
-   If you already have a Cloudflare account and have added your domain to it, follow the first three steps in [this guide](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/get-started/create-local-tunnel/) to create a Cloudflared tunnel using the CLI.
+2. **Create a Cloudflared Tunnel**
+   Create a tunnel in the [Cloudflare Zero Trust dashboard](https://one.dash.cloudflare.com/) or via the CLI, depending on which mode you plan to use.
 
-3. **Store Tunnel Files**
+### Remote Tunnel Mode
+
+Remote tunnels are created and managed entirely from the Cloudflare Zero Trust dashboard. After creating a tunnel, you will receive a tunnel token.
+
+#### Installing with a token value
+
+```console
+helm upgrade --install [RELEASE_NAME] community-charts/cloudflared -n [NAMESPACE] --create-namespace \
+  --set=tunnelMode=remote \
+  --set=tunnelToken.value=[TUNNEL_TOKEN]
+```
+
+#### Installing with an existing Kubernetes secret
+
+First, create a secret containing your tunnel token:
+
+```console
+kubectl create secret generic cloudflared-tunnel-token -n [NAMESPACE] \
+  --from-literal=tunnel-token=[TUNNEL_TOKEN]
+```
+
+Then install the chart referencing the secret:
+
+```console
+helm upgrade --install [RELEASE_NAME] community-charts/cloudflared -n [NAMESPACE] --create-namespace \
+  --set=tunnelMode=remote \
+  --set=tunnelToken.existingSecret.name=cloudflared-tunnel-token \
+  --set=tunnelToken.existingSecret.key=tunnel-token
+```
+
+### Local Tunnel Mode
+
+Local tunnels require a credentials JSON file and a certificate PEM file, which are created when you set up a tunnel via the Cloudflared CLI.
+
+#### Prerequisites for Local Mode
+
+1. **Set Up a Cloudflared Tunnel via CLI**
+   Follow the first three steps in [this guide](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/get-started/create-local-tunnel/) to create a Cloudflared tunnel using the CLI.
+
+2. **Store Tunnel Files**
    After creating your Cloudflared tunnel via CLI, ensure the following files are stored in the `~/.cloudflared` directory under your home directory:
    - Your tunnel credentials JSON file.
    - Your tunnel certificate PEM file.
 
-### Encoding and Configuring Tunnel Files
+#### Encoding and Configuring Tunnel Files
 
 To configure the chart, encode the required tunnel files using the following commands and set their values accordingly:
 
@@ -69,7 +113,7 @@ To configure the chart, encode the required tunnel files using the following com
 3. **Set the Tunnel Name**
    Pass the name of your tunnel, as created earlier via the Cloudflared CLI, to the `tunnelConfig.name` configuration.
 
-### Setting Credentials to Kubernetes Secrets and working with Existing Secrets
+#### Setting Credentials to Kubernetes Secrets and working with Existing Secrets
 
 ```console
 cp ~/.cloudflared/*.json ./credentials.json
@@ -88,7 +132,7 @@ tunnelSecrets:
     name: cert-pem-file-secret
 ```
 
-### Configuring Ingress
+#### Configuring Ingress
 
 The default ingress configuration is shown below. Replace the placeholder values with your domain and server settings. It is recommended to use a separate `values.yaml` file to manage this configuration.
 
@@ -100,7 +144,7 @@ ingress:
   - service: http_status:404
 ```
 
-### Installing the Chart
+#### Installing with Local Mode
 
 Use the following `helm` command to install or upgrade the chart. Replace the placeholders with your specific values:
 
@@ -162,7 +206,7 @@ helm upgrade [RELEASE_NAME] community-charts/cloudflared
 | image.repository | string | `"cloudflare/cloudflared"` | The docker image repository to use |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
-| ingress | list | `[{"hostname":"example.com","service":"http://traefik.kube-system.svc.cluster.local:80"},{"service":"http_status:404"}]` | Cloudflare ingress rules. More information can be found here: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/configure-tunnels/local-management/configuration-file/#how-traffic-is-matched |
+| ingress | list | `[{"hostname":"example.com","service":"http://traefik.kube-system.svc.cluster.local:80"},{"service":"http_status:404"}]` | Cloudflare ingress rules. Only used when tunnelMode is "local". More information can be found here: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/configure-tunnels/local-management/configuration-file/#how-traffic-is-matched |
 | livenessProbe | object | `{"failureThreshold":1,"httpGet":{"path":"/ready","port":2000},"initialDelaySeconds":10,"periodSeconds":10}` | This is for configuring the liveness probe. For more information checkout: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ |
 | nameOverride | string | `""` | This is to override the chart name. |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | For more information checkout: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
@@ -182,9 +226,10 @@ helm upgrade [RELEASE_NAME] community-charts/cloudflared
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | terminationGracePeriodSeconds | int | `30` |  |
 | tolerations | list | `[{"effect":"NoSchedule","operator":"Exists"}]` | For more information checkout: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
-| tunnelConfig | object | `{"autoUpdateFrequency":"24h","connectTimeout":"30s","gracePeriod":"30s","logLevel":"info","metricsUpdateFrequency":"5s","name":"","noAutoUpdate":true,"protocol":"auto","retries":5,"transportLogLevel":"warn","warpRouting":false}` | Please find more configuration from https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/configuration/arguments/ |
+| tunnelConfig | object | `{"autoUpdateFrequency":"24h","connectTimeout":"30s","gracePeriod":"30s","logLevel":"info","metricsUpdateFrequency":"5s","name":"","noAutoUpdate":true,"protocol":"auto","retries":5,"transportLogLevel":"warn","warpRouting":false}` | Please find more configuration from https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/configuration/arguments/. Only used when tunnelMode is "local". |
 | tunnelConfig.name | string | `""` | cloudflared tunnel name |
-| tunnelSecrets | object | `{"base64EncodedConfigJsonFile":"","base64EncodedPemFile":"","existingConfigJsonFileSecret":{"key":"credentials.json","name":""},"existingPemFileSecret":{"key":"cert.pem","name":""}}` | This is for setting up the cloudflared tunnel secrets. For more information checkout: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/do-more-with-tunnels/local-management/create-local-tunnel/ |
+| tunnelMode | string | `"local"` | Tunnel mode: "local" for locally-managed tunnels (config file + credentials), "remote" for remotely-managed tunnels (token-based, configured in Cloudflare dashboard) |
+| tunnelSecrets | object | `{"base64EncodedConfigJsonFile":"","base64EncodedPemFile":"","existingConfigJsonFileSecret":{"key":"credentials.json","name":""},"existingPemFileSecret":{"key":"cert.pem","name":""}}` | This is for setting up the cloudflared tunnel secrets. Only used when tunnelMode is "local". For more information checkout: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/do-more-with-tunnels/local-management/create-local-tunnel/ |
 | tunnelSecrets.base64EncodedConfigJsonFile | string | `""` | This is for cloudflared tunnel configuration JSON file. |
 | tunnelSecrets.base64EncodedPemFile | string | `""` | This is for cloudflared tunnel certificate PEM file. |
 | tunnelSecrets.existingConfigJsonFileSecret | object | `{"key":"credentials.json","name":""}` | This is for setting up the existing secret for the cloudflared tunnel configuration JSON file. If not set, the base64EncodedConfigJsonFile will be used. |
@@ -193,6 +238,11 @@ helm upgrade [RELEASE_NAME] community-charts/cloudflared
 | tunnelSecrets.existingPemFileSecret | object | `{"key":"cert.pem","name":""}` | This is for setting up the existing secret for the cloudflared tunnel certificate PEM file. If not set, the base64EncodedPemFile will be used. |
 | tunnelSecrets.existingPemFileSecret.key | string | `"cert.pem"` | This is the key of the certificate PEM file in the existing secret. |
 | tunnelSecrets.existingPemFileSecret.name | string | `""` | This is the name of the existing secret. |
+| tunnelToken | object | `{"existingSecret":{"key":"tunnel-token","name":""},"value":""}` | Tunnel token for remote mode. Get this from the Cloudflare Zero Trust dashboard. Only used when tunnelMode is "remote". |
+| tunnelToken.existingSecret | object | `{"key":"tunnel-token","name":""}` | Use an existing secret containing the tunnel token. |
+| tunnelToken.existingSecret.key | string | `"tunnel-token"` | Key in the secret containing the tunnel token. |
+| tunnelToken.existingSecret.name | string | `""` | Name of the existing secret. |
+| tunnelToken.value | string | `""` | The tunnel token value. Either set this or use existingSecret. |
 | updateStrategy.rollingUpdate.maxUnavailable | int | `1` |  |
 | updateStrategy.type | string | `"RollingUpdate"` |  |
 

--- a/charts/cloudflared/README.md.gotmpl
+++ b/charts/cloudflared/README.md.gotmpl
@@ -23,20 +23,64 @@ _See [`helm repo`](https://helm.sh/docs/helm/helm_repo/) for command documentati
 
 > **Tip**: The creation of a Cloudflare account and the setup of a Cloudflared tunnel are prerequisites for using this chart. These steps are not included as part of the chart installation process and must be completed beforehand.
 
+This chart supports two tunnel modes:
+
+- **Remote mode** (`tunnelMode: remote`) — The tunnel is configured entirely from the Cloudflare Zero Trust dashboard. You only need a tunnel token. This is the recommended approach for most users.
+- **Local mode** (`tunnelMode: local`, default) — The tunnel is configured locally via a config file, credentials JSON, and certificate PEM. Ingress rules are defined in your Helm values.
+
 ### Prerequisites
 
 1. **Create a Cloudflare Account**
    If you do not yet have a Cloudflare account, please refer to [Cloudflare's official documentation](https://developers.cloudflare.com/fundamentals/setup/account/create-account/) to create one.
 
-2. **Set Up a Cloudflared Tunnel**
-   If you already have a Cloudflare account and have added your domain to it, follow the first three steps in [this guide](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/get-started/create-local-tunnel/) to create a Cloudflared tunnel using the CLI.
+2. **Create a Cloudflared Tunnel**
+   Create a tunnel in the [Cloudflare Zero Trust dashboard](https://one.dash.cloudflare.com/) or via the CLI, depending on which mode you plan to use.
 
-3. **Store Tunnel Files**
+### Remote Tunnel Mode
+
+Remote tunnels are created and managed entirely from the Cloudflare Zero Trust dashboard. After creating a tunnel, you will receive a tunnel token.
+
+#### Installing with a token value
+
+```console
+helm upgrade --install [RELEASE_NAME] community-charts/{{ template "chart.name" . }} -n [NAMESPACE] --create-namespace \
+  --set=tunnelMode=remote \
+  --set=tunnelToken.value=[TUNNEL_TOKEN]
+```
+
+#### Installing with an existing Kubernetes secret
+
+First, create a secret containing your tunnel token:
+
+```console
+kubectl create secret generic cloudflared-tunnel-token -n [NAMESPACE] \
+  --from-literal=tunnel-token=[TUNNEL_TOKEN]
+```
+
+Then install the chart referencing the secret:
+
+```console
+helm upgrade --install [RELEASE_NAME] community-charts/{{ template "chart.name" . }} -n [NAMESPACE] --create-namespace \
+  --set=tunnelMode=remote \
+  --set=tunnelToken.existingSecret.name=cloudflared-tunnel-token \
+  --set=tunnelToken.existingSecret.key=tunnel-token
+```
+
+### Local Tunnel Mode
+
+Local tunnels require a credentials JSON file and a certificate PEM file, which are created when you set up a tunnel via the Cloudflared CLI.
+
+#### Prerequisites for Local Mode
+
+1. **Set Up a Cloudflared Tunnel via CLI**
+   Follow the first three steps in [this guide](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/get-started/create-local-tunnel/) to create a Cloudflared tunnel using the CLI.
+
+2. **Store Tunnel Files**
    After creating your Cloudflared tunnel via CLI, ensure the following files are stored in the `~/.cloudflared` directory under your home directory:
    - Your tunnel credentials JSON file.
    - Your tunnel certificate PEM file.
 
-### Encoding and Configuring Tunnel Files
+#### Encoding and Configuring Tunnel Files
 
 To configure the chart, encode the required tunnel files using the following commands and set their values accordingly:
 
@@ -69,7 +113,7 @@ To configure the chart, encode the required tunnel files using the following com
 3. **Set the Tunnel Name**
    Pass the name of your tunnel, as created earlier via the Cloudflared CLI, to the `tunnelConfig.name` configuration.
 
-### Setting Credentials to Kubernetes Secrets and working with Existing Secrets
+#### Setting Credentials to Kubernetes Secrets and working with Existing Secrets
 
 ```console
 cp ~/.cloudflared/*.json ./credentials.json
@@ -88,7 +132,7 @@ tunnelSecrets:
     name: cert-pem-file-secret
 ```
 
-### Configuring Ingress
+#### Configuring Ingress
 
 The default ingress configuration is shown below. Replace the placeholder values with your domain and server settings. It is recommended to use a separate `values.yaml` file to manage this configuration.
 
@@ -100,7 +144,7 @@ ingress:
   - service: http_status:404
 ```
 
-### Installing the Chart
+#### Installing with Local Mode
 
 Use the following `helm` command to install or upgrade the chart. Replace the placeholders with your specific values:
 

--- a/charts/cloudflared/templates/NOTES.txt
+++ b/charts/cloudflared/templates/NOTES.txt
@@ -1,2 +1,7 @@
+{{- if eq .Values.tunnelMode "remote" }}
+Cloudflared is running in remote tunnel mode.
+Tunnel configuration is managed via the Cloudflare Zero Trust dashboard.
+{{- else }}
 {{- $config := .Values.tunnelSecrets.base64EncodedConfigJsonFile | b64dec | fromJson }}
 Please go to the Cloudflare dashboard, navigate to the DNS tab, and create a CNAME record specifically targeting {{ $config.TunnelID }}.cfargotunnel.com
+{{- end }}

--- a/charts/cloudflared/templates/configmap.yaml
+++ b/charts/cloudflared/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.tunnelMode "local" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -32,3 +33,4 @@ data:
     # info, warn, error, fatal, panic
     loglevel: {{ .Values.tunnelConfig.logLevel }}
     transport-loglevel: {{ .Values.tunnelConfig.transportLogLevel }}
+{{- end }}

--- a/charts/cloudflared/templates/configmap.yaml
+++ b/charts/cloudflared/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.tunnelMode "local" }}
+{{- if eq .Values.tunnelMode "local" -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -33,4 +33,4 @@ data:
     # info, warn, error, fatal, panic
     loglevel: {{ .Values.tunnelConfig.logLevel }}
     transport-loglevel: {{ .Values.tunnelConfig.transportLogLevel }}
-{{- end }}
+{{ end -}}

--- a/charts/cloudflared/templates/deployment.yaml
+++ b/charts/cloudflared/templates/deployment.yaml
@@ -25,7 +25,9 @@ spec:
   template:
     metadata:
       annotations:
+        {{- if eq .Values.tunnelMode "local" }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- end }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -45,23 +47,48 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- if eq .Values.tunnelMode "local" }}
           args:
             - tunnel
             - --config
             - /etc/cloudflared/config/config.yaml
             - run
+          {{- else }}
+          args:
+            - tunnel
+            - --no-autoupdate
+            - --metrics
+            - 0.0.0.0:2000
+            - run
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: active-con-stat
               containerPort: 2000
               protocol: TCP
           env:
+            {{- if eq .Values.tunnelMode "local" }}
             - name: TUNNEL_ORIGIN_CERT
               value: {{ printf "/etc/cloudflared/creds/%s" (default "cert.pem" .Values.tunnelSecrets.existingPemFileSecret.key) | quote }}
+            {{- else }}
+            - name: TUNNEL_TOKEN
+              {{- if .Values.tunnelToken.existingSecret.name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.tunnelToken.existingSecret.name }}
+                  key: {{ .Values.tunnelToken.existingSecret.key }}
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cloudflared.fullname" . }}-tunnel-token
+                  key: tunnel-token
+              {{- end }}
+            {{- end }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- if eq .Values.tunnelMode "local" }}
           volumeMounts:
             - name: config
               mountPath: /etc/cloudflared/config
@@ -69,8 +96,10 @@ spec:
             - name: creds
               mountPath: /etc/cloudflared/creds
               readOnly: true
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- if eq .Values.tunnelMode "local" }}
       volumes:
         - name: creds
           projected:
@@ -93,6 +122,7 @@ spec:
             items:
               - key: config.yaml
                 path: config.yaml
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/cloudflared/templates/secret.yaml
+++ b/charts/cloudflared/templates/secret.yaml
@@ -1,3 +1,16 @@
+{{- if eq .Values.tunnelMode "remote" }}
+{{- if not .Values.tunnelToken.existingSecret.name }}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "cloudflared.fullname" . }}-tunnel-token
+  labels:
+    {{- include "cloudflared.labels" . | nindent 4 }}
+data:
+  tunnel-token: {{ required "tunnelToken.value is required when tunnelMode is 'remote' and no existingSecret is provided" .Values.tunnelToken.value | b64enc | quote }}
+{{- end }}
+{{- else }}
 {{- if or (eq .Values.tunnelSecrets.existingPemFileSecret.name "") (eq .Values.tunnelSecrets.existingConfigJsonFileSecret.name "") }}
 apiVersion: v1
 kind: Secret
@@ -11,4 +24,5 @@ data:
   {{- if eq .Values.tunnelSecrets.existingPemFileSecret.name "" }}
   cert.pem: {{ required "Base64 encoded certificate pem file string is required! Run base64 -b 0 -i ~/.cloudflared/cert.pem and add output to tunnelSecrets.base64EncodedPemFile in values.yaml file." .Values.tunnelSecrets.base64EncodedPemFile | quote }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/cloudflared/unittests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/cloudflared/unittests/__snapshot__/configmap_test.yaml.snap
@@ -2,7 +2,7 @@ should match snapshot of default values:
   1: |
     apiVersion: v1
     data:
-      config.yaml: "tunnel: unittest\ncredentials-file: /etc/cloudflared/creds/credentials.json\noriginRequest:\n  connectTimeout: 30s\n\ningress: \n  - hostname: example.com\n    service: http://traefik.kube-system.svc.cluster.local:80\n  - service: http_status:404\n\nmetrics: 0.0.0.0:2000\nmetrics-update-freq: 5s\n\nautoupdate-freq: 24h\nno-autoupdate: true\n\ngrace-period: 30s\n\nretries: 5\n\n# auto, http2, h2mux, quic\nprotocol: auto\n\n# info, warn, error, fatal, panic\nloglevel: info\ntransport-loglevel: warn\n"
+      config.yaml: "\ntunnel: unittest\ncredentials-file: /etc/cloudflared/creds/credentials.json\noriginRequest:\n  connectTimeout: 30s\n\ningress: \n  - hostname: example.com\n    service: http://traefik.kube-system.svc.cluster.local:80\n  - service: http_status:404\n\nmetrics: 0.0.0.0:2000\nmetrics-update-freq: 5s\n\nautoupdate-freq: 24h\nno-autoupdate: true\n\ngrace-period: 30s\n\nretries: 5\n\n# auto, http2, h2mux, quic\nprotocol: auto\n\n# info, warn, error, fatal, panic\nloglevel: info\ntransport-loglevel: warn\n"
     kind: ConfigMap
     metadata:
       name: cloudflared
@@ -10,7 +10,7 @@ should match snapshot of warp routing on:
   1: |
     apiVersion: v1
     data:
-      config.yaml: "tunnel: unittest\ncredentials-file: /etc/cloudflared/creds/credentials.json\noriginRequest:\n  connectTimeout: 30s\nwarp-routing:\n  enabled: true\n\ningress: \n  - hostname: example.com\n    service: http://traefik.kube-system.svc.cluster.local:80\n  - service: http_status:404\n\nmetrics: 0.0.0.0:2000\nmetrics-update-freq: 5s\n\nautoupdate-freq: 24h\nno-autoupdate: true\n\ngrace-period: 30s\n\nretries: 5\n\n# auto, http2, h2mux, quic\nprotocol: auto\n\n# info, warn, error, fatal, panic\nloglevel: info\ntransport-loglevel: warn\n"
+      config.yaml: "\ntunnel: unittest\ncredentials-file: /etc/cloudflared/creds/credentials.json\noriginRequest:\n  connectTimeout: 30s\nwarp-routing:\n  enabled: true\n\ningress: \n  - hostname: example.com\n    service: http://traefik.kube-system.svc.cluster.local:80\n  - service: http_status:404\n\nmetrics: 0.0.0.0:2000\nmetrics-update-freq: 5s\n\nautoupdate-freq: 24h\nno-autoupdate: true\n\ngrace-period: 30s\n\nretries: 5\n\n# auto, http2, h2mux, quic\nprotocol: auto\n\n# info, warn, error, fatal, panic\nloglevel: info\ntransport-loglevel: warn\n"
     kind: ConfigMap
     metadata:
       name: cloudflared

--- a/charts/cloudflared/unittests/__snapshot__/configmap_test.yaml.snap
+++ b/charts/cloudflared/unittests/__snapshot__/configmap_test.yaml.snap
@@ -2,7 +2,7 @@ should match snapshot of default values:
   1: |
     apiVersion: v1
     data:
-      config.yaml: "\ntunnel: unittest\ncredentials-file: /etc/cloudflared/creds/credentials.json\noriginRequest:\n  connectTimeout: 30s\n\ningress: \n  - hostname: example.com\n    service: http://traefik.kube-system.svc.cluster.local:80\n  - service: http_status:404\n\nmetrics: 0.0.0.0:2000\nmetrics-update-freq: 5s\n\nautoupdate-freq: 24h\nno-autoupdate: true\n\ngrace-period: 30s\n\nretries: 5\n\n# auto, http2, h2mux, quic\nprotocol: auto\n\n# info, warn, error, fatal, panic\nloglevel: info\ntransport-loglevel: warn\n"
+      config.yaml: "tunnel: unittest\ncredentials-file: /etc/cloudflared/creds/credentials.json\noriginRequest:\n  connectTimeout: 30s\n\ningress: \n  - hostname: example.com\n    service: http://traefik.kube-system.svc.cluster.local:80\n  - service: http_status:404\n\nmetrics: 0.0.0.0:2000\nmetrics-update-freq: 5s\n\nautoupdate-freq: 24h\nno-autoupdate: true\n\ngrace-period: 30s\n\nretries: 5\n\n# auto, http2, h2mux, quic\nprotocol: auto\n\n# info, warn, error, fatal, panic\nloglevel: info\ntransport-loglevel: warn\n"
     kind: ConfigMap
     metadata:
       name: cloudflared
@@ -10,7 +10,7 @@ should match snapshot of warp routing on:
   1: |
     apiVersion: v1
     data:
-      config.yaml: "\ntunnel: unittest\ncredentials-file: /etc/cloudflared/creds/credentials.json\noriginRequest:\n  connectTimeout: 30s\nwarp-routing:\n  enabled: true\n\ningress: \n  - hostname: example.com\n    service: http://traefik.kube-system.svc.cluster.local:80\n  - service: http_status:404\n\nmetrics: 0.0.0.0:2000\nmetrics-update-freq: 5s\n\nautoupdate-freq: 24h\nno-autoupdate: true\n\ngrace-period: 30s\n\nretries: 5\n\n# auto, http2, h2mux, quic\nprotocol: auto\n\n# info, warn, error, fatal, panic\nloglevel: info\ntransport-loglevel: warn\n"
+      config.yaml: "tunnel: unittest\ncredentials-file: /etc/cloudflared/creds/credentials.json\noriginRequest:\n  connectTimeout: 30s\nwarp-routing:\n  enabled: true\n\ningress: \n  - hostname: example.com\n    service: http://traefik.kube-system.svc.cluster.local:80\n  - service: http_status:404\n\nmetrics: 0.0.0.0:2000\nmetrics-update-freq: 5s\n\nautoupdate-freq: 24h\nno-autoupdate: true\n\ngrace-period: 30s\n\nretries: 5\n\n# auto, http2, h2mux, quic\nprotocol: auto\n\n# info, warn, error, fatal, panic\nloglevel: info\ntransport-loglevel: warn\n"
     kind: ConfigMap
     metadata:
       name: cloudflared

--- a/charts/cloudflared/unittests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/cloudflared/unittests/__snapshot__/deployment_test.yaml.snap
@@ -2,7 +2,7 @@ should match snapshot of default values:
   1: |
     apiVersion: v1
     data:
-      config.yaml: "\ntunnel: unittest\ncredentials-file: /etc/cloudflared/creds/credentials.json\noriginRequest:\n  connectTimeout: 30s\n\ningress: \n  - hostname: example.com\n    service: http://traefik.kube-system.svc.cluster.local:80\n  - service: http_status:404\n\nmetrics: 0.0.0.0:2000\nmetrics-update-freq: 5s\n\nautoupdate-freq: 24h\nno-autoupdate: true\n\ngrace-period: 30s\n\nretries: 5\n\n# auto, http2, h2mux, quic\nprotocol: auto\n\n# info, warn, error, fatal, panic\nloglevel: info\ntransport-loglevel: warn\n"
+      config.yaml: "tunnel: unittest\ncredentials-file: /etc/cloudflared/creds/credentials.json\noriginRequest:\n  connectTimeout: 30s\n\ningress: \n  - hostname: example.com\n    service: http://traefik.kube-system.svc.cluster.local:80\n  - service: http_status:404\n\nmetrics: 0.0.0.0:2000\nmetrics-update-freq: 5s\n\nautoupdate-freq: 24h\nno-autoupdate: true\n\ngrace-period: 30s\n\nretries: 5\n\n# auto, http2, h2mux, quic\nprotocol: auto\n\n# info, warn, error, fatal, panic\nloglevel: info\ntransport-loglevel: warn\n"
     kind: ConfigMap
     metadata:
       name: cloudflared
@@ -29,7 +29,7 @@ should match snapshot of default values:
       template:
         metadata:
           annotations:
-            checksum/config: 6914168e330d7d7832f59de17cb31e7f60be876dd10f1e52413ad6057a1f8076
+            checksum/config: 3e285a26cff83736e271964f306496425ea30ac9f330eebe28f5ebe8b7f1514d
           labels:
             app: cloudflared
             app.kubernetes.io/instance: cloudflared
@@ -108,6 +108,89 @@ should match snapshot of default values:
                     path: config.yaml
                 name: cloudflared
               name: config
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 1
+        type: RollingUpdate
+should match snapshot of remote mode:
+  1: |
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        app: cloudflared
+        app.kubernetes.io/instance: cloudflared
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: cloudflared
+        app.kubernetes.io/version: 1.0.0
+        helm.sh/chart: cloudflared-1.0.0
+      name: cloudflared
+    spec:
+      selector:
+        matchLabels:
+          app: cloudflared
+          app.kubernetes.io/instance: cloudflared
+          app.kubernetes.io/name: cloudflared
+      template:
+        metadata:
+          annotations: null
+          labels:
+            app: cloudflared
+            app.kubernetes.io/instance: cloudflared
+            app.kubernetes.io/name: cloudflared
+        spec:
+          containers:
+            - args:
+                - tunnel
+                - --no-autoupdate
+                - --metrics
+                - 0.0.0.0:2000
+                - run
+              env:
+                - name: TUNNEL_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      key: tunnel-token
+                      name: cloudflared-tunnel-token
+              image: cloudflare/cloudflared:1.0.0
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 1
+                httpGet:
+                  path: /ready
+                  port: 2000
+                initialDelaySeconds: 10
+                periodSeconds: 10
+              name: cloudflared
+              ports:
+                - containerPort: 2000
+                  name: active-con-stat
+                  protocol: TCP
+              resources: {}
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  add: []
+                  drop:
+                    - ALL
+                privileged: false
+                readOnlyRootFilesystem: true
+                runAsGroup: 65532
+                runAsNonRoot: true
+                runAsUser: 65532
+          nodeSelector:
+            kubernetes.io/os: linux
+          securityContext:
+            fsGroup: 65532
+            fsGroupChangePolicy: OnRootMismatch
+            sysctls:
+              - name: net.ipv4.ping_group_range
+                value: 0 2147483647
+          serviceAccountName: cloudflared
+          terminationGracePeriodSeconds: 30
+          tolerations:
+            - effect: NoSchedule
+              operator: Exists
       updateStrategy:
         rollingUpdate:
           maxUnavailable: 1

--- a/charts/cloudflared/unittests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/cloudflared/unittests/__snapshot__/deployment_test.yaml.snap
@@ -2,7 +2,7 @@ should match snapshot of default values:
   1: |
     apiVersion: v1
     data:
-      config.yaml: "tunnel: unittest\ncredentials-file: /etc/cloudflared/creds/credentials.json\noriginRequest:\n  connectTimeout: 30s\n\ningress: \n  - hostname: example.com\n    service: http://traefik.kube-system.svc.cluster.local:80\n  - service: http_status:404\n\nmetrics: 0.0.0.0:2000\nmetrics-update-freq: 5s\n\nautoupdate-freq: 24h\nno-autoupdate: true\n\ngrace-period: 30s\n\nretries: 5\n\n# auto, http2, h2mux, quic\nprotocol: auto\n\n# info, warn, error, fatal, panic\nloglevel: info\ntransport-loglevel: warn\n"
+      config.yaml: "\ntunnel: unittest\ncredentials-file: /etc/cloudflared/creds/credentials.json\noriginRequest:\n  connectTimeout: 30s\n\ningress: \n  - hostname: example.com\n    service: http://traefik.kube-system.svc.cluster.local:80\n  - service: http_status:404\n\nmetrics: 0.0.0.0:2000\nmetrics-update-freq: 5s\n\nautoupdate-freq: 24h\nno-autoupdate: true\n\ngrace-period: 30s\n\nretries: 5\n\n# auto, http2, h2mux, quic\nprotocol: auto\n\n# info, warn, error, fatal, panic\nloglevel: info\ntransport-loglevel: warn\n"
     kind: ConfigMap
     metadata:
       name: cloudflared
@@ -29,7 +29,7 @@ should match snapshot of default values:
       template:
         metadata:
           annotations:
-            checksum/config: 3e285a26cff83736e271964f306496425ea30ac9f330eebe28f5ebe8b7f1514d
+            checksum/config: 6914168e330d7d7832f59de17cb31e7f60be876dd10f1e52413ad6057a1f8076
           labels:
             app: cloudflared
             app.kubernetes.io/instance: cloudflared
@@ -117,6 +117,8 @@ should match snapshot of remote mode:
     apiVersion: apps/v1
     kind: DaemonSet
     metadata:
+      annotations:
+        ignore-check.kube-linter.io/unsafe-sysctls: net.ipv4.ping_group_range is required for cloudflared ICMP tunneling support
       labels:
         app: cloudflared
         app.kubernetes.io/instance: cloudflared
@@ -166,6 +168,12 @@ should match snapshot of remote mode:
                 - containerPort: 2000
                   name: active-con-stat
                   protocol: TCP
+              readinessProbe:
+                httpGet:
+                  path: /ready
+                  port: 2000
+                initialDelaySeconds: 10
+                periodSeconds: 10
               resources: {}
               securityContext:
                 allowPrivilegeEscalation: false

--- a/charts/cloudflared/unittests/configmap_test.yaml
+++ b/charts/cloudflared/unittests/configmap_test.yaml
@@ -56,3 +56,12 @@ tests:
       appVersion: 1.0.0
     asserts:
       - matchSnapshot: { }
+
+  - it: should not render configmap in remote mode
+    set:
+      tunnelMode: remote
+      tunnelToken:
+        value: my-test-token
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/cloudflared/unittests/deployment_test.yaml
+++ b/charts/cloudflared/unittests/deployment_test.yaml
@@ -237,3 +237,101 @@ tests:
       appVersion: 1.0.0
     asserts:
       - matchSnapshot: { }
+
+  # Remote tunnel mode tests
+  - it: should use remote args in remote mode
+    set:
+      tunnelMode: remote
+      tunnelToken:
+        value: my-test-token
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "cloudflared")].args
+          content: "run"
+        template: deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "cloudflared")].args
+          content: "--no-autoupdate"
+        template: deployment.yaml
+
+  - it: should not have volume mounts in remote mode
+    set:
+      tunnelMode: remote
+      tunnelToken:
+        value: my-test-token
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[?(@.name == "cloudflared")].volumeMounts
+        template: deployment.yaml
+
+  - it: should not have volumes in remote mode
+    set:
+      tunnelMode: remote
+      tunnelToken:
+        value: my-test-token
+    asserts:
+      - isNull:
+          path: spec.template.spec.volumes
+        template: deployment.yaml
+
+  - it: should set TUNNEL_TOKEN env from chart-created secret in remote mode
+    set:
+      tunnelMode: remote
+      tunnelToken:
+        value: my-test-token
+    release:
+      name: cloudflared
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "cloudflared")].env
+          content:
+            name: TUNNEL_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: cloudflared-tunnel-token
+                key: tunnel-token
+        template: deployment.yaml
+
+  - it: should set TUNNEL_TOKEN env from existing secret in remote mode
+    set:
+      tunnelMode: remote
+      tunnelToken:
+        existingSecret:
+          name: my-tunnel-secret
+          key: my-token-key
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "cloudflared")].env
+          content:
+            name: TUNNEL_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: my-tunnel-secret
+                key: my-token-key
+        template: deployment.yaml
+
+  - it: should use DaemonSet in remote mode when allNodes enabled
+    set:
+      tunnelMode: remote
+      tunnelToken:
+        value: my-test-token
+      replica:
+        allNodes: true
+    asserts:
+      - isKind:
+          of: DaemonSet
+        template: deployment.yaml
+
+  - it: should match snapshot of remote mode
+    set:
+      tunnelMode: remote
+      tunnelToken:
+        value: my-test-token
+    release:
+      name: cloudflared
+      namespace: cloudflare
+    chart:
+      version: 1.0.0
+      appVersion: 1.0.0
+    asserts:
+      - matchSnapshot: { }

--- a/charts/cloudflared/values.schema.json
+++ b/charts/cloudflared/values.schema.json
@@ -927,6 +927,52 @@
       "title": "tunnelConfig",
       "type": "object"
     },
+    "tunnelMode": {
+      "default": "local",
+      "description": "Tunnel mode: 'local' for locally-managed tunnels (config file + credentials), 'remote' for remotely-managed tunnels (token-based, configured in Cloudflare dashboard)",
+      "required": [],
+      "title": "tunnelMode",
+      "type": "string",
+      "enum": ["local", "remote"]
+    },
+    "tunnelToken": {
+      "additionalProperties": false,
+      "description": "Tunnel token for remote mode. Only used when tunnelMode is 'remote'.",
+      "properties": {
+        "value": {
+          "default": "",
+          "description": "The tunnel token value.",
+          "required": [],
+          "title": "value",
+          "type": "string"
+        },
+        "existingSecret": {
+          "additionalProperties": false,
+          "description": "Use an existing secret containing the tunnel token.",
+          "properties": {
+            "name": {
+              "default": "",
+              "description": "Name of the existing secret.",
+              "required": [],
+              "title": "name",
+              "type": "string"
+            },
+            "key": {
+              "default": "tunnel-token",
+              "description": "Key in the secret containing the tunnel token.",
+              "required": [],
+              "title": "key",
+              "type": "string"
+            }
+          },
+          "required": ["name", "key"],
+          "type": "object"
+        }
+      },
+      "required": [],
+      "title": "tunnelToken",
+      "type": "object"
+    },
     "tunnelSecrets": {
       "additionalProperties": false,
       "properties": {
@@ -1017,6 +1063,7 @@
     "podLabels",
     "podSecurityContext",
     "securityContext",
+    "tunnelMode",
     "tunnelSecrets",
     "tunnelConfig",
     "livenessProbe",

--- a/charts/cloudflared/values.yaml
+++ b/charts/cloudflared/values.yaml
@@ -70,7 +70,21 @@ securityContext:
   runAsUser: 65532
   runAsGroup: 65532
 
-# -- This is for setting up the cloudflared tunnel secrets. For more information checkout: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/do-more-with-tunnels/local-management/create-local-tunnel/
+# -- Tunnel mode: "local" for locally-managed tunnels (config file + credentials), "remote" for remotely-managed tunnels (token-based, configured in Cloudflare dashboard)
+tunnelMode: local
+
+# -- Tunnel token for remote mode. Get this from the Cloudflare Zero Trust dashboard. Only used when tunnelMode is "remote".
+tunnelToken:
+  # -- The tunnel token value. Either set this or use existingSecret.
+  value: ""
+  # -- Use an existing secret containing the tunnel token.
+  existingSecret:
+    # -- Name of the existing secret.
+    name: ""
+    # -- Key in the secret containing the tunnel token.
+    key: "tunnel-token"
+
+# -- This is for setting up the cloudflared tunnel secrets. Only used when tunnelMode is "local". For more information checkout: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/do-more-with-tunnels/local-management/create-local-tunnel/
 tunnelSecrets:
   # -- This is for cloudflared tunnel certificate PEM file.
   base64EncodedPemFile: ""
@@ -89,7 +103,7 @@ tunnelSecrets:
     # -- This is the key of the configuration JSON file in the existing secret.
     key: "credentials.json"
 
-# -- Please find more configuration from https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/configuration/arguments/
+# -- Please find more configuration from https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/configuration/arguments/. Only used when tunnelMode is "local".
 tunnelConfig:
   # -- cloudflared tunnel name
   name: ""
@@ -106,7 +120,7 @@ tunnelConfig:
   connectTimeout: 30s
   warpRouting: false
 
-# -- Cloudflare ingress rules. More information can be found here: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/configure-tunnels/local-management/configuration-file/#how-traffic-is-matched
+# -- Cloudflare ingress rules. Only used when tunnelMode is "local". More information can be found here: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/configure-tunnels/local-management/configuration-file/#how-traffic-is-matched
 ingress:
   - hostname: example.com # or "*.example.com" but you must define a CNAME record for "*" to your DNS
     service: http://traefik.kube-system.svc.cluster.local:80


### PR DESCRIPTION
#### What this PR does / why we need it:

Revives #432 (@elliot's work, cherry-picked with authorship and sign-off intact), rebased onto current `main`, **with the maintainer's question answered by measurement** and one behaviour fix found while answering it.

@burakince, on #432 you asked:

> Have you able to test this locally? Because it was not working with remote token a few years ago. Maybe they fixed the problem.

**It works.** I ran it against a real, remotely-managed Cloudflare tunnel created for this purpose (and destroyed afterwards), with cloudflared **2026.8.2**, the version this chart currently pins:

```
INF Version 2026.8.2
INF Registered tunnel connection connIndex=0 … location=hkg09 protocol=quic
INF Updated to new configuration config="{\"ingress\":[{\"service\":\"http_status:404\"}], \"warp-routing\":{\"enabled\":false}}" version=1
INF Registered tunnel connection connIndex=1 … protocol=quic
INF Registered tunnel connection connIndex=2 … protocol=quic
INF Registered tunnel connection connIndex=3 … protocol=quic
```

That `Updated to new configuration` line is the whole answer — the connector fetched its ingress table from the edge using nothing but `TUNNEL_TOKEN`, and it matches exactly what the tunnel was configured with. Cloudflare's API reported the tunnel `status: healthy` with `connections: 4` and `config_src: cloudflare`.

Both token paths were exercised on a real cluster, not just rendered:

| Path | Result |
|---|---|
| `tunnelToken.existingSecret` | pod Running 1/1, 4 QUIC connections, remote config received |
| `tunnelToken.value` (chart-created Secret) | same, after `helm upgrade`; env correctly points at `<release>-cloudflared-tunnel-token` |

#### Which issue this PR fixes

  - fixes #424

#### Special notes for your reviewer:

**One real fix on top of the original PR — the upgrade must not restart existing installs.**

Wrapping `configmap.yaml` in `{{- if ... }}` prepends a newline to the template's rendered output, and `deployment.yaml` hashes exactly that output into `checksum/config`. Every existing local-mode release would therefore have rolled its pods on upgrade, for a config that did not change. Rendering the file as `{{- if ... -}}` / `{{ end -}}` restores byte-exact output and the checksum is again the one 2.2.16 produces.

Concretely, rendering a real local-mode release against `2.2.16` and against this branch now differs **only** in the `helm.sh/chart` label — the pod template is byte-identical, so upgrading changes nothing.

**Snapshots were regenerated with helm-unittest `v0.8.2`,** the version `release.yml` pins. Newer plugin versions serialise the `config.yaml` block scalar without its leading newline, which I think is what produced the churn your CI-version commit had to undo on the original PR. With the pinned version the snapshot diff against `main` is **purely additive: +91 lines, 0 removed**, and `configmap_test.yaml.snap` is untouched.

**Rebase notes:**

- `values.schema.json` — `main` gained `livenessProbe`/`readinessProbe` in the same region this feature adds `tunnelMode`/`tunnelToken`; merged both. I kept the root `required` list as it is on `main` and only added `tunnelMode`. The original PR also dropped `tunnelSecrets`/`tunnelConfig`/`ingress` from `required`, which is a no-op in practice (Helm always merges chart defaults, so those keys are always present) and needlessly relaxes validation — happy to restore that if you prefer it.
- `deployment.yaml` — probes are value-driven on `main` now; kept that alongside the local-mode gate on `volumeMounts`.
- Version bumped `2.2.16` → `2.3.0` (additive feature, default `tunnelMode: local`, no behaviour change for existing users).

**Validation run locally, matching what CI does** (note `charts/cloudflared/.skip-kind-test` means `ct install` is skipped for this chart):

- `helm unittest --strict` → 30/30 tests, 5/5 snapshots
- `ct lint` with `.github/configs/ct-lint.yaml` + `lintconf.yaml` → passes
- `helm-docs` → README regenerated, idempotent
- Schema negatives: `tunnelMode=bogus` rejected by the enum; unknown top-level keys rejected by `additionalProperties: false`; remote mode with neither `tunnelToken.value` nor an `existingSecret` fails with its `required` message
- Remote mode honours `imagePullSecrets`, `podSecurityContext`, `securityContext`, `resources`, `nodeSelector`, `tolerations` and both probes (verified against a non-trivial values file, DaemonSet mode)

Credit for the feature itself belongs to @elliot — I only rebased it, fixed the checksum behaviour, and supplied the runtime evidence.

#### Checklist
- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated
