### PR TITLE
[mlflow] Cap dbchecker init container backoff at 30 seconds

### DIFF
--- a/charts/mlflow/CLAUDE.md
+++ b/charts/mlflow/CLAUDE.md
@@ -92,7 +92,7 @@ When `oidcAuth.enabled`, the chart injects this same secret as `SECRET_KEY` (the
 
 When a database is configured the init containers always run in this fixed order:
 
-1. **dbchecker** — polls DB port using Fibonacci-backoff netcat (unbounded retries); runs only when `backendStore.databaseConnectionCheck: true`
+1. **dbchecker** — polls DB port with netcat using an iterative Fibonacci backoff capped at 30 s (`MAX_SLEEP` in `files/dbchecker.sh`; retries forever); runs only when `backendStore.databaseConnectionCheck: true`
 2. **mlflow-db-migration** — runs `python /opt/mlflow/migrations.py` (wraps `mlflow db upgrade`); runs only when `backendStore.databaseMigration: true`
 3. **ini-file-initializer** — writes `auth_result.ini` into an `emptyDir` shared with the main container; runs when `auth.enabled` or `ldapAuth.enabled`. Uses `sed` when `auth.enabled` (substitutes `$(ADMIN_USERNAME_PLACEHOLDER)` etc. from secrets); uses `cp` when only `ldapAuth.enabled` (no placeholders — the INI uses literal `fakeuser`/`fakepassword`, secrets are not needed)
 4. **user-provided** `initContainers` — appended last

--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.11.7
+version: 1.11.8
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -51,16 +51,11 @@ annotations:
       url: https://github.com/burakince/mlflow
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
-    - kind: changed
-      description: Update burakince/mlflow image version to 3.16.0
+    - kind: fixed
+      description: Cap the dbchecker init container retry sleep at 30 seconds and compute the Fibonacci backoff iteratively instead of with a recursive subshell function
       links:
-        - name: Upstream Project
-          url: https://hub.docker.com/r/burakince/mlflow
-    - kind: changed
-      description: Update dependency postgresql from 18.8.13 to 18.8.17
-      links:
-        - name: ArtifactHub
-          url: https://artifacthub.io/packages/helm/bitnami/postgresql
+        - name: GitHub Issue
+          url: https://github.com/community-charts/helm-charts/issues/604
   artifacthub.io/images: |-
     - name: mlflow
       image: burakince/mlflow:3.16.0

--- a/charts/mlflow/README.md
+++ b/charts/mlflow/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for Mlflow open source platform for the machine learning lifecycle
 
-![Version: 1.11.7](https://img.shields.io/badge/Version-1.11.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.16.0](https://img.shields.io/badge/AppVersion-3.16.0-informational?style=flat-square)
+![Version: 1.11.8](https://img.shields.io/badge/Version-1.11.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.16.0](https://img.shields.io/badge/AppVersion-3.16.0-informational?style=flat-square)
 
 ## Official Documentation
 

--- a/charts/mlflow/files/dbchecker.sh
+++ b/charts/mlflow/files/dbchecker.sh
@@ -20,25 +20,24 @@ else
   PORT="${MSSQL_TCP_PORT}"
 fi
 
-COUNT=0
-
-function fib() {
-  if [ $1 -le 0 ]; then
-    echo 0
-  elif [ $1 -eq 1 ]; then
-    echo 1
-  else
-    echo $(( $(fib $(($1 - 1)) ) + $(fib $(($1 - 2)) ) ))
-  fi
-}
+# Retry with an iterative Fibonacci backoff (1, 1, 2, 3, 5, 8, ...) clamped to
+# MAX_SLEEP seconds, so a database that comes back after a long outage is
+# noticed within MAX_SLEEP seconds instead of after an ever-growing sleep.
+MAX_SLEEP=30
+PREV_SLEEP=0
+SLEEP_TIME=1
 
 echo "[INFO] Waiting for Database to become ready..."
 
 until nc -z -w 2 $HOST $PORT; do
-  COUNT=$((COUNT + 1));
-  SLEEP_TIME=$(fib $COUNT);
   echo "[WARNING] Unable to access database! Sleeping $SLEEP_TIME seconds. Waiting for $HOST to listen on $PORT...";
   sleep $SLEEP_TIME;
+  NEXT_SLEEP=$((PREV_SLEEP + SLEEP_TIME));
+  PREV_SLEEP=$SLEEP_TIME;
+  SLEEP_TIME=$NEXT_SLEEP;
+  if [ $SLEEP_TIME -gt $MAX_SLEEP ]; then
+    SLEEP_TIME=$MAX_SLEEP;
+  fi
 done;
 
 echo "[INFO] Database OK ✓"

--- a/charts/mlflow/unittests/configmap_test.yaml
+++ b/charts/mlflow/unittests/configmap_test.yaml
@@ -53,6 +53,28 @@ tests:
       - hasDocuments:
           count: 2
 
+  - it: should render a bounded iterative backoff in the database connection checker script
+    set:
+      backendStore.postgres.enabled: true
+      backendStore.postgres.host: postgres-service
+      backendStore.postgres.port: 5432
+      backendStore.postgres.database: postgres
+      backendStore.databaseConnectionCheck: true
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: metadata.name
+          value: mlflow-dbchecker
+      - matchRegex:
+          path: data["dbchecker.sh"]
+          pattern: MAX_SLEEP=30
+      - matchRegex:
+          path: data["dbchecker.sh"]
+          pattern: if \[ \$SLEEP_TIME -gt \$MAX_SLEEP \]; then
+      - notMatchRegex:
+          path: data["dbchecker.sh"]
+          pattern: fib
+
   - it: should have mysql environments when mysql is enabled
     set:
       backendStore.mysql.enabled: true


### PR DESCRIPTION
#### What this PR does / why we need it:

## Problem

When `backendStore.databaseConnectionCheck: true`, the `dbchecker` init container waits for the database with a Fibonacci sleep that has no upper bound. Once the database has been unreachable for about an hour the next single `sleep` is already 43 min to 1.9 h and keeps growing, so the pod stays in `Init:0/N` for hours after the database is reachable again. The only recovery is deleting the pod.

## Root cause

`charts/mlflow/files/dbchecker.sh` computes `SLEEP_TIME=$(fib $COUNT)` with a naive recursive `fib()` where every recursion is a `$(...)` subshell. Two effects:

- the sleep value follows `fib(n)` with no cap: 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, ..., 2584, 4181, ...
- computing one value forks `2*fib(n+1)-1` processes (~8k for n=18, ~150k for n=24); `fib(16)` alone takes seconds of CPU in the init container just to decide how long to sleep.

## Fix

Only the retry loop in `files/dbchecker.sh` changes:

- the Fibonacci sequence is computed iteratively (`NEXT = PREV + CURRENT`), no recursion, no forks;
- the sleep is clamped to `MAX_SLEEP=30` seconds, so a recovered database is detected within 30 s regardless of how long the outage lasted;
- the first eight sleep values (1, 1, 2, 3, 5, 8, 13, 21) and every log line are unchanged; the host/port selection and `nc -z -w 2` probe are untouched.

The cap is a constant with a comment rather than a new value, since the chart exposes no tuning knobs for this init container today. Chart version bumped to 1.11.8, `artifacthub.io/changes` updated, `charts/mlflow/CLAUDE.md` init-container description updated to match.

## How tested

Rendered ConfigMap `mlflow-dbchecker` key `dbchecker.sh` before/after (`helm template ... --set backendStore.postgres.enabled=true --set backendStore.databaseConnectionCheck=true`):

```diff
-COUNT=0
-
-function fib() {
-  if [ $1 -le 0 ]; then
-    echo 0
-  elif [ $1 -eq 1 ]; then
-    echo 1
-  else
-    echo $(( $(fib $(($1 - 1)) ) + $(fib $(($1 - 2)) ) ))
-  fi
-}
+# Retry with an iterative Fibonacci backoff (1, 1, 2, 3, 5, 8, ...) clamped to
+# MAX_SLEEP seconds, so a database that comes back after a long outage is
+# noticed within MAX_SLEEP seconds instead of after an ever-growing sleep.
+MAX_SLEEP=30
+PREV_SLEEP=0
+SLEEP_TIME=1
 
 echo "[INFO] Waiting for Database to become ready..."
 
 until nc -z -w 2 $HOST $PORT; do
-  COUNT=$((COUNT + 1));
-  SLEEP_TIME=$(fib $COUNT);
   echo "[WARNING] Unable to access database! Sleeping $SLEEP_TIME seconds. Waiting for $HOST to listen on $PORT...";
   sleep $SLEEP_TIME;
+  NEXT_SLEEP=$((PREV_SLEEP + SLEEP_TIME));
+  PREV_SLEEP=$SLEEP_TIME;
+  SLEEP_TIME=$NEXT_SLEEP;
+  if [ $SLEEP_TIME -gt $MAX_SLEEP ]; then
+    SLEEP_TIME=$MAX_SLEEP;
+  fi
 done;
```

The rest of the rendered output is identical apart from the chart label and the pod `checksum/config` annotation (which changes because the ConfigMap content changed, so existing pods roll once on upgrade). The deployment's `dbchecker` init container spec is unchanged.

Sleep sequence, timing-free: the script was run in the chart's default init image `busybox:1.38.0` with `nc` stubbed to fail 20 times and `sleep` stubbed to record its argument (busybox `sh` prefers its own applets over `PATH`, so a copy of the script with only those two command names redirected to the stubs was used; everything else verbatim). Output for 20 failed probes:

```
new: 1 1 2 3 5 8 13 21 30 30 30 30 30 30 30 30 30 30 30 30   (max 30, exit 0, "[INFO] Database OK")
old: 1 1 2 3 5 8 13 21 34 55 89 144 ...                        (12 probes shown; unbounded)
```

Same result under Ubuntu's `busybox sh` 1.36.1 and under `bash`. No `not found` / `syntax error` output in any shell. For reference, the recursive `fib` copied verbatim takes 2.8 s wall for `fib 16` in bash on a server; the iterative loop is a few integer additions.

Unit test: a new case in `unittests/configmap_test.yaml` asserts on the rendered `mlflow-dbchecker` ConfigMap that the script contains `MAX_SLEEP=30` and the clamp, and no longer contains `fib`. It fails against the previous script (`Tests: 1 failed, 39 passed`) and passes with this change. Full suite: `helm unittest --strict --file 'unittests/**/*.yaml' charts/mlflow` -> `Tests: 269 passed, 269 total, Snapshot: 24 passed`. `helm lint charts/mlflow` passes.

## Links

- https://github.com/community-charts/helm-charts/issues/604

#### Which issue this PR fixes
  - fixes #604

#### Special notes for your reviewer:

If a different cap (e.g. 60 s) or a configurable value is preferred, it is a one-line change to `MAX_SLEEP`; the tests assert the literal `MAX_SLEEP=30` and would need the same adjustment. @burakince

#### Checklist
- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented (no values changed)
- [x] `README.md` file updated (version badge only; no values changed)

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.
