### PR TITLE
[outline] Update outline chart to 1.10.0

### DIFF
--- a/charts/outline/Chart.lock
+++ b/charts/outline/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 27.0.15
+  version: 28.0.12
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 18.8.0
+  version: 18.8.13
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:2eb2547d70b6fd339db1234d11dc883b87493c097c898d35577c633ccbf82d68
-generated: "2026-07-21T02:56:42.378441516Z"
+digest: sha256:7d5f562861533981d3a3eef8f592190466c4167e7dc5e46a36859d8926a9bde5
+generated: "2026-09-02T02:50:04.776065286Z"

--- a/charts/outline/Chart.yaml
+++ b/charts/outline/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.3
+version: 0.9.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.9.2"
+appVersion: "1.10.0"
 kubeVersion: ">=1.23.0-0"
 home: https://www.getoutline.com/
 maintainers:
@@ -53,18 +53,23 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update outlinewiki/outline image version to 1.9.2
+      description: Update outlinewiki/outline image version to 1.10.0
       links:
         - name: Upstream Project
           url: https://hub.docker.com/r/outlinewiki/outline
     - kind: changed
-      description: Update dependency postgresql from 18.7.13 to 18.8.0
+      description: Update dependency redis from 27.0.15 to 28.0.12
+      links:
+        - name: ArtifactHub
+          url: https://artifacthub.io/packages/helm/bitnami/redis
+    - kind: changed
+      description: Update dependency postgresql from 18.8.0 to 18.8.13
       links:
         - name: ArtifactHub
           url: https://artifacthub.io/packages/helm/bitnami/postgresql
   artifacthub.io/images: |
     - name: outline
-      image: outlinewiki/outline:1.9.2
+      image: outlinewiki/outline:1.10.0
       platforms:
         - linux/amd64
         - linux/arm64
@@ -83,11 +88,11 @@ annotations:
     url: https://keybase.io/communitycharts/pgp_keys.asc
 dependencies:
   - name: redis
-    version: 27.0.15
+    version: 28.0.12
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: postgresql
-    version: 18.8.0
+    version: 18.8.13
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: minio

--- a/charts/outline/README.md
+++ b/charts/outline/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for the fastest knowledge base for growing teams. Beautiful, realtime collaborative, feature packed, and markdown compatible.
 
-![Version: 0.9.3](https://img.shields.io/badge/Version-0.9.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.2](https://img.shields.io/badge/AppVersion-1.9.2-informational?style=flat-square)
+![Version: 0.9.4](https://img.shields.io/badge/Version-0.9.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.0](https://img.shields.io/badge/AppVersion-1.10.0-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -516,8 +516,8 @@ Kubernetes: `>=1.23.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 18.8.0 |
-| https://charts.bitnami.com/bitnami | redis | 27.0.15 |
+| https://charts.bitnami.com/bitnami | postgresql | 18.8.13 |
+| https://charts.bitnami.com/bitnami | redis | 28.0.12 |
 | https://charts.min.io/ | minio | 5.4.0 |
 
 ## Uninstall Helm Chart


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the outline chart to use the latest image version 1.10.0 from outlinewiki/outline. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated