### PR TITLE
[n8n] Update n8n chart to 2.38.4

### DIFF
--- a/charts/n8n/Chart.lock
+++ b/charts/n8n/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 28.0.15
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 18.9.0
+  version: 18.10.0
 - name: minio
   repository: https://charts.min.io/
   version: 5.4.0
-digest: sha256:059beffdc398f15ad536ff0a309cecea5a15f0900736a5f0fa323eef6b108eb2
-generated: "2026-09-08T02:50:02.137586024Z"
+digest: sha256:fe38e2f813fc987c8f09c917f7a650ed8b2b1940168f891a98fd44df9b45567c
+generated: "2026-09-09T02:49:43.932778273Z"

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -14,12 +14,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.24.39
+version: 1.24.40
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.37.11"
+appVersion: "2.38.4"
 kubeVersion: ">=1.23.0-0"
 home: https://n8n.io
 maintainers:
@@ -51,23 +51,23 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update n8nio/n8n image version to 2.37.11
+      description: Update n8nio/n8n image version to 2.38.4
       links:
         - name: Upstream Project
           url: https://github.com/n8n-io/n8n
     - kind: changed
-      description: Update dependency postgresql from 18.8.17 to 18.9.0
+      description: Update dependency postgresql from 18.9.0 to 18.10.0
       links:
         - name: ArtifactHub
           url: https://artifacthub.io/packages/helm/bitnami/postgresql
   artifacthub.io/images: |
     - name: n8n
-      image: n8nio/n8n:2.37.11
+      image: n8nio/n8n:2.38.4
       platforms:
         - linux/amd64
         - linux/arm64
     - name: n8n-runners
-      image: n8nio/runners:2.37.11
+      image: n8nio/runners:2.38.4
       platforms:
         - linux/amd64
         - linux/arm64
@@ -88,7 +88,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: postgresql
-    version: 18.9.0
+    version: 18.10.0
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: minio

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -4,7 +4,7 @@
 
 A Helm chart for fair-code workflow automation platform with native AI capabilities. Combine visual building with custom code, self-host or cloud, 400+ integrations.
 
-![Version: 1.24.39](https://img.shields.io/badge/Version-1.24.39-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.37.11](https://img.shields.io/badge/AppVersion-2.37.11-informational?style=flat-square)
+![Version: 1.24.40](https://img.shields.io/badge/Version-1.24.40-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.38.4](https://img.shields.io/badge/AppVersion-2.38.4-informational?style=flat-square)
 
 ## Official Documentation
 
@@ -1396,7 +1396,7 @@ Kubernetes: `>=1.23.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 18.9.0 |
+| https://charts.bitnami.com/bitnami | postgresql | 18.10.0 |
 | https://charts.bitnami.com/bitnami | redis | 28.0.15 |
 | https://charts.min.io/ | minio | 5.4.0 |
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR updates the n8n chart to use the latest image version 2.38.4 from n8nio/n8n. This ensures the chart stays current with the latest upstream release.

#### Which issue this PR fixes

- fixes none

#### Checklist

- [x] [DCO](https://github.com/community-charts/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Chart `artifacthub.io/changes` field updated (if exists)
- [x] Title of the PR starts with chart name (e.g. `[mlflow]`)
- [x] Unit tests written
- [x] `values.yaml` file fields documented
- [x] `README.md` file updated