### PR TITLE
[mlflow] Add existingSecret support for the Flask server secret key

### DIFF
--- a/charts/mlflow/Chart.yaml
+++ b/charts/mlflow/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.11.7
+version: 1.12.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -51,16 +51,11 @@ annotations:
       url: https://github.com/burakince/mlflow
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
-    - kind: changed
-      description: Update burakince/mlflow image version to 3.16.0
+    - kind: added
+      description: Add flaskServerSecretKeyExistingSecret to read the Flask server secret key from a pre-existing secret instead of generating one, so helm template based delivery such as ArgoCD keeps a stable key across syncs
       links:
-        - name: Upstream Project
-          url: https://hub.docker.com/r/burakince/mlflow
-    - kind: changed
-      description: Update dependency postgresql from 18.8.13 to 18.8.17
-      links:
-        - name: ArtifactHub
-          url: https://artifacthub.io/packages/helm/bitnami/postgresql
+        - name: GitHub Issue
+          url: https://github.com/community-charts/helm-charts/issues/605
   artifacthub.io/images: |-
     - name: mlflow
       image: burakince/mlflow:3.16.0

--- a/charts/mlflow/README.md
+++ b/charts/mlflow/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for Mlflow open source platform for the machine learning lifecycle
 
-![Version: 1.11.7](https://img.shields.io/badge/Version-1.11.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.16.0](https://img.shields.io/badge/AppVersion-3.16.0-informational?style=flat-square)
+![Version: 1.12.0](https://img.shields.io/badge/Version-1.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.16.0](https://img.shields.io/badge/AppVersion-3.16.0-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -1079,7 +1079,10 @@ helm upgrade [RELEASE_NAME] community-charts/mlflow
 | extraSecretNamesForEnvFrom | list | `[]` | Extra secrets for environment variables |
 | extraVolumeMounts | list | `[]` | Extra Volume Mounts for the mlflow container |
 | extraVolumes | list | `[]` | Extra Volumes for the pod |
-| flaskServerSecretKey | string | `""` | Mlflow Flask Server Secret Key. Default: Will be auto generated. |
+| flaskServerSecretKey | string | `""` | Mlflow Flask Server Secret Key. Default: Will be auto generated. The generated key is only kept across upgrades by a real Helm release; helm template based delivery (for example ArgoCD) renders a new key on every sync, use flaskServerSecretKeyExistingSecret there. |
+| flaskServerSecretKeyExistingSecret | object | `{"key":"MLFLOW_FLASK_SERVER_SECRET_KEY","name":""}` | Reference a pre-existing secret that holds the Flask server secret key instead of generating one |
+| flaskServerSecretKeyExistingSecret.key | string | `"MLFLOW_FLASK_SERVER_SECRET_KEY"` | Key in the existing secret that holds the Flask server secret key value |
+| flaskServerSecretKeyExistingSecret.name | string | `""` | Name of the pre-existing secret; if empty the chart generates the key and creates the secret |
 | fullnameOverride | string | `""` | String to override the default generated fullname |
 | image | object | `{"digest":"","pullPolicy":"IfNotPresent","repository":"burakince/mlflow","tag":""}` | Image of mlflow |
 | image.digest | string | `""` | Image digest in the format sha256:<hex>. When set, overrides the tag for immutable pulls. |

--- a/charts/mlflow/templates/_helpers.tpl
+++ b/charts/mlflow/templates/_helpers.tpl
@@ -119,6 +119,28 @@ Usage: {{ include "mlflow.oidcAuthDbSecretName" . }}
 {{- end -}}
 
 {{/*
+Return the name of the secret that holds the Flask server secret key.
+When flaskServerSecretKeyExistingSecret.name is set the user manages the secret; otherwise the chart creates one.
+Usage: {{ include "mlflow.flaskServerSecretName" . }}
+*/}}
+{{- define "mlflow.flaskServerSecretName" -}}
+{{- default (printf "%s-flask-server-secret-key" (include "mlflow.fullname" .)) .Values.flaskServerSecretKeyExistingSecret.name -}}
+{{- end -}}
+
+{{/*
+Return the key inside the Flask server secret that holds the secret key value.
+The chart-managed secret always uses MLFLOW_FLASK_SERVER_SECRET_KEY; an existing secret uses flaskServerSecretKeyExistingSecret.key.
+Usage: {{ include "mlflow.flaskServerSecretKeyName" . }}
+*/}}
+{{- define "mlflow.flaskServerSecretKeyName" -}}
+{{- if .Values.flaskServerSecretKeyExistingSecret.name -}}
+{{- .Values.flaskServerSecretKeyExistingSecret.key -}}
+{{- else -}}
+MLFLOW_FLASK_SERVER_SECRET_KEY
+{{- end -}}
+{{- end -}}
+
+{{/*
 Build the full container image reference, appending digest when set.
 */}}
 {{- define "mlflow.containerImage" -}}

--- a/charts/mlflow/templates/deployment.yaml
+++ b/charts/mlflow/templates/deployment.yaml
@@ -184,7 +184,7 @@ spec:
           imagePullPolicy: {{ .Values.initImages.mlflowDbMigration.pullPolicy }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-        {{- if or .Values.postgresql.enabled .Values.mysql.enabled .Values.backendStore.existingDatabaseSecret.name (and .Values.backendStore.mssql.enabled .Values.backendStore.mssql.existingConnectionUrlSecret.name) }}
+        {{- if or .Values.postgresql.enabled .Values.mysql.enabled .Values.backendStore.existingDatabaseSecret.name (and .Values.backendStore.mssql.enabled .Values.backendStore.mssql.existingConnectionUrlSecret.name) .Values.flaskServerSecretKeyExistingSecret.name }}
           env:
         {{- end }}
           {{- if .Values.postgresql.enabled }}
@@ -256,13 +256,22 @@ spec:
                   name: {{ .Values.backendStore.mssql.existingConnectionUrlSecret.name }}
                   key: {{ .Values.backendStore.mssql.existingConnectionUrlSecret.key }}
           {{- end }}
+          {{- if .Values.flaskServerSecretKeyExistingSecret.name }}
+            - name: MLFLOW_FLASK_SERVER_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mlflow.flaskServerSecretName" . }}
+                  key: {{ include "mlflow.flaskServerSecretKeyName" . }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "mlflow.fullname" . }}-env-configmap
             - secretRef:
                 name: {{ include "mlflow.fullname" . }}-env-secret
+          {{- if not .Values.flaskServerSecretKeyExistingSecret.name }}
             - secretRef:
-                name: {{ include "mlflow.fullname" . }}-flask-server-secret-key
+                name: {{ include "mlflow.flaskServerSecretName" . }}
+          {{- end }}
           command: ["python"]
           args:
             - /opt/mlflow/migrations.py
@@ -470,8 +479,8 @@ spec:
             - name: SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "mlflow.fullname" . }}-flask-server-secret-key
-                  key: MLFLOW_FLASK_SERVER_SECRET_KEY
+                  name: {{ include "mlflow.flaskServerSecretName" . }}
+                  key: {{ include "mlflow.flaskServerSecretKeyName" . }}
             {{- if .Values.oidcAuth.cache.enabled }}
             - name: CACHE_BACKEND
               value: "redis"
@@ -610,13 +619,22 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
           {{- end }}
+          {{- if .Values.flaskServerSecretKeyExistingSecret.name }}
+            - name: MLFLOW_FLASK_SERVER_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mlflow.flaskServerSecretName" . }}
+                  key: {{ include "mlflow.flaskServerSecretKeyName" . }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "mlflow.fullname" . }}-env-configmap
             - secretRef:
                 name: {{ include "mlflow.fullname" . }}-env-secret
+          {{- if not .Values.flaskServerSecretKeyExistingSecret.name }}
             - secretRef:
-                name: {{ include "mlflow.fullname" . }}-flask-server-secret-key
+                name: {{ include "mlflow.flaskServerSecretName" . }}
+          {{- end }}
           {{- range .Values.extraSecretNamesForEnvFrom }}
             - secretRef:
                 name: {{ . }}

--- a/charts/mlflow/templates/flask_secret.yaml
+++ b/charts/mlflow/templates/flask_secret.yaml
@@ -1,4 +1,5 @@
-{{- $secretName := printf "%s-flask-server-secret-key" (include "mlflow.fullname" .) }}
+{{- if not .Values.flaskServerSecretKeyExistingSecret.name }}
+{{- $secretName := include "mlflow.flaskServerSecretName" . }}
 {{- $flaskServerSecretKey := ternary .Values.flaskServerSecretKey (include "mlflow.generateRandomHex" 32) (ne .Values.flaskServerSecretKey "") }}
 {{- if not (lookup "v1" "Secret" .Release.Namespace $secretName) }}
 ---
@@ -15,4 +16,5 @@ metadata:
 type: Opaque
 data:
   MLFLOW_FLASK_SERVER_SECRET_KEY: {{ $flaskServerSecretKey | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/charts/mlflow/unittests/deployment_test.yaml
+++ b/charts/mlflow/unittests/deployment_test.yaml
@@ -3064,3 +3064,78 @@ tests:
           path: spec.template.spec.initContainers[?(@.name == "dbchecker")].securityContext.readOnlyRootFilesystem
           value: true
         template: deployment.yaml
+
+  - it: should reference the chart-managed flask server secret via envFrom when flaskServerSecretKeyExistingSecret is not set
+    set:
+      backendStore:
+        postgres:
+          enabled: true
+          host: postgres.example.com
+          database: mlflow
+          user: mlflowuser
+          password: mlflowpassword
+        databaseMigration: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "mlflow")].envFrom
+          content:
+            secretRef:
+              name: mlflow-flask-server-secret-key
+        template: deployment.yaml
+      - contains:
+          path: spec.template.spec.initContainers[?(@.name == "mlflow-db-migration")].envFrom
+          content:
+            secretRef:
+              name: mlflow-flask-server-secret-key
+        template: deployment.yaml
+      - notContains:
+          path: spec.template.spec.containers[?(@.name == "mlflow")].env
+          content:
+            name: MLFLOW_FLASK_SERVER_SECRET_KEY
+          any: true
+        template: deployment.yaml
+
+  - it: should reference the existing flask server secret via env when flaskServerSecretKeyExistingSecret.name is set
+    set:
+      backendStore:
+        postgres:
+          enabled: true
+          host: postgres.example.com
+          database: mlflow
+          user: mlflowuser
+          password: mlflowpassword
+        databaseMigration: true
+      flaskServerSecretKeyExistingSecret:
+        name: my-flask-secret
+        key: my-flask-key
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "mlflow")].env
+          content:
+            name: MLFLOW_FLASK_SERVER_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: my-flask-secret
+                key: my-flask-key
+        template: deployment.yaml
+      - notContains:
+          path: spec.template.spec.containers[?(@.name == "mlflow")].envFrom
+          content:
+            secretRef:
+              name: mlflow-flask-server-secret-key
+        template: deployment.yaml
+      - contains:
+          path: spec.template.spec.initContainers[?(@.name == "mlflow-db-migration")].env
+          content:
+            name: MLFLOW_FLASK_SERVER_SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: my-flask-secret
+                key: my-flask-key
+        template: deployment.yaml
+      - notContains:
+          path: spec.template.spec.initContainers[?(@.name == "mlflow-db-migration")].envFrom
+          content:
+            secretRef:
+              name: mlflow-flask-server-secret-key
+        template: deployment.yaml

--- a/charts/mlflow/unittests/flask_secret_test.yaml
+++ b/charts/mlflow/unittests/flask_secret_test.yaml
@@ -1,0 +1,42 @@
+suite: test flask server secret key secret
+
+templates:
+  - flask_secret.yaml
+
+release:
+  name: mlflow
+  namespace: mlflow
+
+tests:
+  - it: should create the secret with a generated key when flaskServerSecretKey is not set
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: mlflow-flask-server-secret-key
+      - matchRegex:
+          path: data.MLFLOW_FLASK_SERVER_SECRET_KEY
+          pattern: ^[0-9a-f]{32}$
+          decodeBase64: true
+
+  - it: should create the secret with the provided flaskServerSecretKey
+    set:
+      flaskServerSecretKey: my-flask-key
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: data.MLFLOW_FLASK_SERVER_SECRET_KEY
+          value: my-flask-key
+          decodeBase64: true
+
+  - it: should not create the secret when flaskServerSecretKeyExistingSecret.name is set
+    set:
+      flaskServerSecretKeyExistingSecret:
+        name: my-flask-secret
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/mlflow/unittests/oidc_auth_test.yaml
+++ b/charts/mlflow/unittests/oidc_auth_test.yaml
@@ -279,3 +279,22 @@ tests:
             name: OIDC_REDIRECT_URI
         template: deployment.yaml
 
+
+  - it: should inject SECRET_KEY from existing secret when flaskServerSecretKeyExistingSecret name is set
+    set:
+      oidcAuth:
+        enabled: true
+        clientSecret: "test-secret"
+      flaskServerSecretKeyExistingSecret:
+        name: my-flask-secret
+        key: my-flask-key
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[?(@.name == "mlflow")].env
+          content:
+            name: SECRET_KEY
+            valueFrom:
+              secretKeyRef:
+                name: my-flask-secret
+                key: my-flask-key
+        template: deployment.yaml

--- a/charts/mlflow/values.schema.json
+++ b/charts/mlflow/values.schema.json
@@ -2314,6 +2314,29 @@
       "title": "flaskServerSecretKey",
       "type": "string"
     },
+    "flaskServerSecretKeyExistingSecret": {
+      "additionalProperties": false,
+      "description": "Reference a pre-existing secret that holds the Flask server secret key instead of generating one",
+      "properties": {
+        "name": {
+          "default": "",
+          "description": "Name of the existing secret; leave empty to let the chart generate the key and create the secret",
+          "required": [],
+          "title": "name",
+          "type": "string"
+        },
+        "key": {
+          "default": "MLFLOW_FLASK_SERVER_SECRET_KEY",
+          "description": "Key in the existing secret that holds the Flask server secret key value",
+          "required": [],
+          "title": "key",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "flaskServerSecretKeyExistingSecret",
+      "type": "object"
+    },
     "auth": {
       "additionalProperties": false,
       "description": "Mlflow authentication settings",
@@ -3265,6 +3288,7 @@
     "livenessProbe",
     "readinessProbe",
     "flaskServerSecretKey",
+    "flaskServerSecretKeyExistingSecret",
     "auth",
     "ldapAuth",
     "autoscaling"

--- a/charts/mlflow/values.yaml
+++ b/charts/mlflow/values.yaml
@@ -280,8 +280,14 @@ artifactRoot:
     bucket: "" # required
     # -- Google Cloud Storage bucket folder. If you want to use root level, please don't set anything.
     path: "" # optional
-# -- Mlflow Flask Server Secret Key. Default: Will be auto generated.
+# -- Mlflow Flask Server Secret Key. Default: Will be auto generated. The generated key is only kept across upgrades by a real Helm release; helm template based delivery (for example ArgoCD) renders a new key on every sync, use flaskServerSecretKeyExistingSecret there.
 flaskServerSecretKey: ""
+# -- Reference a pre-existing secret that holds the Flask server secret key instead of generating one
+flaskServerSecretKeyExistingSecret:
+  # -- Name of the pre-existing secret; if empty the chart generates the key and creates the secret
+  name: ""
+  # -- Key in the existing secret that holds the Flask server secret key value
+  key: "MLFLOW_FLASK_SERVER_SECRET_KEY"
 # -- Mlflow authentication settings
 auth:
   # -- Specifies if you want to enable mlflow authentication. auth, ldapAuth, and oidcAuth can't be enabled at same time.


### PR DESCRIPTION
#### What this PR does / why we need it:

## Problem

`templates/flask_secret.yaml` generates a random Flask server secret key when `flaskServerSecretKey` is empty and relies on `lookup` to keep the value across upgrades. `lookup` only returns data during a real `helm install`/`helm upgrade`. Anything that renders with `helm template` (ArgoCD, `helm template | kubectl apply` pipelines) gets an empty lookup, so a fresh key is rendered on every sync and, because the Secret is a `pre-install,pre-upgrade` hook with `before-hook-creation`, ArgoCD deletes and recreates it on every sync operation. Pods started after a sync get a different key than running ones, replicas disagree on session cookies / CSRF tokens, and every rolling restart invalidates all sessions (with `oidcAuth` every user is logged out).

Every other credential in this chart can be supplied through an `existingSecret`; the Flask key could not.

## Root cause

- `charts/mlflow/templates/flask_secret.yaml:3` gates the Secret on `lookup`, which is always empty under `helm template`; lines 13-14 make it a `before-hook-creation` hook, so the freshly rendered value replaces the existing one on every ArgoCD sync.
- `charts/mlflow/templates/deployment.yaml:265`, `:473-474` and `:619` hard-code `<fullname>-flask-server-secret-key` / `MLFLOW_FLASK_SERVER_SECRET_KEY`, so there was no way to point the Deployment at a user-managed Secret.

## Fix

- New values `flaskServerSecretKeyExistingSecret.name` / `.key` (default key `MLFLOW_FLASK_SERVER_SECRET_KEY`), following the `existingSecret` shape already used by `oidcAuth`, `oauth2Proxy` and `artifactRoot.s3`.
- New helpers `mlflow.flaskServerSecretName` and `mlflow.flaskServerSecretKeyName` in `_helpers.tpl` (same `default` pattern as `mlflow.oidcAuthSecretName`) so the three reference sites stay in sync.
- When `name` is set: `templates/flask_secret.yaml` renders nothing, and the migration init container, the main container and the `oidcAuth` `SECRET_KEY` env read the key from the configured secret/key via `secretKeyRef` (explicit env instead of `envFrom`, so the key inside the user's Secret can have any name).
- When `name` is empty (default): rendering is unchanged (`envFrom` on the chart-managed hook Secret), so existing releases are not affected. Documented on `flaskServerSecretKey` that the generated key is only stable with a real Helm release.
- `values.schema.json`, `README.md` (helm-docs) and `Chart.yaml` (`1.11.7` -> `1.12.0`, `artifacthub.io/changes`) updated.

#### Which issue this PR fixes
  - fixes #605

#### Special notes for your reviewer:

## How tested

Reproduction of the issue on `main` (same command twice, different key each time):

```
$ helm template mlflow charts/mlflow --show-only templates/flask_secret.yaml | grep MLFLOW_FLASK
  MLFLOW_FLASK_SERVER_SECRET_KEY: "ZDZkYWQ5YjFhMWIzMjEzY2EzMjI5MTQ2YWNkMWMzZjc="
$ helm template mlflow charts/mlflow --show-only templates/flask_secret.yaml | grep MLFLOW_FLASK
  MLFLOW_FLASK_SERVER_SECRET_KEY: "ZGY5YWVhOTEwMzNmYTllNjhmZTY2YmEwNDJlOTNlOTk="
```

New unit tests (`unittests/flask_secret_test.yaml`, plus cases in `deployment_test.yaml` and `oidc_auth_test.yaml`) fail on `main` before the fix:

```
$ helm unittest --strict --file 'unittests/**/*.yaml' charts/mlflow
 FAIL  test deployment	charts/mlflow/unittests/deployment_test.yaml
	- should reference the existing flask server secret via env when flaskServerSecretKeyExistingSecret.name is set
		Error: values don't meet the specifications of the schema(s) in the following chart(s):
mlflow:
- at '': additional properties 'flaskServerSecretKeyExistingSecret' not allowed
 FAIL  test flask server secret key secret	charts/mlflow/unittests/flask_secret_test.yaml
	- should not create the secret when flaskServerSecretKeyExistingSecret.name is set
		Error: values don't meet the specifications of the schema(s) in the following chart(s):
mlflow:
- at '': additional properties 'flaskServerSecretKeyExistingSecret' not allowed
 FAIL  test oidc auth	charts/mlflow/unittests/oidc_auth_test.yaml
	- should inject SECRET_KEY from existing secret when flaskServerSecretKeyExistingSecret name is set
		Error: values don't meet the specifications of the schema(s) in the following chart(s):
mlflow:
- at '': additional properties 'flaskServerSecretKeyExistingSecret' not allowed
Test Suites: 3 failed, 13 passed, 16 total
Tests:       4 failed, 3 errored, 270 passed, 274 total
```

and pass with the fix:

```
$ helm unittest --strict --file 'unittests/**/*.yaml' charts/mlflow
Test Suites: 16 passed, 16 total
Tests:       274 passed, 274 total
Snapshot:    24 passed, 24 total
```

All 24 existing snapshots are unchanged, i.e. default rendering is identical. `helm lint charts/mlflow` passes and `helm-docs` output is committed (`check-helm-docs` clean). With `--set flaskServerSecretKeyExistingSecret.name=my-flask-secret` two consecutive `helm template` runs produce byte-identical output, no `flask-server-secret-key` Secret is rendered, and all three env sites reference `my-flask-secret`.

#### Checklist
- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated

## Links

- Issue: https://github.com/community-charts/helm-charts/issues/605
- Related: https://github.com/community-charts/helm-charts/issues/66 (hook added so real Helm upgrades keep the key), https://github.com/community-charts/helm-charts/issues/208 (same class of problem for the auth database config)

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.
